### PR TITLE
Upgrade supported python versions to 3.10/3.11/3.12

### DIFF
--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -17,10 +17,10 @@ jobs:
       newVersion: ${{ steps.checkTag.outputs.newVersion }}
     steps:
       - uses: actions/checkout@v4
-      - name: Use Python 3.10
+      - name: Use Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Check current tag
         id: checkTag
         run: |
@@ -65,10 +65,10 @@ jobs:
     if: ${{ needs.get-current-version.outputs.doTag == 'true' }}
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install pypa/build
         run: >-
           python3 -m

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install pypa/build
         run: >-
           python3 -m
@@ -32,7 +32,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -25,10 +25,10 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install package
         run: |
           set -eux

--- a/Dockerfiles/class_selection
+++ b/Dockerfiles/class_selection
@@ -1,21 +1,5 @@
 # This Dockerfile is used for Relion class selection
-# First stage builds relion
-FROM rockylinux:8 AS relion-build
-
-# Get required build packages and libraries
-RUN yum install gcc gcc-c++ cmake openmpi -y
-RUN yum install fftw-devel libtiff-devel libpng-devel libjpeg-devel zlib-devel -y
-
-# Build Relion - need to be on the ver4.0 tag
-RUN mkdir -p /install/relion4.0
-COPY packages/relion_fork /install/relion_src
-RUN mkdir /install/relion_src/build
-
-RUN cmake -DCMAKE_INSTALL_PREFIX=/install/relion4.0 -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++ -DMPI_C_COMPILER=/usr/lib64/openmpi/bin/mpicc -DMPI_CXX_COMPILER=/usr/lib64/openmpi/bin/mpicxx -DMPI_C_LIBRARIES=/usr/lib64/openmpi/lib/libmpi.so -DMPI_CXX_LIBRARIES=/usr/lib64/openmpi/lib/libmpi.so -DGUI=OFF -DALTCPU=ON -B/install/relion_src/build -S/install/relion_src
-RUN make --directory=/install/relion_src/build/ install
-
-
-# Second stage creates the conda environment
+# First stage creates a conda environment
 FROM rockylinux:8 AS conda-build
 
 # Set up conda environment
@@ -26,20 +10,49 @@ RUN source "/conda/etc/profile.d/conda.sh" && conda install -c conda-forge conda
 RUN source "/conda/etc/profile.d/conda.sh" && source "/conda/etc/profile.d/mamba.sh" && \
     mamba create -c conda-forge -p /install/pythonenv python=3.11 pip libtiff=4.4.0 --override-channels -y
 RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/pythonenv && \
-    pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+    pip install torch==2.0.1 torchvision==0.15.2 --index-url https://download.pytorch.org/whl/cpu
 
 # Install cryoem-services and pipeliner
 RUN mkdir /install/cryoem-services
 COPY packages/cryoem-services /install/cryoem-services
 RUN mkdir /install/ccpem-pipeliner
 COPY packages/ccpem-pipeliner /install/ccpem-pipeliner
-RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/pythonenv && pip install /install/ccpem-pipeliner && pip install /install/cryoem-services
+RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/pythonenv && \
+    pip install /install/ccpem-pipeliner && pip install /install/cryoem-services
+
+# Install relion classranker
+RUN mkdir /install/relion-classranker
+COPY packages/relion-classranker /install/relion-classranker
+RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/pythonenv && \
+    pip install /install/relion-classranker
 
 # Pack the environment
 RUN /conda/bin/conda-pack -p /install/pythonenv -o /tmp/env.tar.gz
 RUN mkdir /install/venv
 RUN tar -xzf /tmp/env.tar.gz -C /install/venv
 RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/venv && /install/venv/bin/conda-unpack
