### PR TITLE
Added missing pytest plugins to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,8 @@ dev = [
     "ipykernel",
     "pre-commit",
     "pytest",
+    "pytest-datafiles",
+    "pytest-mock",
 ]
 [project.urls]
     Bug-Tracker = "https://github.com/DiamondLightSource/cryoem-services/issues"


### PR DESCRIPTION
`pytest-mock` and `pytest-datafiles` are needed in addition to `pytest` to successfully run tests on our own machines. Added them to the package list under the `[dev]` optional dependency in the pyproject.toml file.