### PR TITLE
Change the method of generating and sending tomogram ids

### DIFF
--- a/recipes/em-tomo-align.json
+++ b/recipes/em-tomo-align.json
@@ -12,14 +12,14 @@
   },
   "2": {
     "output": {
-      "denoise": 7,
+      "denoise": 5,
       "failure": 3,
       "images": 6,
-      "ispyb_connector": 5,
+      "ispyb_connector": 4,
       "movie": 6,
       "projxy": 6,
       "projxz": 6,
-      "success": 4
+      "success": 7
     },
     "parameters": {
       "input_file_list": "{input_file_list}",
@@ -45,16 +45,6 @@
   },
   "4": {
     "parameters": {
-      "ispyb_command": "update_processing_status",
-      "message": "processing successful",
-      "program_id": "{appid}",
-      "status": "success"
-    },
-    "queue": "ispyb_connector",
-    "service": "EMISPyB"
-  },
-  "5": {
-    "parameters": {
       "dcid": "{dcid}",
       "ispyb_command": "multipart_message",
       "program_id": "{appid}",
@@ -63,11 +53,7 @@
     "queue": "ispyb_connector",
     "service": "EMISPyB"
   },
-  "6": {
-    "queue": "images",
-    "service": "Images"
-  },
-  "7": {
+  "5": {
     "output": {
       "images": 6,
       "ispyb_connector": 9,
@@ -76,6 +62,20 @@
     },
     "queue": "denoise",
     "service": "Denoise"
+  },
+  "6": {
+    "queue": "images",
+    "service": "Images"
+  },
+  "7": {
+    "parameters": {
+      "ispyb_command": "update_processing_status",
+      "message": "processing successful",
+      "program_id": "{appid}",
+      "status": "success"
+    },
+    "queue": "ispyb_connector",
+    "service": "EMISPyB"
   },
   "8": {
     "output": {

--- a/recipes/em-tomo-align.json
+++ b/recipes/em-tomo-align.json
@@ -1,14 +1,25 @@
 {
   "1": {
+    "output": 2,
+    "parameters": {
+      "dcid": "{dcid}",
+      "ispyb_command": "insert_tomogram",
+      "program_id": "{appid}",
+      "store_result": "ispyb_tomogram_id"
+    },
+    "queue": "ispyb_connector",
+    "service": "EMISPyB"
+  },
+  "2": {
     "output": {
-      "denoise": 4,
-      "failure": 2,
-      "images": 5,
-      "ispyb_connector": 3,
-      "movie": 5,
-      "projxy": 5,
-      "projxz": 5,
-      "success": 6
+      "denoise": 7,
+      "failure": 3,
+      "images": 6,
+      "ispyb_connector": 5,
+      "movie": 6,
+      "projxy": 6,
+      "projxz": 6,
+      "success": 4
     },
     "parameters": {
       "input_file_list": "{input_file_list}",
@@ -16,12 +27,13 @@
       "path_pattern": "{path_pattern}",
       "pixel_size": "{pixel_size}",
       "relion_options": {},
-      "stack_file": "{stack_file}"
+      "stack_file": "{stack_file}",
+      "tomogram_id": "$ispyb_tomogram_id"
     },
     "queue": "tomo_align",
     "service": "TomoAlign"
   },
-  "2": {
+  "3": {
     "parameters": {
       "ispyb_command": "update_processing_status",
       "message": "processing failure",
@@ -31,30 +43,7 @@
     "queue": "ispyb_connector",
     "service": "EMISPyB"
   },
-  "3": {
-    "parameters": {
-      "dcid": "{dcid}",
-      "ispyb_command": "multipart_message",
-      "program_id": "{appid}",
-      "tomogram_id": "$ispyb_tomogram_id"
-    },
-    "queue": "ispyb_connector",
-    "service": "EMISPyB"
-  },
   "4": {
-    "output": {
-      "images": 5,
-      "movie": 5,
-      "segmentation": 7
-    },
-    "queue": "denoise",
-    "service": "Denoise"
-  },
-  "5": {
-    "queue": "images",
-    "service": "Images"
-  },
-  "6": {
     "parameters": {
       "ispyb_command": "update_processing_status",
       "message": "processing successful",
@@ -64,13 +53,45 @@
     "queue": "ispyb_connector",
     "service": "EMISPyB"
   },
+  "5": {
+    "parameters": {
+      "dcid": "{dcid}",
+      "ispyb_command": "multipart_message",
+      "program_id": "{appid}",
+      "tomogram_id": "$ispyb_tomogram_id"
+    },
+    "queue": "ispyb_connector",
+    "service": "EMISPyB"
+  },
+  "6": {
+    "queue": "images",
+    "service": "Images"
+  },
   "7": {
     "output": {
-      "images": 5,
-      "movie": 5
+      "images": 6,
+      "ispyb_connector": 9,
+      "movie": 6,
+      "segmentation": 8
+    },
+    "queue": "denoise",
+    "service": "Denoise"
+  },
+  "8": {
+    "output": {
+      "images": 6,
+      "ispyb_connector": 9,
+      "movie": 6
     },
     "queue": "segmentation",
     "service": "MembrainSeg"
+  },
+  "9": {
+    "parameters": {
+      "tomogram_id": "$ispyb_tomogram_id"
+    },
+    "queue": "ispyb_connector",
+    "service": "EMISPyB"
   },
   "start": [[1, []]]
 }

--- a/src/cryoemservices/services/denoise_slurm.py
+++ b/src/cryoemservices/services/denoise_slurm.py
@@ -39,7 +39,7 @@ class DenoiseParameters(BaseModel):
     patch_padding: Optional[int] = None  # 48
     device: Optional[int] = None  # -2
     cleanup_output: bool = True
-    tomogram_uuid: int
+    tomogram_id: int
     relion_options: RelionServiceOptions
 
     @validator("model")
@@ -263,11 +263,10 @@ class DenoiseSlurm(CommonService):
 
         # Insert the denoised tomogram into ISPyB
         ispyb_parameters = {
-            "ispyb_command": "buffer",
-            "buffer_command": {"ispyb_command": "insert_processed_tomogram"},
-            "buffer_lookup": {"tomogram_id": denoise_params.tomogram_uuid},
+            "ispyb_command": "insert_processed_tomogram",
             "file_path": str(denoised_full_path),
             "processing_type": "Denoised",
+            "tomogram_id": denoise_params.tomogram_id,
         }
         if isinstance(rw, MockRW):
             rw.transport.send(
@@ -300,6 +299,7 @@ class DenoiseSlurm(CommonService):
                 message={
                     "tomogram": str(denoised_full_path),
                     "output_dir": str(segmentation_dir),
+                    "tomogram_id": denoise_params.tomogram_id,
                 },
             )
         else:
@@ -308,6 +308,7 @@ class DenoiseSlurm(CommonService):
                 {
                     "tomogram": str(denoised_full_path),
                     "output_dir": str(segmentation_dir),
+                    "tomogram_id": denoise_params.tomogram_id,
                 },
             )
 

--- a/src/cryoemservices/services/membrain_seg.py
+++ b/src/cryoemservices/services/membrain_seg.py
@@ -25,7 +25,7 @@ class MembrainSegParameters(BaseModel):
     connected_component_threshold: Optional[int] = None
     segmentation_threshold: Optional[float] = None
     cleanup_output: bool = True
-    tomogram_uuid: int
+    tomogram_id: int
 
 
 class MembrainSeg(CommonService):
@@ -219,11 +219,10 @@ class MembrainSeg(CommonService):
 
         # Insert the segmented tomogram into ISPyB
         ispyb_parameters = {
-            "ispyb_command": "buffer",
-            "buffer_command": {"ispyb_command": "insert_processed_tomogram"},
-            "buffer_lookup": {"tomogram_id": membrain_seg_params.tomogram_uuid},
+            "ispyb_command": "insert_processed_tomogram",
             "filePath": str(segmented_path),
             "processingType": "Segmented",
+            "tomogram_id": membrain_seg_params.tomogram_id,
         }
         if isinstance(rw, MockRW):
             rw.transport.send(

--- a/src/cryoemservices/services/tomo_align.py
+++ b/src/cryoemservices/services/tomo_align.py
@@ -46,7 +46,7 @@ class TomoParameters(BaseModel):
     out_imod_xf: Optional[int] = None
     dark_tol: Optional[Union[int, str]] = None
     manual_tilt_offset: Optional[float] = None
-    tomogram_uuid: int
+    tomogram_id: int
     relion_options: RelionServiceOptions
 
     @validator("input_file_list")
@@ -376,9 +376,7 @@ class TomoAlign(CommonService):
         # Tomogram (one per-tilt-series)
         ispyb_command_list = [
             {
-                "ispyb_command": "buffer",
-                "buffer_command": {"ispyb_command": "insert_tomogram"},
-                "buffer_store": tomo_params.tomogram_uuid,
+                "ispyb_command": "insert_tomogram",
                 "volume_file": str(
                     aretomo_output_path.relative_to(self.alignment_output_dir)
                 ),
@@ -396,7 +394,7 @@ class TomoAlign(CommonService):
                 "proj_xy": xy_proj_file,
                 "proj_xz": xz_proj_file,
                 "alignment_quality": str(self.alignment_quality),
-                "store_result": "ispyb_tomogram_id",
+                "tomogram_id": tomo_params.tomogram_id,
             }
         ]
 
@@ -443,6 +441,7 @@ class TomoAlign(CommonService):
                             ),
                             "refined_tilt_axis": str(self.rot),
                             "path": movie[0],
+                            "tomogram_id": tomo_params.tomogram_id,
                         }
                     )
                     node_creator_params_list.append(
@@ -581,6 +580,7 @@ class TomoAlign(CommonService):
                         project_dir / f"Denoise/job{job_number+1:03}/tomograms"
                     ),
                     "relion_options": dict(tomo_params.relion_options),
+                    "tomogram_id": tomo_params.tomogram_id,
                 },
             )
         else:
@@ -592,6 +592,7 @@ class TomoAlign(CommonService):
                         project_dir / f"Denoise/job{job_number+1:03}/tomograms"
                     ),
                     "relion_options": dict(tomo_params.relion_options),
+                    "tomogram_id": tomo_params.tomogram_id,
                 },
             )
 