+
+
+# Second stage builds relion
+FROM rockylinux:8 AS relion-build
+
+# Copy python environment
+COPY --from=conda-build --chown="${userid}":"${groupid}" /install/venv /install/venv
+ENV PATH="/install/venv/bin:${PATH}"
+
+# Get required build packages and libraries
+RUN yum install gcc gcc-c++ cmake openmpi -y
+RUN yum install fftw-devel libtiff-devel libpng-devel libjpeg-devel zlib-devel -y
+
+# Build Relion - need to be on the ver5.0-mc-devolve tag
+RUN mkdir -p /install/relion5.0
+COPY packages/relion_fork /install/relion_src
+RUN mkdir /install/relion_src/build
+
+RUN mkdir /torch_home
+
+RUN cmake -DCMAKE_INSTALL_PREFIX=/install/relion5.0 -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++ -DMPI_C_COMPILER=/usr/lib64/openmpi/bin/mpicc -DMPI_CXX_COMPILER=/usr/lib64/openmpi/bin/mpicxx -DMPI_C_LIBRARIES=/usr/lib64/openmpi/lib/libmpi.so -DMPI_CXX_LIBRARIES=/usr/lib64/openmpi/lib/libmpi.so -DGUI=OFF -DALTCPU=ON -DPYTHON_EXE_PATH=/install/venv/bin/python -DTORCH_HOME_PATH=/torch_home -B/install/relion_src/build -S/install/relion_src
+RUN make --directory=/install/relion_src/build/ install
 
 
 # Third stage combines the Relion and conda builds
@@ -55,9 +68,14 @@ RUN groupadd -r -g "${groupid}" "${groupname}" && useradd -r -M "${groupname}" -
 RUN yum install openmpi fftw-devel libtiff-devel libpng-devel libjpeg-devel zlib-devel -y
 
 # Copy Relion
-COPY --from=relion-build --chown="${userid}":"${groupid}" /install/relion4.0 /install/relion4.0
-ENV PATH="/install/relion4.0/bin:${PATH}"
+COPY --from=relion-build --chown="${userid}":"${groupid}" /install/relion5.0 /install/relion5.0
+ENV PATH="/install/relion5.0/bin:${PATH}"
 
-# Copy python environment
-COPY --from=conda-build --chown="${userid}":"${groupid}" /install/venv /install/venv
+# Copy python environment (from Relion build)
+COPY --from=relion-build --chown="${userid}":"${groupid}" /install/venv /install/venv
 ENV PATH="/install/venv/bin:${PATH}"
+
+# Copy Relion torch models
+COPY --from=relion-build --chown="${userid}":"${groupid}" /torch_home /torch_home
+ENV RELION_PYTHON_EXECUTABLE="/install/venv/bin/python"
+ENV TORCH_HOME="/torch_home"

--- a/Dockerfiles/class_selection
+++ b/Dockerfiles/class_selection
@@ -23,7 +23,7 @@ RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/downloa
 RUN bash Mambaforge-$(uname)-$(uname -m).sh -b -p "conda"
 
 RUN source "/conda/etc/profile.d/conda.sh" && conda install -c conda-forge conda-pack
-RUN source "/conda/etc/profile.d/conda.sh" && source "/conda/etc/profile.d/mamba.sh" && mamba create -c conda-forge -p /install/pythonenv python=3.9 pip libtiff=4.4.0 pytorch-cpu=1.10.0 numpy=1.25.2 --override-channels -y
+RUN source "/conda/etc/profile.d/conda.sh" && source "/conda/etc/profile.d/mamba.sh" && mamba create -c conda-forge -p /install/pythonenv python=3.10 pip libtiff=4.4.0 pytorch-cpu=1.10.0 numpy=1.25.2 --override-channels -y
 
 # Install cryoem-services and pipeliner
 RUN mkdir /install/cryoem-services

--- a/Dockerfiles/class_selection
+++ b/Dockerfiles/class_selection
@@ -52,13 +52,9 @@ RUN groupadd -r -g "${groupid}" "${groupname}" && useradd -r -M "${groupname}" -
 RUN yum install openmpi fftw-devel libtiff-devel libpng-devel libjpeg-devel zlib-devel -y
 
 # Copy Relion
-RUN mkdir -p /install/relion4.0
-COPY --from=relion-build /install/relion4.0 /install/relion4.0
+COPY --from=relion-build --chown="${userid}":"${groupid}" /install/relion4.0 /install/relion4.0
 ENV PATH="/install/relion4.0/bin:${PATH}"
 
 # Copy python environment
