### PR TITLE
Allow the use of CTFFind5

### DIFF
--- a/Dockerfiles/ctffind
+++ b/Dockerfiles/ctffind
@@ -16,7 +16,11 @@ RUN python -m pip install -e ./cryoem-services
 RUN groupadd -r -g "${groupid}" "${groupname}" && useradd -r -M "${groupname}" -u "${userid}" -g "${groupname}"
 USER "${userid}":"${groupid}"
 
-# Install CTFFind executable
+# Install CTFFind 4 and 5 executables
 COPY --chown="${userid}":"${groupid}" packages/ctffind-4.1.14 /CTFFind/4.1.14
 ENV PATH="/CTFFind/4.1.14/bin:${PATH}"
 RUN chmod -R a+x /CTFFind/4.1.14
+
+COPY --chown="${userid}":"${groupid}" packages/ctffind-5.0.2 /CTFFind/5.0.2
+ENV PATH="/CTFFind/5.0.2/bin:${PATH}"
+RUN chmod -R a+x /CTFFind/5.0.2

--- a/src/cryoemservices/services/ctffind.py
+++ b/src/cryoemservices/services/ctffind.py
@@ -129,8 +129,6 @@ class CTFFind(CommonService):
             rw.recipe_step = {"parameters": message["parameters"]}
             message = message["content"]
 
-        command = ["ctffind"]
-
         try:
             if isinstance(message, dict):
                 ctf_params = CTFParameters(
@@ -152,6 +150,11 @@ class CTFFind(CommonService):
             rw.transport.nack(header)
             return
         self.log.info(f"Using CTFFind version {ctf_params.ctffind_version}")
+
+        if ctf_params.ctffind_version == 5:
+            command = ["ctffind5"]
+        else:
+            command = ["ctffind"]
 
         # Check if this file has been run before
         if Path(ctf_params.output_image).is_file():

--- a/src/cryoemservices/services/ctffind.py
+++ b/src/cryoemservices/services/ctffind.py
@@ -32,6 +32,7 @@ class CTFParameters(BaseModel):
     astigmatism_restrain: str = "no"
     additional_phase_shift: str = "no"
     expert_options: str = "no"
+    # Ctffind5 parameters
     determine_tilt: str = "no"
     determine_thickness: str = "no"
     brute_force_1d: str = "yes"
@@ -40,6 +41,7 @@ class CTFParameters(BaseModel):
     node_high_res: float = 3.0
     node_rounded_square: str = "no"
     node_downweight: str = "no"
+    # IDs
     ctffind_version: int = 4
     mc_uuid: int
     picker_uuid: int
@@ -151,10 +153,7 @@ class CTFFind(CommonService):
             return
         self.log.info(f"Using CTFFind version {ctf_params.ctffind_version}")
 
-        if ctf_params.ctffind_version == 5:
-            command = ["ctffind5"]
-        else:
-            command = ["ctffind"]
+        command = ["ctffind5"] if ctf_params.ctffind_version == 5 else ["ctffind"]
 
         # Check if this file has been run before
         if Path(ctf_params.output_image).is_file():
@@ -191,7 +190,7 @@ class CTFFind(CommonService):
                     ctf_params.determine_thickness,
                 ]
             )
-            if ctf_params.determine_thickness in ["yes", "Yes"]:
+            if ctf_params.determine_thickness.lower() == "yes":
                 parameters_list.extend(
                     [
                         ctf_params.brute_force_1d,

--- a/src/cryoemservices/services/ctffind.py
+++ b/src/cryoemservices/services/ctffind.py
@@ -180,14 +180,19 @@ class CTFFind(CommonService):
                 [
                     ctf_params.determine_tilt,
                     ctf_params.determine_thickness,
-                    ctf_params.brute_force_1d,
-                    ctf_params.refinement_2d,
-                    ctf_params.node_low_res,
-                    ctf_params.node_high_res,
-                    ctf_params.node_rounded_square,
-                    ctf_params.node_downweight,
                 ]
             )
+            if ctf_params.determine_thickness in ["yes", "Yes"]:
+                parameters_list.extend(
+                    [
+                        ctf_params.brute_force_1d,
+                        ctf_params.refinement_2d,
+                        ctf_params.node_low_res,
+                        ctf_params.node_high_res,
+                        ctf_params.node_rounded_square,
+                        ctf_params.node_downweight,
+                    ]
+                )
         parameters_list.append(ctf_params.expert_options)
 
         parameters_string = "\n".join(map(str, parameters_list))

--- a/src/cryoemservices/services/ctffind.py
+++ b/src/cryoemservices/services/ctffind.py
@@ -147,6 +147,12 @@ class CTFFind(CommonService):
             rw.transport.nack(header)
             return
 
+        if ctf_params.ctffind_version not in [4, 5]:
+            self.log.error(f"Cannot use CTFFind version {ctf_params.ctffind_version}")
+            rw.transport.nack(header)
+            return
+        self.log.info(f"Using CTFFind version {ctf_params.ctffind_version}")
+
         # Check if this file has been run before
         if Path(ctf_params.output_image).is_file():
             job_is_rerun = True

--- a/src/cryoemservices/services/ctffind.py
+++ b/src/cryoemservices/services/ctffind.py
@@ -32,6 +32,15 @@ class CTFParameters(BaseModel):
     astigmatism_restrain: str = "no"
     additional_phase_shift: str = "no"
     expert_options: str = "no"
+    determine_tilt: str = "no"
+    determine_thickness: str = "no"
+    brute_force_1d: str = "yes"
+    refinement_2d: str = "yes"
+    node_low_res: float = 30.0
+    node_high_res: float = 3.0
+    node_rounded_square: str = "no"
+    node_downweight: str = "no"
+    ctffind_version: int = 4
     mc_uuid: int
     picker_uuid: int
     relion_options: RelionServiceOptions
@@ -165,8 +174,21 @@ class CTFFind(CommonService):
             ctf_params.slow_search,
             ctf_params.astigmatism_restrain,
             ctf_params.additional_phase_shift,
-            ctf_params.expert_options,
         ]