--- a/tests/services/test_denoise_slurm.py
+++ b/tests/services/test_denoise_slurm.py
@@ -85,7 +85,7 @@ def test_denoise_slurm_service(
             "patch_padding": 48,
             "device": "-2",
             "cleanup_output": False,
-            "tomogram_uuid": 0,
+            "tomogram_id": 0,
             "relion_options": {},
         },
         "content": "dummy",
@@ -241,11 +241,10 @@ def test_denoise_slurm_service(
         destination="ispyb_connector",
         message={
             "parameters": {
-                "ispyb_command": "buffer",
-                "buffer_command": {"ispyb_command": "insert_processed_tomogram"},
-                "buffer_lookup": {"tomogram_id": 0},
+                "ispyb_command": "insert_processed_tomogram",
                 "file_path": f"{tmp_path}/Denoise/job007/denoised/test_stack_aretomo.denoised.mrc",
                 "processing_type": "Denoised",
+                "tomogram_id": 0,
             },
             "content": {"dummy": "dummy"},
         },
@@ -255,5 +254,6 @@ def test_denoise_slurm_service(
         message={
             "tomogram": f"{tmp_path}/Denoise/job007/denoised/test_stack_aretomo.denoised.mrc",
             "output_dir": f"{tmp_path}/Segmentation/job008",
+            "tomogram_id": 0,
         },
     )

--- a/tests/services/test_membrain_seg.py
+++ b/tests/services/test_membrain_seg.py
@@ -68,7 +68,7 @@ def test_membrain_seg_service(
             "connected_component_threshold": 2,
             "segmentation_threshold": 4,
             "cleanup_output": False,
-            "tomogram_uuid": 0,
+            "tomogram_id": 0,
         },
         "content": "dummy",
     }