-COPY --from=conda-build /install/venv /install/venv
+COPY --from=conda-build --chown="${userid}":"${groupid}" /install/venv /install/venv
 ENV PATH="/install/venv/bin:${PATH}"
-
-# Change permissions
-RUN chown -R "${userid}":"${groupid}" install

--- a/Dockerfiles/class_selection
+++ b/Dockerfiles/class_selection
@@ -19,11 +19,14 @@ RUN make --directory=/install/relion_src/build/ install
 FROM rockylinux:8 AS conda-build
 
 # Set up conda environment
-RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh"
-RUN bash Mambaforge-$(uname)-$(uname -m).sh -b -p "conda"
+RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+RUN bash Miniforge3-$(uname)-$(uname -m).sh -b -p "conda"
 
 RUN source "/conda/etc/profile.d/conda.sh" && conda install -c conda-forge conda-pack
-RUN source "/conda/etc/profile.d/conda.sh" && source "/conda/etc/profile.d/mamba.sh" && mamba create -c conda-forge -p /install/pythonenv python=3.10 pip libtiff=4.4.0 pytorch-cpu=1.10.0 numpy=1.25.2 --override-channels -y
+RUN source "/conda/etc/profile.d/conda.sh" && source "/conda/etc/profile.d/mamba.sh" && \
+    mamba create -c conda-forge -p /install/pythonenv python=3.11 pip libtiff=4.4.0 --override-channels -y
+RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/pythonenv && \
+    pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
 
 # Install cryoem-services and pipeliner
 RUN mkdir /install/cryoem-services

--- a/Dockerfiles/cryoemservices_cpu
+++ b/Dockerfiles/cryoemservices_cpu
@@ -1,5 +1,5 @@
 # This Dockerfile is used for the services that can run on CPU
-FROM python:3.10
+FROM python:3.11
 
 ENV VIRTUAL_ENV=/venv
 RUN python3 -m venv $VIRTUAL_ENV

--- a/Dockerfiles/cryolo
+++ b/Dockerfiles/cryolo
@@ -2,8 +2,8 @@
 FROM rockylinux:8 AS conda-build
 
 # Set up conda environment
-RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh"
-RUN bash Mambaforge-$(uname)-$(uname -m).sh -b -p "conda"
+RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+RUN bash Miniforge3-$(uname)-$(uname -m).sh -b -p "conda"
 
 # Create different conda environments for cryoem-services and cryolo
 RUN source "/conda/etc/profile.d/conda.sh" && conda install -c conda-forge conda-pack
@@ -14,7 +14,8 @@ RUN source "/conda/etc/profile.d/conda.sh" && source "/conda/etc/profile.d/mamba
 # Install cryoem-services and Cryolo in their own environments
 RUN mkdir /install/cryoem-services
 COPY packages/cryoem-services /install/cryoem-services
-RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/services_env && pip install --cache-dir /tmp /install/cryoem-services
+RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/services_env && \
+    pip install --cache-dir /tmp /install/cryoem-services
 RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/cryolo_env && pip install cryolo[cpu]
 
 # Pack the environments

--- a/Dockerfiles/cryolo
+++ b/Dockerfiles/cryolo
@@ -1,26 +1,54 @@
 # This Dockerfile is used for cryolo
-FROM continuumio/miniconda
+FROM rockylinux:8 AS conda-build
 