+        if ctf_params.ctffind_version == 5:
+            parameters_list.extend(
+                [
+                    ctf_params.determine_tilt,
+                    ctf_params.determine_thickness,
+                    ctf_params.brute_force_1d,
+                    ctf_params.refinement_2d,
+                    ctf_params.node_low_res,
+                    ctf_params.node_high_res,
+                    ctf_params.node_rounded_square,
+                    ctf_params.node_downweight,
+                ]
+            )
+        parameters_list.append(ctf_params.expert_options)
 
         parameters_string = "\n".join(map(str, parameters_list))
         self.log.info(

--- a/tests/services/test_ctffind_service.py
+++ b/tests/services/test_ctffind_service.py
@@ -264,7 +264,7 @@ def test_ctffind5_service(mock_subprocess, offline_transport, tmp_path):
 
     assert mock_subprocess.call_count == 4
     mock_subprocess.assert_called_with(
-        ["ctffind"],
+        ["ctffind5"],
         input=parameters_string.encode("ascii"),
         capture_output=True,
     )
@@ -280,7 +280,7 @@ def test_ctffind5_service(mock_subprocess, offline_transport, tmp_path):
                 "input_file": f"{tmp_path}/MotionCorr/job002/sample.mrc",
                 "output_file": f"{tmp_path}/CtfFind/job006/sample.ctf",
                 "relion_options": output_relion_options,
-                "command": f"ctffind\n{' '.join(map(str, parameters_list))}",
+                "command": f"ctffind5\n{' '.join(map(str, parameters_list))}",
                 "stdout": "stdout",
                 "stderr": "stderr",
                 "success": True,
@@ -359,7 +359,7 @@ def test_ctffind5_service_nothickness(mock_subprocess, offline_transport, tmp_pa
 
     assert mock_subprocess.call_count == 4
     mock_subprocess.assert_called_with(
-        ["ctffind"],
+        ["ctffind5"],
         input=parameters_string.encode("ascii"),
         capture_output=True,
     )

--- a/tests/services/test_ctffind_service.py
+++ b/tests/services/test_ctffind_service.py
@@ -19,7 +19,7 @@ def offline_transport(mocker):
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 @mock.patch("cryoemservices.services.ctffind.subprocess.run")
-def test_ctffind4_service(mock_subprocess, offline_transport, tmp_path):
+def test_ctffind4_service_spa(mock_subprocess, offline_transport, tmp_path):
     """
     Send a test message to CTFFind
     This should call the mock subprocess then send messages on to the
@@ -184,7 +184,7 @@ def test_ctffind4_service(mock_subprocess, offline_transport, tmp_path):
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 @mock.patch("cryoemservices.services.ctffind.subprocess.run")
-def test_ctffind5_service(mock_subprocess, offline_transport, tmp_path):
+def test_ctffind5_service_tomo(mock_subprocess, offline_transport, tmp_path):
     """
     Send a test message to CTFFind with the version 5 flags on
     """


### PR DESCRIPTION
We now have a working version of CTFFind5 so this updates the service to be compatible with version 4 or 5. For compatibility I've chosen to rename the executable as "ctffind5" for version 5 but keep it as "ctffind" for version 4.

Relion does not currently support version 5 though, so we may want to stick with using 4 at the moment.

Addresses another part of #10 