@@ -150,11 +150,10 @@ def test_membrain_seg_service(
         destination="ispyb_connector",
         message={
             "parameters": {
-                "ispyb_command": "buffer",
-                "buffer_command": {"ispyb_command": "insert_processed_tomogram"},
-                "buffer_lookup": {"tomogram_id": 0},
+                "ispyb_command": "insert_processed_tomogram",
                 "filePath": f"{tmp_path}/Segmentation/job008/test_stack_aretomo.denoised_segmented.mrc",
                 "processingType": "Segmented",
+                "tomogram_id": 0,
             },
             "content": {"dummy": "dummy"},
         },

--- a/tests/services/test_tomo_align.py
+++ b/tests/services/test_tomo_align.py
@@ -87,7 +87,7 @@ def test_tomo_align_service(
             "out_imod_xf": None,
             "dark_tol": None,
             "manual_tilt_offset": None,
-            "tomogram_uuid": 0,
+            "tomogram_id": 0,
             "relion_options": {},
         },
         "content": "dummy",
@@ -228,9 +228,7 @@ def test_tomo_align_service(
                 "ispyb_command": "multipart_message",
                 "ispyb_command_list": [
                     {
-                        "ispyb_command": "buffer",
-                        "buffer_command": {"ispyb_command": "insert_tomogram"},
-                        "buffer_store": 0,
+                        "ispyb_command": "insert_tomogram",
                         "volume_file": "test_stack_aretomo.mrc",
                         "stack_file": tomo_align_test_message["parameters"][
                             "stack_file"
@@ -248,7 +246,7 @@ def test_tomo_align_service(
                         "proj_xy": "test_stack_aretomo_projXY.jpeg",
                         "proj_xz": "test_stack_aretomo_projXZ.jpeg",
                         "alignment_quality": "0.5",
-                        "store_result": "ispyb_tomogram_id",
+                        "tomogram_id": 0,
                     },
                     {
                         "ispyb_command": "insert_tilt_image_alignment",
@@ -257,6 +255,7 @@ def test_tomo_align_service(
                         "refined_tilt_angle": "4.5",
                         "refined_tilt_axis": "0.0",
                         "path": f"{tmp_path}/MotionCorr/job002/Movies/input_file_1.mrc",
+                        "tomogram_id": 0,
                     },
                 ],
             },
@@ -297,6 +296,7 @@ def test_tomo_align_service(
             "volume": f"{tmp_path}/Tomograms/job006/tomograms/test_stack_aretomo.mrc",
             "output_dir": f"{tmp_path}/Denoise/job007/tomograms",
             "relion_options": output_relion_options,
+            "tomogram_id": 0,
         },
     )
     offline_transport.send.assert_any_call(destination="success", message="")


### PR DESCRIPTION
- Remove uuid references for tomograms
- Generate tomogram ids as a first recipe step
- Add ispyb recipe step for processed tomogram inserts