### PR TITLE
Remove rmq api secret references

### DIFF
--- a/Helm/charts/bfactor_setup/templates/deployment.yaml
+++ b/Helm/charts/bfactor_setup/templates/deployment.yaml
@@ -52,8 +52,6 @@ spec:
           sources:
           - secret:
               name: {{ .Values.global.rmqSecretName }}
-          - secret:
-              name: {{ .Values.global.rmqApiSecretName }}
 {{- if .Values.global.extraGlobalVolumes }}
 {{ toYaml .Values.global.extraGlobalVolumes | indent 6 }}
 {{ end }}

--- a/Helm/charts/cluster_submission/templates/deployment.yaml
+++ b/Helm/charts/cluster_submission/templates/deployment.yaml
@@ -52,8 +52,6 @@ spec:
           sources:
           - secret:
               name: {{ .Values.global.rmqSecretName }}
-          - secret:
-              name: {{ .Values.global.rmqApiSecretName }}
 {{- if .Values.global.extraGlobalVolumes }}
 {{ toYaml .Values.global.extraGlobalVolumes | indent 6 }}
 {{ end }}

--- a/Helm/charts/cryolo/templates/deployment.yaml
+++ b/Helm/charts/cryolo/templates/deployment.yaml
@@ -52,8 +52,6 @@ spec:
           sources:
           - secret:
               name: {{ .Values.global.rmqSecretName }}
-          - secret:
-              name: {{ .Values.global.rmqApiSecretName }}
 {{- if .Values.global.extraGlobalVolumes }}
 {{ toYaml .Values.global.extraGlobalVolumes | indent 6 }}
 {{ end }}

--- a/Helm/charts/ctffind/templates/deployment.yaml
+++ b/Helm/charts/ctffind/templates/deployment.yaml
@@ -52,8 +52,6 @@ spec:
           sources:
           - secret:
               name: {{ .Values.global.rmqSecretName }}
-          - secret:
-              name: {{ .Values.global.rmqApiSecretName }}
 {{- if .Values.global.extraGlobalVolumes }}
 {{ toYaml .Values.global.extraGlobalVolumes | indent 6 }}
 {{ end }}

--- a/Helm/charts/denoise/templates/deployment.yaml
+++ b/Helm/charts/denoise/templates/deployment.yaml
@@ -59,8 +59,6 @@ spec:
           sources:
           - secret:
               name: {{ .Values.global.rmqSecretName }}
-          - secret:
-              name: {{ .Values.global.rmqApiSecretName }}
 {{- if .Values.global.extraGlobalVolumes }}
 {{ toYaml .Values.global.extraGlobalVolumes | indent 6 }}
 {{ end }}

--- a/Helm/charts/denoise_slurm/templates/deployment.yaml
+++ b/Helm/charts/denoise_slurm/templates/deployment.yaml
@@ -55,8 +55,6 @@ spec:
           sources:
           - secret:
               name: {{ .Values.global.rmqSecretName }}
-          - secret:
-              name: {{ .Values.global.rmqApiSecretName }}
 {{- if .Values.global.extraGlobalVolumes }}
 {{ toYaml .Values.global.extraGlobalVolumes | indent 6 }}
 {{ end }}

--- a/Helm/charts/extract/templates/deployment.yaml
+++ b/Helm/charts/extract/templates/deployment.yaml
@@ -59,8 +59,6 @@ spec:
           sources:
           - secret:
               name: {{ .Values.global.rmqSecretName }}
-          - secret:
-              name: {{ .Values.global.rmqApiSecretName }}
 {{- if .Values.global.extraGlobalVolumes }}
 {{ toYaml .Values.global.extraGlobalVolumes | indent 6 }}
 {{ end }}

--- a/Helm/charts/extract_class/templates/deployment.yaml
+++ b/Helm/charts/extract_class/templates/deployment.yaml
@@ -52,8 +52,6 @@ spec:
           sources:
           - secret:
               name: {{ .Values.global.rmqSecretName }}
-          - secret:
-              name: {{ .Values.global.rmqApiSecretName }}
 {{- if .Values.global.extraGlobalVolumes }}
 {{ toYaml .Values.global.extraGlobalVolumes | indent 6 }}
 {{ end }}

--- a/Helm/charts/icebreaker/templates/deployment.yaml
+++ b/Helm/charts/icebreaker/templates/deployment.yaml
@@ -52,8 +52,6 @@ spec:
           sources:
           - secret:
               name: {{ .Values.global.rmqSecretName }}
-          - secret:
-              name: {{ .Values.global.rmqApiSecretName }}
 {{- if .Values.global.extraGlobalVolumes }}
 {{ toYaml .Values.global.extraGlobalVolumes | indent 6 }}
 {{ end }}

--- a/Helm/charts/images/templates/deployment.yaml
+++ b/Helm/charts/images/templates/deployment.yaml
@@ -52,8 +52,6 @@ spec:
           sources:
           - secret:
               name: {{ .Values.global.rmqSecretName }}
-          - secret:
-              name: {{ .Values.global.rmqApiSecretName }}
 {{- if .Values.global.extraGlobalVolumes }}
 {{ toYaml .Values.global.extraGlobalVolumes | indent 6 }}
 {{ end }}

--- a/Helm/charts/ispyb_connector/templates/deployment.yaml
+++ b/Helm/charts/ispyb_connector/templates/deployment.yaml
@@ -54,8 +54,6 @@ spec:
               name: {{ .Values.global.dbSecretName }}
           - secret:
               name: {{ .Values.global.rmqSecretName }}
