### PR TITLE
Removed spaces when generating CLEM image series names

### DIFF
--- a/src/cryoemservices/wrappers/clem_process_raw_lifs.py
+++ b/src/cryoemservices/wrappers/clem_process_raw_lifs.py
@@ -67,7 +67,12 @@ def process_lif_substack(
             logger.info(f"{folder} already exists")
 
     # Create a name for this series
-    series_name = img_dir.relative_to(root_save_dir).as_posix().replace("/", "--")
+    series_name = (
+        img_dir.relative_to(root_save_dir)
+        .as_posix()
+        .replace("/", "--")
+        .replace(" ", "_")
+    )
 
     # Save image stack XML metadata (all channels together)
     img_xml_file = img_xml_dir / (img_name + ".xml")

--- a/src/cryoemservices/wrappers/clem_process_raw_tiffs.py
+++ b/src/cryoemservices/wrappers/clem_process_raw_tiffs.py
@@ -93,7 +93,7 @@ def convert_tiff_to_stack(
             logger.info(f"{metadata_dir} already exists")
 
         # Save image metadata
-        img_xml_file = metadata_dir / (series_name_short + ".xml")
+        img_xml_file = metadata_dir / (series_name_short.replace(" ", "_") + ".xml")
         metadata_tree = ET.ElementTree(metadata)
         ET.indent(metadata_tree, "  ")
         metadata_tree.write(img_xml_file, encoding="utf-8")
@@ -239,7 +239,9 @@ def convert_tiff_to_stack(
     # Use the names of the TIFF files to get the unique path to it
     #   Remove the "--Z##--C##.tiff" end of the file path strings
     series_path = tiff_list[0].parent / tiff_list[0].stem.split("--")[0]
-    series_name_short = series_path.stem  # For finding and parsing metadata file
+    series_name_short = (
+        series_path.stem
+    )  # For finding and parsing metadata file; may contain spaces
 
     # Parse path parts to construct parameters
     path_parts = list(series_path.parts)
@@ -264,7 +266,7 @@ def convert_tiff_to_stack(
         return None
 
     # Construct long name of the series for database records
-    series_name_long = "--".join(path_parts[root_index + 1 :])
+    series_name_long = "--".join(path_parts[root_index + 1 :]).replace(" ", "_")
     logger.info(f"Processing {series_name_long} TIFF files")
 
     # Construct save directory


### PR DESCRIPTION
Forgot to replace the spaces with underscores when generating the names to store the series in the database with.

The name of the series as stored in the XML metadata file will be in its original format, and thus may contain spaces.