### PR TITLE
Reduce the space taken up by icebreaker results

### DIFF
--- a/src/cryoemservices/services/icebreaker.py
+++ b/src/cryoemservices/services/icebreaker.py
@@ -6,8 +6,6 @@ import shutil
 from pathlib import Path
 from typing import Any, Literal, Optional
 
-import mrcfile
-import numpy as np
 import workflows.recipe
 from gemmi import cif
 from icebreaker import ice_groups, icebreaker_equalize_multi, icebreaker_icegroups_multi
@@ -144,18 +142,13 @@ class IceBreaker(CommonService):
                 icebreaker_icegroups_multi.multigroup(
                     icebreaker_tmp_dir / mic_from_project.name
                 )
-                # Convert this to a 16-bit integer to make it smaller
-                with mrcfile.open(
-                    icebreaker_tmp_dir
-                    / "grouped"
-                    / f"{micrograph_name.stem}_grouped.mrc",
-                    "r",
-                ) as mrc:
-                    ib_data = mrc.data
-                with mrcfile.new(
-                    f"{mic_dir_from_job}/{micrograph_name.stem}_grouped.mrc"
-                ) as new_mrc:
-                    new_mrc.set_data((ib_data * 1000).astype(np.int16))
+                # Rename the file from the tmp directory to the output directory
+                for ib_grouped_mic in icebreaker_tmp_dir.glob(
+                    f"grouped/{micrograph_name.stem}_grouped_*.mrc"
+                ):
+                    ib_grouped_mic.rename(
+                        f"{mic_dir_from_job}/{micrograph_name.stem}_grouped.mrc"
+                    )
             else:
                 (icebreaker_tmp_dir / "flattened").mkdir()
                 icebreaker_equalize_multi.multigroup(

--- a/src/cryoemservices/services/icebreaker.py
+++ b/src/cryoemservices/services/icebreaker.py
@@ -161,15 +161,13 @@ class IceBreaker(CommonService):
                 icebreaker_equalize_multi.multigroup(
                     icebreaker_tmp_dir / mic_from_project.name
                 )
-                (
+                # The flattened micrograph is not currently used, so remove it
+                # If it was used it should be renamed to
+                # f"{mic_dir_from_job}/{micrograph_name.stem}_flattened.mrc"
+                Path(
                     icebreaker_tmp_dir
                     / "flattened"
                     / f"{micrograph_name.stem}_flattened.mrc"
-                ).rename(f"{mic_dir_from_job}/{micrograph_name.stem}_flattened.mrc")
-
-                # The flattened micrograph is not currently used, so remove it
-                Path(
-                    f"{mic_dir_from_job}/{micrograph_name.stem}_flattened.mrc"
                 ).unlink()
             shutil.rmtree(icebreaker_tmp_dir)
 

--- a/tests/services/test_icebreaker_service.py
+++ b/tests/services/test_icebreaker_service.py
@@ -5,7 +5,6 @@ import sys
 from pathlib import Path
 from unittest import mock
 
-import mrcfile
 import pytest
 from workflows.transport.offline_transport import OfflineTransport
 
@@ -24,10 +23,7 @@ def offline_transport(mocker):
 
 def icebreaker_group_output_file(*args):
     input_file = Path(args[0])
-    with mrcfile.new(
-        input_file.parent / f"grouped/{input_file.stem}_grouped.mrc"
-    ) as mrc:
-        mrc.set_data = [[1.0006, 2.5465647, 3.4646547, 4.442434]]
+    (input_file.parent / f"grouped/{input_file.stem}_grouped.mrc").touch()
 
 
 def icebreaker_flatten_output_file(*args):

--- a/tests/services/test_icebreaker_service.py
+++ b/tests/services/test_icebreaker_service.py
@@ -5,6 +5,7 @@ import sys
 from pathlib import Path
 from unittest import mock
 
+import mrcfile
 import pytest
 from workflows.transport.offline_transport import OfflineTransport
 
@@ -23,7 +24,10 @@ def offline_transport(mocker):
 
 def icebreaker_group_output_file(*args):
     input_file = Path(args[0])
-    (input_file.parent / f"grouped/{input_file.stem}_grouped.mrc").touch()
+    with mrcfile.new(
+        input_file.parent / f"grouped/{input_file.stem}_grouped.mrc"
+    ) as mrc:
+        mrc.set_data = [[1.0006, 2.5465647, 3.4646547, 4.442434]]
 
 
 def icebreaker_flatten_output_file(*args):


### PR DESCRIPTION
- Removes the flattened IceBreaker output mrc, as this is currently not user.
- Allows the grouping job to use the "updates" branch of IceBreaker, which writes smaller files