### PR TITLE
Add an option to override the default queue used by the services

### DIFF
--- a/src/cryoemservices/cli/start_service.py
+++ b/src/cryoemservices/cli/start_service.py
@@ -36,6 +36,12 @@ def run():
         default="default",
         help="Optional slurm cluster name, matching a key present in the config file",
     )
+    parser.add_argument(
+        "--queue",
+        required=False,
+        default="",
+        help="Optional override for the default queue used by the service",
+    )
     args = parser.parse_args()
 
     service_config = config_from_file(args.config_file)
@@ -64,7 +70,11 @@ def run():
         "transport": transport_factory,
         "transport_command_channel": "command",
         "verbose_service": True,
-        "environment": {"config": args.config_file, "slurm_cluster": args.slurm},
+        "environment": {
+            "config": args.config_file,
+            "slurm_cluster": args.slurm,
+            "queue": args.queue,
+        },
     }
 
     # Create and start workflows Frontend object

--- a/src/cryoemservices/services/bfactor_setup.py
+++ b/src/cryoemservices/services/bfactor_setup.py
@@ -45,7 +45,7 @@ class BFactor(CommonService):
         self.log.info("BFactor setup service starting")
         workflows.recipe.wrap_subscribe(
             self._transport,
-            "bfactor",
+            self._environment["queue"] or "bfactor",
             self.bfactor_setup,
             acknowledgement=True,
             log_extender=self.extend_log,

--- a/src/cryoemservices/services/cluster_submission.py
+++ b/src/cryoemservices/services/cluster_submission.py
@@ -145,7 +145,7 @@ class ClusterSubmission(CommonService):
         self.log.info(f"Supported schedulers: {', '.join(self.schedulers.keys())}")
         workflows.recipe.wrap_subscribe(
             self._transport,
-            "cluster.submission",
+            self._environment["queue"] or "cluster.submission",
             self.run_submit_job,
             acknowledgement=True,
             log_extender=self.extend_log,

--- a/src/cryoemservices/services/cryolo.py
+++ b/src/cryoemservices/services/cryolo.py
@@ -82,7 +82,7 @@ class CrYOLO(CommonService):
         self.log.info("crYOLO service starting")
         workflows.recipe.wrap_subscribe(
             self._transport,
-            "cryolo",
+            self._environment["queue"] or "cryolo",
             self.cryolo,
             acknowledgement=True,
             log_extender=self.extend_log,

--- a/src/cryoemservices/services/ctffind.py
+++ b/src/cryoemservices/services/ctffind.py
@@ -82,7 +82,7 @@ class CTFFind(CommonService):
         self.log.info("CTFFind service starting")
         workflows.recipe.wrap_subscribe(
             self._transport,
-            "ctffind",
+            self._environment["queue"] or "ctffind",
             self.ctf_find,
             acknowledgement=True,
             log_extender=self.extend_log,

--- a/src/cryoemservices/services/denoise.py
+++ b/src/cryoemservices/services/denoise.py
@@ -83,7 +83,7 @@ class Denoise(CommonService):
         self.log.info("Denoise service starting")
         workflows.recipe.wrap_subscribe(
             self._transport,
-            "denoise",
+            self._environment["queue"] or "denoise",
             self.denoise,
             acknowledgement=True,
             log_extender=self.extend_log,

--- a/src/cryoemservices/services/extract.py
+++ b/src/cryoemservices/services/extract.py
@@ -60,7 +60,7 @@ class Extract(CommonService):
         self.log.info("Extract service starting")
         workflows.recipe.wrap_subscribe(
             self._transport,
-            "extract",
+            self._environment["queue"] or "extract",
             self.extract,
             acknowledgement=True,
             log_extender=self.extend_log,

--- a/src/cryoemservices/services/extract_class.py
+++ b/src/cryoemservices/services/extract_class.py
@@ -53,7 +53,7 @@ class ExtractClass(CommonService):
         self.log.info("Class extraction service starting")
         workflows.recipe.wrap_subscribe(
             self._transport,
-            "extract_class",
+            self._environment["queue"] or "extract_class",
             self.extract_class,
             acknowledgement=True,
             log_extender=self.extend_log,

--- a/src/cryoemservices/services/icebreaker.py
+++ b/src/cryoemservices/services/icebreaker.py
@@ -51,7 +51,7 @@ class IceBreaker(CommonService):
         self.log.info("IceBreaker service starting")
         workflows.recipe.wrap_subscribe(
             self._transport,
-            "icebreaker",
+            self._environment["queue"] or "icebreaker",
             self.icebreaker,
             acknowledgement=True,
             log_extender=self.extend_log,

--- a/src/cryoemservices/services/images.py
+++ b/src/cryoemservices/services/images.py
@@ -48,7 +48,7 @@ class Images(CommonService):
         )
         workflows.recipe.wrap_subscribe(
             self._transport,
-            "images",
+            self._environment["queue"] or "images",
             self.image_call,
             acknowledgement=True,
             log_extender=self.extend_log,

--- a/src/cryoemservices/services/ispyb_connector.py
+++ b/src/cryoemservices/services/ispyb_connector.py
@@ -38,7 +38,7 @@ class EMISPyB(CommonService):
         self.log.info("ISPyB service ready")
         workflows.recipe.wrap_subscribe(
             self._transport,
-            "ispyb_connector",
+            self._environment["queue"] or "ispyb_connector",
             self.insert_into_ispyb,
             acknowledgement=True,
             log_extender=self.extend_log,

--- a/src/cryoemservices/services/membrain_seg.py
+++ b/src/cryoemservices/services/membrain_seg.py
@@ -46,7 +46,7 @@ class MembrainSeg(CommonService):
         self.log.info("membrain-seg service starting")
         workflows.recipe.wrap_subscribe(
             self._transport,
-            "segmentation",
+            self._environment["queue"] or "segmentation",
             self.membrain_seg,
             acknowledgement=True,
             log_extender=self.extend_log,

--- a/src/cryoemservices/services/motioncorr.py
+++ b/src/cryoemservices/services/motioncorr.py
@@ -100,7 +100,7 @@ class MotionCorr(CommonService):
         self.log.info("Motion correction service starting")
         workflows.recipe.wrap_subscribe(
             self._transport,
-            "motioncorr",
+            self._environment["queue"] or "motioncorr",
             self.motion_correction,
             acknowledgement=True,
             log_extender=self.extend_log,

--- a/src/cryoemservices/services/node_creator.py
+++ b/src/cryoemservices/services/node_creator.py
@@ -235,14 +235,12 @@ class NodeCreator(CommonService):
 
     def initializing(self):
         """Subscribe to a queue. Received messages must be acknowledged."""
-        try:
-            queue_name = os.environ["NODE_CREATOR_QUEUE"]
-        except KeyError:
-            queue_name = "node_creator"
-        self.log.info(f"Relion node creator service starting for queue {queue_name}")
+        self.log.info(
+            f"Relion node creator service starting for queue {self._environment['queue']}"
+        )
         workflows.recipe.wrap_subscribe(
             self._transport,
-            queue_name,
+            self._environment["queue"] or "node_creator",
             self.node_creator,
             acknowledgement=True,
             log_extender=self.extend_log,

--- a/src/cryoemservices/services/postprocess.py
+++ b/src/cryoemservices/services/postprocess.py
@@ -59,7 +59,7 @@ class PostProcess(CommonService):
         self.log.info("Postprocessing service starting")
         workflows.recipe.wrap_subscribe(
             self._transport,
-            "postprocess",
+            self._environment["queue"] or "postprocess",
             self.postprocess,
             acknowledgement=True,
             log_extender=self.extend_log,

--- a/src/cryoemservices/services/process_recipe.py
+++ b/src/cryoemservices/services/process_recipe.py
@@ -66,7 +66,7 @@ class ProcessRecipe(CommonService):
 
         workflows.recipe.wrap_subscribe(
             self._transport,
-            "processing_recipe",
+            self._environment["queue"] or "processing_recipe",
             self.process,
             acknowledgement=True,
             log_extender=self.extend_log,

--- a/src/cryoemservices/services/select_classes.py
+++ b/src/cryoemservices/services/select_classes.py
@@ -69,7 +69,7 @@ class SelectClasses(CommonService):
         self.log.info("Select classes service starting")
         workflows.recipe.wrap_subscribe(
             self._transport,
-            "select_classes",
+            self._environment["queue"] or "select_classes",
             self.select_classes,
             acknowledgement=True,
             log_extender=self.extend_log,

--- a/src/cryoemservices/services/select_particles.py
+++ b/src/cryoemservices/services/select_particles.py
@@ -40,7 +40,7 @@ class SelectParticles(CommonService):
         self.log.info("Select particles service starting")
         workflows.recipe.wrap_subscribe(
             self._transport,
-            "select_particles",
+            self._environment["queue"] or "select_particles",
             self.select_particles,
             acknowledgement=True,
             log_extender=self.extend_log,

--- a/src/cryoemservices/services/tomo_align.py
+++ b/src/cryoemservices/services/tomo_align.py
@@ -120,7 +120,7 @@ class TomoAlign(CommonService):
         self.log.info("TomoAlign service starting")
         workflows.recipe.wrap_subscribe(
             self._transport,
-            "tomo_align",
+            self._environment["queue"] or "tomo_align",
             self.tomo_align,
             acknowledgement=True,
             log_extender=self.extend_log,


### PR DESCRIPTION
This is needed to run the same service from multiple queues:

- Currently we have several node creator queues
- Desirable to run separate CPU and GPU versions of cryolo