-          - secret:
-              name: {{ .Values.global.rmqApiSecretName }}
 {{- if .Values.global.extraGlobalVolumes }}
 {{ toYaml .Values.global.extraGlobalVolumes | indent 6 }}
 {{ end }}

--- a/Helm/charts/membrain_seg/templates/deployment.yaml
+++ b/Helm/charts/membrain_seg/templates/deployment.yaml
@@ -52,8 +52,6 @@ spec:
           sources:
           - secret:
               name: {{ .Values.global.rmqSecretName }}
-          - secret:
-              name: {{ .Values.global.rmqApiSecretName }}
 {{- if .Values.global.extraGlobalVolumes }}
 {{ toYaml .Values.global.extraGlobalVolumes | indent 6 }}
 {{ end }}

--- a/Helm/charts/motioncorr/templates/deployment.yaml
+++ b/Helm/charts/motioncorr/templates/deployment.yaml
@@ -55,8 +55,6 @@ spec:
           sources:
           - secret:
               name: {{ .Values.global.rmqSecretName }}
-          - secret:
-              name: {{ .Values.global.rmqApiSecretName }}
 {{- if .Values.global.extraGlobalVolumes }}
 {{ toYaml .Values.global.extraGlobalVolumes | indent 6 }}
 {{ end }}

--- a/Helm/charts/node_creator/templates/deployment.yaml
+++ b/Helm/charts/node_creator/templates/deployment.yaml
@@ -52,8 +52,6 @@ spec:
           sources:
           - secret:
               name: {{ .Values.global.rmqSecretName }}
-          - secret:
-              name: {{ .Values.global.rmqApiSecretName }}
 {{- if .Values.global.extraGlobalVolumes }}
 {{ toYaml .Values.global.extraGlobalVolumes | indent 6 }}
 {{ end }}

--- a/Helm/charts/postprocess/templates/deployment.yaml
+++ b/Helm/charts/postprocess/templates/deployment.yaml
@@ -52,8 +52,6 @@ spec:
           sources:
           - secret:
               name: {{ .Values.global.rmqSecretName }}
-          - secret:
-              name: {{ .Values.global.rmqApiSecretName }}
 {{- if .Values.global.extraGlobalVolumes }}
 {{ toYaml .Values.global.extraGlobalVolumes | indent 6 }}
 {{ end }}

--- a/Helm/charts/process_recipe/templates/deployment.yaml
+++ b/Helm/charts/process_recipe/templates/deployment.yaml
@@ -54,8 +54,6 @@ spec:
               name: {{ .Values.global.dbSecretName }}
           - secret:
               name: {{ .Values.global.rmqSecretName }}
-          - secret:
-              name: {{ .Values.global.rmqApiSecretName }}
 {{- if .Values.global.extraGlobalVolumes }}
 {{ toYaml .Values.global.extraGlobalVolumes | indent 6 }}
 {{ end }}

--- a/Helm/charts/select_classes/templates/deployment.yaml
+++ b/Helm/charts/select_classes/templates/deployment.yaml
@@ -52,8 +52,6 @@ spec:
           sources:
           - secret:
               name: {{ .Values.global.rmqSecretName }}
-          - secret:
-              name: {{ .Values.global.rmqApiSecretName }}
 {{- if .Values.global.extraGlobalVolumes }}
 {{ toYaml .Values.global.extraGlobalVolumes | indent 6 }}
 {{ end }}

--- a/Helm/charts/select_particles/templates/deployment.yaml
+++ b/Helm/charts/select_particles/templates/deployment.yaml
@@ -52,8 +52,6 @@ spec:
           sources:
           - secret:
               name: {{ .Values.global.rmqSecretName }}
-          - secret:
-              name: {{ .Values.global.rmqApiSecretName }}
 {{- if .Values.global.extraGlobalVolumes }}
 {{ toYaml .Values.global.extraGlobalVolumes | indent 6 }}
 {{ end }}

--- a/Helm/charts/tomo_align/templates/deployment.yaml
+++ b/Helm/charts/tomo_align/templates/deployment.yaml
@@ -57,8 +57,6 @@ spec:
           sources:
           - secret:
               name: {{ .Values.global.rmqSecretName }}
-          - secret:
-              name: {{ .Values.global.rmqApiSecretName }}
 {{- if .Values.global.extraGlobalVolumes }}
 {{ toYaml .Values.global.extraGlobalVolumes | indent 6 }}
 {{ end }}

--- a/Helm/charts/tomo_align_slurm/templates/deployment.yaml
+++ b/Helm/charts/tomo_align_slurm/templates/deployment.yaml
@@ -61,8 +61,6 @@ spec:
           sources:
           - secret:
               name: {{ .Values.global.rmqSecretName }}
-          - secret:
-              name: {{ .Values.global.rmqApiSecretName }}
 {{- if .Values.global.extraGlobalVolumes }}
 {{ toYaml .Values.global.extraGlobalVolumes | indent 6 }}
 {{ end }}

--- a/Helm/values.yaml
+++ b/Helm/values.yaml
@@ -8,7 +8,6 @@ global:
   dbSecretName: ispyb
   dbFileName: ispyb.cfg
   rmqSecretName: rmq-creds-k8s
-  rmqApiSecretName: rmq-api-reader-k8s
   extraGlobalVolumes:
     - name: home
       hostPath:


### PR DESCRIPTION
Now that the zocalo config file has been removed, the rmq api secret can be merged with the main rmq secret