### PR TITLE
Various fixes to ispyb inserts

### DIFF
--- a/src/cryoemservices/services/ispyb_connector.py
+++ b/src/cryoemservices/services/ispyb_connector.py
@@ -149,11 +149,8 @@ class EMISPyB(CommonService):
             rw.checkpoint(result.get("checkpoint_dict"))
             rw.transport.ack(header)
         elif message["expiry_time"] > time.time():
-            self.log.warning(
-                f"Failed call {command}. Checkpointing for delayed resubmission"
-            )
-            rw.checkpoint(message, delay=20)
-            rw.transport.ack(header)
+            self.log.warning(f"Failed call {command} due to timeout")
+            rw.transport.nack(header)
         else:
             self.log.error(f"ISPyB request for {command} failed")
             rw.transport.nack(header)

--- a/src/cryoemservices/services/ispyb_connector.py
+++ b/src/cryoemservices/services/ispyb_connector.py
@@ -73,14 +73,12 @@ class EMISPyB(CommonService):
 
         def replace_with_environment(env_value):
             """Replace any $ keys with their value provided in the environment"""
-            for key in sorted(rw.environment, key=len, reverse=True):
-                if "${" + str(key) + "}" in env_value:
+            for key in rw.environment:
+                if "${" + str(key) + "}" == env_value:
                     env_value = env_value.replace(
                         "${" + str(key) + "}", str(rw.environment[key])
                     )
-                # Replace longest keys first, as the following replacement is
-                # not well-defined when one key is a prefix of another:
-                if f"${key}" in env_value:
+                if f"${key}" == env_value:
                     env_value = env_value.replace(f"${key}", str(rw.environment[key]))
             return env_value
 

--- a/src/cryoemservices/util/ispyb_commands.py
+++ b/src/cryoemservices/util/ispyb_commands.py
@@ -15,6 +15,23 @@ logger = logging.getLogger("cryoemservices.util.ispyb_commands")
 logger.setLevel(logging.INFO)
 
 
+def parameters_with_replacement(param: str, message: dict, all_parameters: Callable):
+    """
+    Create a parameter lookup function specific to this call.
+    Slight change in behaviour compared to 'parameters' in a direct call:
+    If the value is defined in the command list item then this takes
+    precedence.
+    """
+    if message.get(param) and "$" not in str(message[param]):
+        # Precedence for command list items
+        return message[param]
+    elif message.get(param):
+        # Run lookup on dollar parameters
+        return all_parameters(message[param])
+    # Lookup anything else
+    return all_parameters(param)
+
+
 def multipart_message(
     message: dict, parameters: Callable, session: sqlalchemy.orm.Session
 ):