+# Set up conda environment
+RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh"
+RUN bash Mambaforge-$(uname)-$(uname -m).sh -b -p "conda"
+
+# Create different conda environments for cryoem-services and cryolo
+RUN source "/conda/etc/profile.d/conda.sh" && conda install -c conda-forge conda-pack
+RUN source "/conda/etc/profile.d/conda.sh" && source "/conda/etc/profile.d/mamba.sh" && \
+    mamba create -p /install/services_env -c conda-forge python=3.11 --override-channels -y && \
+    mamba create -p /install/cryolo_env -c conda-forge pyqt=5 python=3.7 cudatoolkit=10.0.130 cudnn=7.6.5 numpy==1.18.5 libtiff wxPython=4.1.1 --override-channels -y
+
+# Install cryoem-services and Cryolo in their own environments
+RUN mkdir /install/cryoem-services
+COPY packages/cryoem-services /install/cryoem-services
+RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/services_env && pip install --cache-dir /tmp /install/cryoem-services
+RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/cryolo_env && pip install cryolo[cpu]
+
+# Pack the environments
+RUN /conda/bin/conda-pack -p /install/services_env -o /tmp/services_env.tar.gz
+RUN mkdir /install/venv_services
+RUN tar -xzf /tmp/services_env.tar.gz -C /install/venv_services
+RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/venv_services && /install/venv_services/bin/conda-unpack
+
+RUN /conda/bin/conda-pack -p /install/cryolo_env -o /tmp/cryolo_env.tar.gz
+RUN mkdir /install/venv_cryolo
+RUN tar -xzf /tmp/cryolo_env.tar.gz -C /install/venv_cryolo
+RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/venv_cryolo && /install/venv_cryolo/bin/conda-unpack
+
+
+# Second stage extracts the conda environments
+FROM rockylinux:8
+
+# Create EM user
 ARG groupid
 ARG userid
 ARG groupname
+RUN groupadd -r -g "${groupid}" "${groupname}" && useradd -r -M "${groupname}" -u "${userid}" -g "${groupname}"
 
-# Create different conda environments for cryoem-services and cryolo
-RUN conda create -n services_env -c conda-forge python=3.9 -y && \
-    conda create -n cryolo_env -c conda-forge pyqt=5 python=3.7 cudatoolkit=10.0.130 cudnn=7.6.5 numpy==1.18.5 libtiff wxPython=4.1.1 adwaita-icon-theme conda conda-wrappers --override-channels -y && \
-    conda clean --all --yes
-
-# Install cryoem-services and Cryolo in their own environments
-COPY --chown="${userid}":"${groupid}" packages/cryoem-services ./cryoem-services
-RUN conda run -n services_env /bin/bash -c "pip install -e ./cryoemservices" && \
-    conda run -n cryolo_env /bin/bash -c "pip install cryolo[cpu]==1.8.1"
+# Copy python environment
+COPY --from=conda-build --chown="${userid}":"${groupid}" /install/venv_services /install/venv_services
+COPY --from=conda-build --chown="${userid}":"${groupid}" /install/venv_cryolo /install/venv_cryolo
 
 RUN mkdir -p /dls_sw/apps/EM/crYOLO/phosaurus_models
 COPY cryolo_models/* /dls_sw/apps/EM/crYOLO/phosaurus_models
 RUN chown -R "${userid}":"${groupid}" /dls_sw
+USER "${userid}":"${groupid}"
 
-RUN echo '#!/bin/bash\n\nif [ ! -z ${RECURSION_PROTECTION} ]; then\n    echo "Unintended recursion detected in zocalo indirection ($0)"\n    exit 1\nfi\nexport RECURSION_PROTECTION=1\n\n. /opt/conda/etc/profile.d/conda.sh\nconda activate /opt/conda/envs/cryolo_env\ncryolo_predict.py "$@"' > /opt/conda/envs/services_env/bin/cryolo_predict.py && \
-    chmod +x /opt/conda/envs/services_env/bin/cryolo_predict.py
+RUN echo '#!/bin/bash\n\nif [ ! -z ${RECURSION_PROTECTION} ]; then\n    echo "Unintended recursion detected in zocalo indirection ($0)"\n    exit 1\nfi\nexport RECURSION_PROTECTION=1\n\nexport PATH="/install/venv_cryolo/bin:${PATH}"\ncryolo_predict.py "$@"' > /install/venv_services/bin/cryolo_predict.py && \
+    chmod +x /install/venv_services/bin/cryolo_predict.py
 
-ENV PATH="/opt/conda/envs/services_env/bin:${PATH}"
+ENV PATH="/install/venv_services/bin:${PATH}"
 

--- a/Dockerfiles/ctffind
+++ b/Dockerfiles/ctffind
@@ -1,5 +1,5 @@
 # This Dockerfile is used for CTFFind4
-FROM python:3.10
+FROM python:3.11
 
 ENV VIRTUAL_ENV=/venv
 RUN python3 -m venv $VIRTUAL_ENV

--- a/Dockerfiles/motioncor2
+++ b/Dockerfiles/motioncor2
@@ -1,5 +1,27 @@
 # This Dockerfile is used for MotionCor2
-FROM nvidia/cuda:12.4.1-runtime-rockylinux8
+FROM rockylinux:8 AS conda-build
+
+# Set up conda environment
+RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh"
+RUN bash Mambaforge-$(uname)-$(uname -m).sh -b -p "conda"
+
+RUN source "/conda/etc/profile.d/conda.sh" && conda install -c conda-forge conda-pack
+RUN source "/conda/etc/profile.d/conda.sh" && source "/conda/etc/profile.d/mamba.sh" && mamba create -c conda-forge -p /install/pythonenv python=3.11 pip libtiff=4.4.0 numpy=1.26.4 --override-channels -y
+
+# Install cryoem-services
+RUN mkdir /install/cryoem-services
+COPY packages/cryoem-services /install/cryoem-services
+RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/pythonenv && pip install --cache-dir /tmp /install/cryoem-services
+
+# Pack the environment
+RUN /conda/bin/conda-pack -p /install/pythonenv -o /tmp/env.tar.gz
+RUN mkdir /install/venv
+RUN tar -xzf /tmp/env.tar.gz -C /install/venv
+RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/venv && /install/venv/bin/conda-unpack
+
+
+# Second stage extracts the conda environment
+FROM nvidia/cuda:10.2-devel-centos7
 
 # Create EM user
 ARG groupid
@@ -7,19 +29,9 @@ ARG userid
 ARG groupname
 RUN groupadd -r -g "${groupid}" "${groupname}" && useradd -r -M "${groupname}" -u "${userid}" -g "${groupname}"
 
-# Set up conda environment
-RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh"
-RUN bash Mambaforge-$(uname)-$(uname -m).sh -b -p "conda"
-
-RUN source "/conda/etc/profile.d/conda.sh" && source "/conda/etc/profile.d/mamba.sh" && mamba create -c conda-forge -p /install/pythonenv python=3.10 pip libtiff=4.4.0 --override-channels -y
-RUN chmod -R a+x /install/pythonenv/bin
-
-# Install cryoem-services
-RUN mkdir /install/cryoem-services
-COPY packages/cryoem-services /install/cryoem-services
-RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/pythonenv && pip install /install/cryoem-services
-RUN chown -R "${userid}":"${groupid}" install
-ENV PATH=/install/pythonenv/bin:${PATH}
+# Copy python environment
+COPY --from=conda-build --chown="${userid}":"${groupid}" /install/venv /install/venv
+ENV PATH="/install/venv/bin:${PATH}"
 
 # Install MotionCor2 executable
 COPY --chown="${userid}":"${groupid}" packages/motioncor-1.4.0 /MotionCor2/1.4.0

--- a/Dockerfiles/motioncor2
+++ b/Dockerfiles/motioncor2
@@ -2,8 +2,8 @@
 FROM rockylinux:8 AS conda-build
 
 # Set up conda environment
-RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh"
-RUN bash Mambaforge-$(uname)-$(uname -m).sh -b -p "conda"
+RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+RUN bash Miniforge3-$(uname)-$(uname -m).sh -b -p "conda"
 
 RUN source "/conda/etc/profile.d/conda.sh" && conda install -c conda-forge conda-pack
 RUN source "/conda/etc/profile.d/conda.sh" && source "/conda/etc/profile.d/mamba.sh" && mamba create -c conda-forge -p /install/pythonenv python=3.11 pip libtiff=4.4.0 numpy=1.26.4 --override-channels -y
@@ -11,7 +11,8 @@ RUN source "/conda/etc/profile.d/conda.sh" && source "/conda/etc/profile.d/mamba
 # Install cryoem-services
 RUN mkdir /install/cryoem-services
 COPY packages/cryoem-services /install/cryoem-services
-RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/pythonenv && pip install --cache-dir /tmp /install/cryoem-services
+RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/pythonenv && \
+    pip install --cache-dir /tmp /install/cryoem-services
 
 # Pack the environment
 RUN /conda/bin/conda-pack -p /install/pythonenv -o /tmp/env.tar.gz

--- a/Dockerfiles/motioncor_relion
+++ b/Dockerfiles/motioncor_relion
@@ -6,12 +6,12 @@ FROM rockylinux:8 AS relion-build
 RUN yum install gcc gcc-c++ cmake openmpi -y
 RUN yum install fftw-devel libtiff-devel libpng-devel libjpeg-devel zlib-devel -y
 
-# Build Relion - need to be on the ver4.0 tag
-RUN mkdir -p /install/relion4.0
+# Build Relion - need to be on the ver5.0-mc-devolve branch
+RUN mkdir -p /install/relion5.0
 COPY packages/relion_fork /install/relion_src
 RUN mkdir /install/relion_src/build
 
-RUN cmake -DCMAKE_INSTALL_PREFIX=/install/relion4.0 -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++ -DMPI_C_COMPILER=/usr/lib64/openmpi/bin/mpicc -DMPI_CXX_COMPILER=/usr/lib64/openmpi/bin/mpicxx -DMPI_C_LIBRARIES=/usr/lib64/openmpi/lib/libmpi.so -DMPI_CXX_LIBRARIES=/usr/lib64/openmpi/lib/libmpi.so -DGUI=OFF -DALTCPU=ON -DDoublePrec_CPU=OFF -DFORCE_OWN_FFTW=ON -DAMDFFTW=ON -B/install/relion_src/build -S/install/relion_src
+RUN cmake -DCMAKE_INSTALL_PREFIX=/install/relion5.0 -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++ -DMPI_C_COMPILER=/usr/lib64/openmpi/bin/mpicc -DMPI_CXX_COMPILER=/usr/lib64/openmpi/bin/mpicxx -DMPI_C_LIBRARIES=/usr/lib64/openmpi/lib/libmpi.so -DMPI_CXX_LIBRARIES=/usr/lib64/openmpi/lib/libmpi.so -DGUI=OFF -DALTCPU=ON -DDoublePrec_CPU=OFF -DFORCE_OWN_FFTW=ON -DAMDFFTW=ON -B/install/relion_src/build -S/install/relion_src
 RUN make --directory=/install/relion_src/build/ install
 
 
@@ -28,8 +28,8 @@ RUN groupadd -r -g "${groupid}" "${groupname}" && useradd -r -M "${groupname}" -
 RUN yum install openmpi fftw-devel libtiff-devel libpng-devel libjpeg-devel python3.11 zlib-devel -y
 
 # Copy Relion
-COPY --from=relion-build --chown="${userid}":"${groupid}" /install/relion4.0 /install/relion4.0
-ENV PATH="/install/relion4.0/bin:${PATH}"
+COPY --from=relion-build --chown="${userid}":"${groupid}" /install/relion5.0 /install/relion5.0
+ENV PATH="/install/relion5.0/bin:${PATH}"
 
 # Make the python virtual environment and install cryoem-services
 ENV VIRTUAL_ENV=/venv

--- a/Dockerfiles/motioncor_relion
+++ b/Dockerfiles/motioncor_relion
@@ -16,7 +16,7 @@ RUN make --directory=/install/relion_src/build/ install
 
 
 # Second stage combines the Relion build with a python environment
-FROM rockylinux:9
+FROM rockylinux:8
 
 # Create EM user
 ARG groupid
@@ -28,10 +28,8 @@ RUN groupadd -r -g "${groupid}" "${groupname}" && useradd -r -M "${groupname}" -
 RUN yum install openmpi fftw-devel libtiff-devel libpng-devel libjpeg-devel python3.11 zlib-devel -y
 
 # Copy Relion
-RUN mkdir -p /install/relion4.0
-COPY --from=relion-build /install/relion4.0 /install/relion4.0
+COPY --from=relion-build --chown="${userid}":"${groupid}" /install/relion4.0 /install/relion4.0
 ENV PATH="/install/relion4.0/bin:${PATH}"
-RUN chown -R "${userid}":"${groupid}" install
 
 # Make the python virtual environment and install cryoem-services
 ENV VIRTUAL_ENV=/venv
@@ -39,4 +37,3 @@ RUN python3.11 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 COPY --chown="${userid}":"${groupid}" packages/cryoem-services ./cryoem-services
 RUN python3.11 -m pip install --upgrade pip && python3.11 -m pip install ./cryoem-services
-

--- a/Dockerfiles/tomo_align
+++ b/Dockerfiles/tomo_align
@@ -1,4 +1,26 @@
 # This Dockerfile is used for GPU AreTomo2 processing
+FROM rockylinux:8 AS conda-build
+
+# Set up conda environment
+RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh"
+RUN bash Mambaforge-$(uname)-$(uname -m).sh -b -p "conda"
+
+RUN source "/conda/etc/profile.d/conda.sh" && conda install -c conda-forge conda-pack
+RUN source "/conda/etc/profile.d/conda.sh" && source "/conda/etc/profile.d/mamba.sh" && mamba create -c conda-forge -p /install/pythonenv python=3.11 pip libtiff=4.4.0 numpy=1.26.4 --override-channels -y
+
+# Install cryoem-services
+RUN mkdir /install/cryoem-services
+COPY packages/cryoem-services /install/cryoem-services
+RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/pythonenv && pip install --cache-dir /tmp /install/cryoem-services
+
+# Pack the environment
+RUN /conda/bin/conda-pack -p /install/pythonenv -o /tmp/env.tar.gz
+RUN mkdir /install/venv
+RUN tar -xzf /tmp/env.tar.gz -C /install/venv
+RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/venv && /install/venv/bin/conda-unpack
+
+
+# Second stage extracts the conda environment
 FROM nvidia/cuda:12.4.1-runtime-rockylinux8
 
 # Create EM user
@@ -7,19 +29,9 @@ ARG userid
 ARG groupname
 RUN groupadd -r -g "${groupid}" "${groupname}" && useradd -r -M "${groupname}" -u "${userid}" -g "${groupname}"
 
-# Set up conda environment
-RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh"
-RUN bash Mambaforge-$(uname)-$(uname -m).sh -b -p "conda"
-
-RUN source "/conda/etc/profile.d/conda.sh" && source "/conda/etc/profile.d/mamba.sh" && mamba create -c conda-forge -p /install/pythonenv python=3.10 pip libtiff=4.4.0 --override-channels -y
-RUN chmod -R a+x /install/pythonenv/bin
-
-# Install cryoem-services
-RUN mkdir /install/cryoem-services
-COPY packages/cryoem-services /install/cryoem-services
-RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/pythonenv && pip install /install/cryoem-services
-RUN chown -R "${userid}":"${groupid}" install
-ENV PATH=/install/pythonenv/bin:${PATH}
+# Copy python environment
+COPY --from=conda-build --chown="${userid}":"${groupid}" /install/venv /install/venv
+ENV PATH="/install/venv/bin:${PATH}"
 
 # Install IMOD
 COPY --chown="${userid}":"${groupid}" packages/imod-4.11.1 /IMOD/4.11.1

--- a/Dockerfiles/tomo_align
+++ b/Dockerfiles/tomo_align
@@ -2,11 +2,12 @@
 FROM rockylinux:8 AS conda-build
 
 # Set up conda environment
-RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh"
-RUN bash Mambaforge-$(uname)-$(uname -m).sh -b -p "conda"
+RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+RUN bash Miniforge3-$(uname)-$(uname -m).sh -b -p "conda"
 
 RUN source "/conda/etc/profile.d/conda.sh" && conda install -c conda-forge conda-pack
-RUN source "/conda/etc/profile.d/conda.sh" && source "/conda/etc/profile.d/mamba.sh" && mamba create -c conda-forge -p /install/pythonenv python=3.11 pip libtiff=4.4.0 numpy=1.26.4 --override-channels -y
+RUN source "/conda/etc/profile.d/conda.sh" && source "/conda/etc/profile.d/mamba.sh" && \
+    mamba create -c conda-forge -p /install/pythonenv python=3.11 pip libtiff=4.4.0 numpy=1.26.4 --override-channels -y
 
 # Install cryoem-services
 RUN mkdir /install/cryoem-services

--- a/Dockerfiles/topaz
+++ b/Dockerfiles/topaz
@@ -1,4 +1,4 @@
-FROM python:3.10
+FROM python:3.11
 
 ENV VIRTUAL_ENV=/venv
 RUN python3 -m venv $VIRTUAL_ENV
@@ -12,7 +12,7 @@ COPY --chown="${userid}":"${groupid}" packages/cryoem-services ./cryoem-services
 RUN python -m pip install ./cryoem-services
 
 # Install topaz
-RUN python -m pip install topaz-em
+RUN python -m pip install topaz-em==0.2.5
 
 # Create EM user
 RUN groupadd -r -g "${groupid}" "${groupname}" && useradd -r -M "${groupname}" -u "${userid}" -g "${groupname}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,17 +17,16 @@ license = { file = "LICENSE" }
 authors = [
     { name = "Diamond Light Source - Data Analysis et al.", email = "dataanalysis@diamond.ac.uk" },
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: BSD License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
     "defusedxml", # CLEM workflow
@@ -46,8 +45,8 @@ dependencies = [
     "starfile",
     "stomp-py==8.1.0",
     "tifffile", # CLEM workflow
-    "workflows",
-    "zocalo>=1",
+    "workflows>=3",
+    "zocalo>=1.2",
 ]
 [project.optional-dependencies]
 dev = [

--- a/src/cryoemservices/services/node_creator.py
+++ b/src/cryoemservices/services/node_creator.py
@@ -18,7 +18,7 @@ from pipeliner.api.manage_project import PipelinerProject
 from pipeliner.data_structure import FAIL_FILE, SUCCESS_FILE
 from pipeliner.job_factory import read_job
 from pipeliner.project_graph import ProjectGraph
-from pipeliner.utils import DirectoryBasedLock
+from pipeliner.utils import DirectoryBasedLock, update_jobinfo_file
 from pydantic import BaseModel, Field, ValidationError, field_validator
 from workflows.services.common_service import CommonService
 
@@ -55,9 +55,10 @@ def adjust_job_counter(pipeline_name: str, job_number: int):
                 break
     if job_count <= job_number:
         job_count = job_number + 1
-        with open(f"{pipeline_name}_pipeline.star", "r") as pipeline_file, open(
-            f"{pipeline_name}_pipeline.star.tmp", "w"
-        ) as new_pipeline:
+        with (
+            open(f"{pipeline_name}_pipeline.star", "r") as pipeline_file,
+            open(f"{pipeline_name}_pipeline.star.tmp", "w") as new_pipeline,
+        ):
             while True:
                 line = pipeline_file.readline()
                 if not line:
@@ -430,7 +431,7 @@ class NodeCreator(CommonService):
         # Load this job as a pipeliner job to create the nodes
         pipeliner_job = read_job(f"{job_dir}/job.star")
         pipeliner_job.output_dir = str(relative_job_dir) + "/"
-        relion_commands = [[], pipeliner_job.get_final_commands()]
+        relion_commands = pipeliner_job.get_final_commands()
 
         # These parts would normally happen in pipeliner_job.prepare_to_run
         pipeliner_job.create_input_nodes()
@@ -552,7 +553,10 @@ class NodeCreator(CommonService):
             )
             # Add the job commands to the process .CCPEM_pipeliner_jobinfo file
             if not (job_dir / ".CCPEM_pipeliner_jobinfo").exists():
-                process.update_jobinfo_file(action="Run", command_list=relion_commands)
+                for command in relion_commands:
+                    update_jobinfo_file(
+                        process.name, action="Run", command_list=command
+                    )
             # Generate the default_pipeline.star file
             project.check_process_completion()
             # Check the job count in the default_pipeline.star


### PR DESCRIPTION
Remove support for python 3.9, and add support for 3.12. All automated actions and dockerfiles are upgraded to 3.11.

Most of this commit consists of Dockerfile updates. These move to 3.11 and Miniforge, but also have some rearrangements as they were out-of-date.

To get Relion's class selection to work in python>3.9 has required moving to Relion 5.0, with a corresponding branch on the fork at https://github.com/d-j-hatton/relion/tree/ver5.0-mc-devolve

The ccpem-pipeliner fork we use at https://gitlab.com/stephen-riggs/ccpem-pipeliner/-/tree/diamond_tomo has also been updated. However, not all the dependencies work in python 3.12, so these have had to be removed temporarily.