@@ -43,15 +60,7 @@ def multipart_message(
 
     # Create a parameter lookup function specific to this step
     def step_parameters(parameter):
-        """Slight change in behaviour compared to 'parameters' in a direct call:
-        If the value is defined in the command list item then this takes
-        precedence.
-        """
-        if parameter in current_command:
-            base_value = current_command[parameter]
-        else:
-            base_value = parameters(parameter)
-        return base_value
+        return parameters_with_replacement(parameter, current_command, parameters)
 
     # If this step previously checkpointed then override the message passed
     # to the step.
@@ -220,7 +229,7 @@ def insert_motion_correction(
     message: dict, parameters: Callable, session: sqlalchemy.orm.Session
 ):
     def full_parameters(param):
-        return message.get(param) or parameters(param)
+        return parameters_with_replacement(param, message, parameters)
 
     try:
         movie_id = None
@@ -279,7 +288,7 @@ def insert_relative_ice_thickness(
     message: dict, parameters: Callable, session: sqlalchemy.orm.Session
 ):
     def full_parameters(param):
-        return message.get(param) or parameters(param)
+        return parameters_with_replacement(param, message, parameters)
 
     try:
         values = models.RelativeIceThickness(
@@ -305,7 +314,7 @@ def insert_relative_ice_thickness(
 
 def insert_ctf(message: dict, parameters: Callable, session: sqlalchemy.orm.Session):
     def full_parameters(param):
-        return message.get(param) or parameters(param)
+        return parameters_with_replacement(param, message, parameters)
 
     try:
         values = models.CTF(
@@ -344,7 +353,7 @@ def insert_particle_picker(
     message: dict, parameters: Callable, session: sqlalchemy.orm.Session
 ):
     def full_parameters(param):
-        return message.get(param) or parameters(param)
+        return parameters_with_replacement(param, message, parameters)
 
     try:
         values = models.ParticlePicker(
@@ -372,7 +381,7 @@ def insert_particle_classification(
     message: dict, parameters: Callable, session: sqlalchemy.orm.Session
 ):
     def full_parameters(param):
-        return message.get(param) or parameters(param)
+        return parameters_with_replacement(param, message, parameters)
 
     try:
         values = models.ParticleClassification(
@@ -432,7 +441,7 @@ def insert_particle_classification_group(
     message: dict, parameters: Callable, session: sqlalchemy.orm.Session
 ):
     def full_parameters(param):
-        return message.get(param) or parameters(param)
+        return parameters_with_replacement(param, message, parameters)
 
     try:
         values = models.ParticleClassificationGroup(
@@ -490,7 +499,7 @@ def insert_cryoem_initial_model(
     message: dict, parameters: Callable, session: sqlalchemy.orm.Session
 ):
     def full_parameters(param):
-        return message.get(param) or parameters(param)
+        return parameters_with_replacement(param, message, parameters)
 
     try:
         if not full_parameters("cryoem_initial_model_id"):
@@ -524,7 +533,7 @@ def insert_bfactor_fit(
     message: dict, parameters: Callable, session: sqlalchemy.orm.Session
 ):
     def full_parameters(param):
-        return message.get(param) or parameters(param)
+        return parameters_with_replacement(param, message, parameters)
 
     try:
         values = models.BFactorFit(
@@ -572,7 +581,7 @@ def insert_tomogram(
         message = {}
 
     def full_parameters(param):
-        return message.get(param) or parameters(param)
+        return parameters_with_replacement(param, message, parameters)
 
     try:
         values = models.Tomogram(
@@ -632,7 +641,7 @@ def insert_processed_tomogram(
     message: dict, parameters: Callable, session: sqlalchemy.orm.Session
 ):
     def full_parameters(param):
-        return message.get(param) or parameters(param)
+        return parameters_with_replacement(param, message, parameters)
 
     try:
         values = models.ProcessedTomogram(
@@ -656,7 +665,7 @@ def insert_tilt_image_alignment(
     message: dict, parameters: Callable, session: sqlalchemy.orm.Session
 ):
     def full_parameters(param):
-        return message.get(param) or parameters(param)
+        return parameters_with_replacement(param, message, parameters)
 
     if full_parameters("movie_id"):
         mvid = full_parameters("movie_id")
@@ -697,7 +706,7 @@ def update_processing_status(
     message: dict, parameters: Callable, session: sqlalchemy.orm.Session
 ):
     def full_parameters(param):
-        return message.get(param) or parameters(param)
+        return parameters_with_replacement(param, message, parameters)
 
     ppid = full_parameters("program_id")
     status_message = full_parameters("status_message")

--- a/src/cryoemservices/util/ispyb_commands.py
+++ b/src/cryoemservices/util/ispyb_commands.py
@@ -187,23 +187,23 @@ def _get_movie_id(
 
 def insert_movie(message: dict, parameters: Callable, session: sqlalchemy.orm.Session):
     try:
-        if parameters("timestamp"):
-            values = models.Movie(
-                dataCollectionId=parameters("dcid"),
-                foilHoleId=parameters("foil_hole_id"),
-                movieNumber=parameters("movie_number"),
-                movieFullPath=parameters("movie_path"),
-                createdTimeStamp=datetime.fromtimestamp(
-                    parameters("timestamp")
-                ).strftime("%Y-%m-%d %H:%M:%S"),
+        foil_hole_id = (
+            parameters("foil_hole_id") if parameters("foil_hole_id") != "None" else None
+        )
+        created_time_stamp = (
+            datetime.fromtimestamp(parameters("timestamp")).strftime(
+                "%Y-%m-%d %H:%M:%S"
             )
-        else:
-            values = models.Movie(
-                dataCollectionId=parameters("dcid"),
-                foilHoleId=parameters("foil_hole_id"),
-                movieNumber=parameters("movie_number"),
-                movieFullPath=parameters("movie_path"),
-            )
+            if parameters("timestamp")
+            else None
+        )
+        values = models.Movie(
+            dataCollectionId=parameters("dcid"),
+            foilHoleId=foil_hole_id,
+            movieNumber=parameters("movie_number"),
+            movieFullPath=parameters("movie_path"),
+            createdTimeStamp=created_time_stamp,
+        )
         session.add(values)
         session.commit()
         logger.info(f"Created Movie record {values.movieId}")

--- a/src/cryoemservices/util/ispyb_commands.py
+++ b/src/cryoemservices/util/ispyb_commands.py
@@ -199,20 +199,23 @@ def insert_movie(message: dict, parameters: Callable, session: sqlalchemy.orm.Se
         foil_hole_id = (
             parameters("foil_hole_id") if parameters("foil_hole_id") != "None" else None
         )
-        created_time_stamp = (
-            datetime.fromtimestamp(parameters("timestamp")).strftime(
-                "%Y-%m-%d %H:%M:%S"
+        if parameters("timestamp"):
+            values = models.Movie(
+                dataCollectionId=parameters("dcid"),
+                foilHoleId=foil_hole_id,
+                movieNumber=parameters("movie_number"),
+                movieFullPath=parameters("movie_path"),
+                createdTimeStamp=datetime.fromtimestamp(
+                    parameters("timestamp")
+                ).strftime("%Y-%m-%d %H:%M:%S"),
             )
-            if parameters("timestamp")
-            else None
-        )
-        values = models.Movie(
-            dataCollectionId=parameters("dcid"),
-            foilHoleId=foil_hole_id,
-            movieNumber=parameters("movie_number"),
-            movieFullPath=parameters("movie_path"),
-            createdTimeStamp=created_time_stamp,
-        )
+        else:
+            values = models.Movie(
+                dataCollectionId=parameters("dcid"),
+                foilHoleId=foil_hole_id,
+                movieNumber=parameters("movie_number"),
+                movieFullPath=parameters("movie_path"),
+            )
         session.add(values)
         session.commit()
         logger.info(f"Created Movie record {values.movieId}")

--- a/src/cryoemservices/util/ispyb_commands.py
+++ b/src/cryoemservices/util/ispyb_commands.py
@@ -362,7 +362,7 @@ def insert_particle_picker(
             firstMotionCorrectionId=full_parameters("motion_correction_id"),
             particlePickingTemplate=full_parameters("particle_picking_template"),
             particleDiameter=full_parameters("particle_diameter"),
-            numberOfParticles=full_parameters("number_of_particles"),
+            numberOfParticles=full_parameters("number_of_particles") or 0,
             summaryImageFullPath=full_parameters("summary_image_full_path"),
         )
         session.add(values)

--- a/tests/services/test_ispyb_service.py
+++ b/tests/services/test_ispyb_service.py
@@ -14,6 +14,7 @@ from cryoemservices.services import ispyb_connector
 def offline_transport(mocker):
     transport = OfflineTransport()
     mocker.spy(transport, "send")
+    mocker.spy(transport, "nack")
     return transport
 
 
@@ -372,7 +373,7 @@ def test_ispyb_service_failed_lookup(
 ):
     """
     Send a test message to the ispyb service for a command which fails
-    This should checkpoint ready for rerunning
+    This currently nacks, but maybe should checkpoint ready for rerunning
     """
     header = {
         "message-id": mock.sentinel,
@@ -397,4 +398,5 @@ def test_ispyb_service_failed_lookup(
     # Check that the correct messages were sent - this checkpoints but does not send
     mock_rw.set_default_channel.assert_not_called()
     mock_rw.send.assert_not_called()
-    mock_rw.checkpoint.assert_called_with(ispyb_test_message, delay=20)
+    mock_rw.checkpoint.assert_not_called()
+    mock_rw.transport.nack.assert_called()

--- a/tests/util/test_ispyb_commands.py
+++ b/tests/util/test_ispyb_commands.py
@@ -7,7 +7,7 @@ from cryoemservices.util import ispyb_commands
 
 
 @mock.patch("cryoemservices.util.ispyb_commands.models")
-def test_insert_movie_notime(mock_models):
+def test_insert_movie_id_notime(mock_models):
     def mock_movie_parameters(p):
         movie_params = {
             "dcid": 101,
@@ -29,6 +29,7 @@ def test_insert_movie_notime(mock_models):
         foilHoleId=2,
         movieNumber=1,
         movieFullPath="/path/to/movie",
+        createdTimeStamp=None,
     )
 
     mock_session.add.assert_called()
@@ -36,7 +37,7 @@ def test_insert_movie_notime(mock_models):
 
 
 @mock.patch("cryoemservices.util.ispyb_commands.models")
-def test_insert_movie_timestamp(mock_models):
+def test_insert_movie_id_timestamp(mock_models):
     def mock_movie_parameters(p):
         movie_params = {
             "dcid": 101,
@@ -59,6 +60,66 @@ def test_insert_movie_timestamp(mock_models):
         movieFullPath="/path/to/movie",
         createdTimeStamp=datetime.fromtimestamp(1).strftime("%Y-%m-%d %H:%M:%S"),
     )
+    mock_session.add.assert_called()
+    mock_session.commit.assert_called()
+
+
+@mock.patch("cryoemservices.util.ispyb_commands.models")
+def test_insert_movie_noid_timestamp(mock_models):
+    def mock_movie_parameters(p):
+        movie_params = {
+            "dcid": 101,
+            "foil_hole_id": "None",
+            "movie_number": 1,
+            "movie_path": "/path/to/movie",
+            "timestamp": 1,
+        }
+        return movie_params[p]
+
+    mock_session = mock.MagicMock()
+
+    return_value = ispyb_commands.insert_movie({}, mock_movie_parameters, mock_session)
+    assert return_value.get("success")
+    assert return_value["return_value"]
+
+    mock_models.Movie.assert_called_with(
+        dataCollectionId=101,
+        foilHoleId=None,
+        movieNumber=1,
+        movieFullPath="/path/to/movie",
+        createdTimeStamp=datetime.fromtimestamp(1).strftime("%Y-%m-%d %H:%M:%S"),
+    )
+
+    mock_session.add.assert_called()
+    mock_session.commit.assert_called()
+
+
+@mock.patch("cryoemservices.util.ispyb_commands.models")
+def test_insert_movie_noid_notime(mock_models):
+    def mock_movie_parameters(p):
+        movie_params = {
+            "dcid": 101,
+            "foil_hole_id": None,
+            "movie_number": 1,
+            "movie_path": "/path/to/movie",
+            "timestamp": None,
+        }
+        return movie_params[p]
+
+    mock_session = mock.MagicMock()
+
+    return_value = ispyb_commands.insert_movie({}, mock_movie_parameters, mock_session)
+    assert return_value.get("success")
+    assert return_value["return_value"]
+
+    mock_models.Movie.assert_called_with(
+        dataCollectionId=101,
+        foilHoleId=None,
+        movieNumber=1,
+        movieFullPath="/path/to/movie",
+        createdTimeStamp=None,
+    )
+
     mock_session.add.assert_called()
     mock_session.commit.assert_called()
 

--- a/tests/util/test_ispyb_commands.py
+++ b/tests/util/test_ispyb_commands.py
@@ -29,7 +29,6 @@ def test_insert_movie_id_notime(mock_models):
         foilHoleId=2,
         movieNumber=1,
         movieFullPath="/path/to/movie",
-        createdTimeStamp=None,
     )
 
     mock_session.add.assert_called()
@@ -117,7 +116,6 @@ def test_insert_movie_noid_notime(mock_models):
         foilHoleId=None,
         movieNumber=1,
         movieFullPath="/path/to/movie",
-        createdTimeStamp=None,
     )
 
     mock_session.add.assert_called()


### PR DESCRIPTION
Addresses a few issues that have cropped up:
- Messages should be nacked if they timeout, rather than checkpointing. In future we may want to re-introduce some checkpointing
- Foil hole ID cannot be string "None"
- Particle pick count should be 0 rather than NULL
- Dollar lookup keys can be present in nested calls. The solution for this is to check these in the nested stages and retrieve them from the parameters function if needed. This isn't a nice method, but it works for now.