### PR TITLE
Add a GPU version of cryolo for tomography processing

### DIFF
--- a/Helm/Chart.yaml
+++ b/Helm/Chart.yaml
@@ -6,6 +6,7 @@ dependencies:
   - name: bfactor_setup
   - name: cluster_submission
   - name: cryolo
+  - name: cryolo_gpu
   - name: ctffind
   - name: denoise
   - name: denoise_slurm

--- a/Helm/charts/cryolo_gpu/Chart.yaml
+++ b/Helm/charts/cryolo_gpu/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: cryolo_gpu
+description: A Helm chart for CrYOLO service running on a GPU
+version: 1.0.1

--- a/Helm/charts/cryolo_gpu/templates/deployment.yaml
+++ b/Helm/charts/cryolo_gpu/templates/deployment.yaml
@@ -1,0 +1,98 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cryolo-gpu
+  namespace: {{ .Values.global.namespace }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: cryolo-gpu
+  template:
+    metadata:
+      labels:
+        app: cryolo-gpu
+    spec:
+      securityContext:
+        runAsUser: {{ .Values.global.runAsUser }}
+        runAsGroup: {{ .Values.global.runAsGroup }}
+      containers:
+      - name: cryolo-gpu-runner
+        image: {{ .Values.image }}
+        imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: {{ .Values.cpuRequest }}
+            nvidia.com/gpu: "1"
+          limits:
+            cpu: {{ .Values.cpuLimit }}
+            memory: {{ .Values.memoryLimit }}
+            nvidia.com/gpu: "1"
+        command: ["/bin/sh"]
+        args:
+          - -c
+          - >-
+              {{ .Values.command }}
+        volumeMounts:
+        - name: config-file
+          mountPath: /cryoemservices/config
+        - name: secrets
+          mountPath: /cryoemservices/secrets
+{{- if .Values.global.extraGlobalVolumeMounts }}
+{{ toYaml .Values.global.extraGlobalVolumeMounts | indent 8 }}
+{{ end }}
+{{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 8 }}
+{{ end }}
+      volumes:
+      - name: config-file
+        configMap:
+          name: {{ .Values.global.configMap }}
+      - name: secrets
+        projected:
+          defaultMode: 0444
+          sources:
+          - secret:
+              name: {{ .Values.global.rmqSecretName }}
+{{- if .Values.global.extraGlobalVolumes }}
+{{ toYaml .Values.global.extraGlobalVolumes | indent 6 }}
+{{ end }}
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
+{{ end }}
+      tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
+      - effect: NoSchedule
+        key: nodetype
+        operator: Equal
+        value: gpu
+{{- if .Values.global.tolerations }}
+{{ toYaml .Values.global.tolerations | indent 6 }}
+{{ end }}
+{{- if .Values.global.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.global.nodeSelector | indent 8 }}
+{{ end }}
+
+{{- if .Values.scaleOnQueueLength }}
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: cryolo-gpu
+  namespace: {{ .Values.global.namespace }}
+spec:
+  scaleTargetRef:
+    name: cryolo-gpu
+  triggers:
+    - type: rabbitmq
+      metadata:
+        host: {{ .Values.global.rmqHost }}
+        queueName: cryolo_gpu
+        mode: QueueLength
+        value: "{{ .Values.queueLengthTrigger }}"
+  minReplicaCount: {{ .Values.minReplicaCount }}
+  maxReplicaCount: {{ .Values.maxReplicaCount }}
+{{ end }}

--- a/Helm/values.yaml
+++ b/Helm/values.yaml
@@ -52,6 +52,15 @@ cryolo:
   minReplicaCount: 0
   maxReplicaCount: 4
 
+cryolo_gpu:
+  replicas: 1
+  image: gcr.io/image/path
+  command: cryoemservices.service -s CrYOLO -c /cryoemservices/config/cryoemservices_config.yaml --queue cryolo_gpu
+  cpuRequest: "1"
+  cpuLimit: "1"
+  memoryLimit: 6Gi
+  scaleOnQueueLength: false
+
 ctffind:
   replicas: 1
   image: gcr.io/image/path

--- a/recipes/em-tomo-align.json
+++ b/recipes/em-tomo-align.json
@@ -95,7 +95,7 @@
       "movie": 6,
       "node_creator": 11
     },
-    "queue": "cryolo",
+    "queue": "cryolo_gpu",
     "service": "CrYOLO"
   },
   "10": {

--- a/src/cryoemservices/services/cryolo.py
+++ b/src/cryoemservices/services/cryolo.py
@@ -177,6 +177,8 @@ class CrYOLO(CommonService):
                         str(cryolo_params.tomo_tracing_missing_frames),
                         "-tmin",
                         str(cryolo_params.tomo_tracing_min_frames),
+                        "--gpus",
+                        "0",
                     ]
                 )
             )

--- a/tests/services/test_bfactor_setup.py
+++ b/tests/services/test_bfactor_setup.py
@@ -55,7 +55,7 @@ def test_bfactor_service(offline_transport, tmp_path):
     output_relion_options["batch_size"] = 10000
 
     # Set up the mock service and call it
-    service = bfactor_setup.BFactor()
+    service = bfactor_setup.BFactor(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
     service.bfactor_setup(None, header=header, message=bfactor_test_message)

--- a/tests/services/test_cluster_submission.py
+++ b/tests/services/test_cluster_submission.py
@@ -84,7 +84,11 @@ def test_cluster_submission_recipeless(
 
     # Set up the mock service
     service = cluster_submission.ClusterSubmission(
-        environment={"config": f"{tmp_path}/config.yaml", "slurm_cluster": "default"}
+        environment={
+            "config": f"{tmp_path}/config.yaml",
+            "slurm_cluster": "default",
+            "queue": "",
+        }
     )
     service.transport = offline_transport
     service.start()
@@ -167,7 +171,11 @@ def test_cluster_submission_recipefile(
 
     # Set up the mock service
     service = cluster_submission.ClusterSubmission(
-        environment={"config": f"{tmp_path}/config.yaml", "slurm_cluster": "default"}
+        environment={
+            "config": f"{tmp_path}/config.yaml",
+            "slurm_cluster": "default",
+            "queue": "",
+        }
     )
     service.transport = offline_transport
     service.start()
@@ -225,7 +233,11 @@ def test_cluster_submission_recipeenvironment(
 
     # Set up the mock service
     service = cluster_submission.ClusterSubmission(
-        environment={"config": f"{tmp_path}/config.yaml", "slurm_cluster": "default"}
+        environment={
+            "config": f"{tmp_path}/config.yaml",
+            "slurm_cluster": "default",
+            "queue": "",
+        }
     )
     service.transport = offline_transport
     service.start()
@@ -287,7 +299,11 @@ def test_cluster_submission_recipewrapper(
 
     # Set up the mock service
     service = cluster_submission.ClusterSubmission(
-        environment={"config": f"{tmp_path}/config.yaml", "slurm_cluster": "default"}
+        environment={
+            "config": f"{tmp_path}/config.yaml",
+            "slurm_cluster": "default",
+            "queue": "",
+        }
     )
     service.transport = offline_transport
     service.start()
@@ -355,7 +371,11 @@ def test_cluster_submission_extra_cluster(
 
     # Set up the mock service
     service = cluster_submission.ClusterSubmission(
-        environment={"config": f"{tmp_path}/config.yaml", "slurm_cluster": "extra"}
+        environment={
+            "config": f"{tmp_path}/config.yaml",
+            "slurm_cluster": "extra",
+            "queue": "",
+        }
     )
     service.transport = offline_transport
     service.start()

--- a/tests/services/test_cryolo_service.py
+++ b/tests/services/test_cryolo_service.py
@@ -77,7 +77,7 @@ def test_cryolo_service_spa(mock_subprocess, offline_transport, tmp_path):
         )
 
     # Set up the mock service and send the message to it
-    service = cryolo.CrYOLO()
+    service = cryolo.CrYOLO(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
     service.cryolo(None, header=header, message=cryolo_test_message)
@@ -227,7 +227,7 @@ def test_cryolo_service_tomography(mock_subprocess, offline_transport, tmp_path)
     )
 
     # Set up the mock service and send the message to it
-    service = cryolo.CrYOLO()
+    service = cryolo.CrYOLO(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
     service.cryolo(None, header=header, message=cryolo_test_message)
@@ -247,6 +247,8 @@ def test_cryolo_service_tomography(mock_subprocess, offline_transport, tmp_path)
             "0",
             "-tmin",
             "5",
+            "--gpus",
+            "0",
             "-i",
             "MotionCorr/job002/sample.mrc",
             "--weights",
@@ -316,7 +318,8 @@ def test_cryolo_service_tomography(mock_subprocess, offline_transport, tmp_path)
             "relion_options": output_relion_options,
             "command": (
                 f"cryolo_predict.py --conf {tmp_path}/AutoPick/job007/cryolo_config.json "
-                f"-o {tmp_path}/AutoPick/job007 --tomogram -tsr -1 -tmem 0 -tmin 5 "
+                f"-o {tmp_path}/AutoPick/job007 "
+                f"--tomogram -tsr -1 -tmem 0 -tmin 5 --gpus 0 "
                 "-i MotionCorr/job002/sample.mrc "
                 "--weights sample_weights --threshold 0.15 "
                 "--distance 0 --norm_margin 0"
@@ -358,7 +361,7 @@ def test_cryolo_spa_needs_uuids_and_pixel_size(
     }
 
     # Set up the mock service
-    service = cryolo.CrYOLO()
+    service = cryolo.CrYOLO(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
 
@@ -386,7 +389,7 @@ def test_parse_cryolo_output(offline_transport):
     Send test lines to the output parser
     to check the number of particles is being read in
     """
-    service = cryolo.CrYOLO()
+    service = cryolo.CrYOLO(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
 

--- a/tests/services/test_ctffind_service.py
+++ b/tests/services/test_ctffind_service.py
@@ -60,7 +60,7 @@ def test_ctffind4_service_spa(mock_subprocess, offline_transport, tmp_path):
     output_relion_options.update(ctffind_test_message["relion_options"])
 
     # Set up the mock service
-    service = ctffind.CTFFind()
+    service = ctffind.CTFFind(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
 
@@ -203,7 +203,7 @@ def test_ctffind5_service_tomo(mock_subprocess, offline_transport, tmp_path):
     output_relion_options.update(ctffind_test_message["relion_options"])
 
     # Set up the mock service
-    service = ctffind.CTFFind()
+    service = ctffind.CTFFind(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
 
@@ -298,7 +298,7 @@ def test_ctffind5_service_nothickness(mock_subprocess, offline_transport, tmp_pa
     output_relion_options.update(ctffind_test_message["relion_options"])
 
     # Set up the mock service
-    service = ctffind.CTFFind()
+    service = ctffind.CTFFind(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
 
@@ -349,7 +349,7 @@ def test_parse_ctffind_output(offline_transport):
     Send test lines to the output parser
     to check the ctf values are being read in
     """
-    service = ctffind.CTFFind()
+    service = ctffind.CTFFind(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
 

--- a/tests/services/test_denoise.py
+++ b/tests/services/test_denoise.py
@@ -97,7 +97,7 @@ def test_denoise_local_service(
     output_relion_options = dict(RelionServiceOptions())
 
     # Set up the mock service
-    service = denoise.Denoise()
+    service = denoise.Denoise(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
 
@@ -255,7 +255,11 @@ def test_denoise_slurm_service(
 
     # Set up the mock service
     service = denoise_slurm.DenoiseSlurm(
-        environment={"config": f"{tmp_path}/config.yaml", "slurm_cluster": "default"}
+        environment={
+            "config": f"{tmp_path}/config.yaml",
+            "slurm_cluster": "default",
+            "queue": "",
+        }
     )
     service.transport = offline_transport
     service.start()

--- a/tests/services/test_extract_class.py
+++ b/tests/services/test_extract_class.py
@@ -112,7 +112,11 @@ def test_extract_class_service(mock_subprocess, offline_transport, tmp_path):
 
     # Set up the mock service and call it
     service = extract_class.ExtractClass(
-        environment={"config": f"{tmp_path}/config.yaml", "slurm_cluster": "default"}
+        environment={
+            "config": f"{tmp_path}/config.yaml",
+            "slurm_cluster": "default",
+            "queue": "",
+        }
     )
     service.transport = offline_transport
     service.start()

--- a/tests/services/test_extract_service.py
+++ b/tests/services/test_extract_service.py
@@ -77,7 +77,7 @@ def test_extract_service(mock_mrcfile, offline_transport, tmp_path):
     output_relion_options.update(extract_test_message["relion_options"])
 
     # Set up the mock service and send the message to it
-    service = extract.Extract()
+    service = extract.Extract(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
     service.extract(None, header=header, message=extract_test_message)

--- a/tests/services/test_icebreaker_service.py
+++ b/tests/services/test_icebreaker_service.py
@@ -88,7 +88,7 @@ def test_icebreaker_micrographs_service(mock_icebreaker, offline_transport, tmp_
     }
 
     # Set up the mock service and send a message to the service
-    service = icebreaker.IceBreaker()
+    service = icebreaker.IceBreaker(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
     service.icebreaker(None, header=header, message=icebreaker_test_message)
@@ -163,7 +163,7 @@ def test_icebreaker_enhancecontrast_service(
     }
 
     # Set up the mock service and send a message to the service
-    service = icebreaker.IceBreaker()
+    service = icebreaker.IceBreaker(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
     service.icebreaker(None, header=header, message=icebreaker_test_message)
@@ -225,7 +225,7 @@ def test_icebreaker_summary_service(mock_icebreaker, offline_transport, tmp_path
     }
 
     # Set up the mock service and send a message to the service
-    service = icebreaker.IceBreaker()
+    service = icebreaker.IceBreaker(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
     service.icebreaker(None, header=header, message=icebreaker_test_message)
@@ -303,7 +303,7 @@ def test_icebreaker_particles_service(mock_icebreaker, offline_transport, tmp_pa
     }
 
     # Set up the mock service and send a message to the service
-    service = icebreaker.IceBreaker()
+    service = icebreaker.IceBreaker(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
     service.icebreaker(None, header=header, message=icebreaker_test_message)
@@ -383,7 +383,11 @@ def test_icebreaker_particles_service_slurm(
 
     # Set up the mock service and send a message to the service
     service = icebreaker.IceBreaker(
-        environment={"config": f"{tmp_path}/config.yaml", "slurm_cluster": "default"}
+        environment={
+            "config": f"{tmp_path}/config.yaml",
+            "slurm_cluster": "default",
+            "queue": "",
+        }
     )
     service.transport = offline_transport
     service.start()

--- a/tests/services/test_ispyb_service.py
+++ b/tests/services/test_ispyb_service.py
@@ -50,7 +50,9 @@ def test_ispyb_service_run(
     write_config_file(tmp_path)
 
     # Set up the mock service and call it
-    service = ispyb_connector.EMISPyB(environment={"config": f"{tmp_path}/config.yaml"})
+    service = ispyb_connector.EMISPyB(
+        environment={"config": f"{tmp_path}/config.yaml", "queue": ""}
+    )
     service.transport = offline_transport
     service.start()
     service.insert_into_ispyb(None, header=header, message=ispyb_test_message)
@@ -106,7 +108,9 @@ def test_ispyb_service_store_result(
     write_config_file(tmp_path)
 
     # Set up the mock service and call it
-    service = ispyb_connector.EMISPyB(environment={"config": f"{tmp_path}/config.yaml"})
+    service = ispyb_connector.EMISPyB(
+        environment={"config": f"{tmp_path}/config.yaml", "queue": ""}
+    )
     service.transport = offline_transport
     service.start()
     service.insert_into_ispyb(rw=mock_rw, header=header, message=ispyb_test_message)
@@ -153,7 +157,9 @@ def test_ispyb_service_env_keys(
     write_config_file(tmp_path)
 
     # Set up the mock service and call it
-    service = ispyb_connector.EMISPyB(environment={"config": f"{tmp_path}/config.yaml"})
+    service = ispyb_connector.EMISPyB(
+        environment={"config": f"{tmp_path}/config.yaml", "queue": ""}
+    )
     service.transport = offline_transport
     service.start()
     service.insert_into_ispyb(rw=mock_rw, header=header, message=ispyb_test_message)
@@ -203,7 +209,9 @@ def test_ispyb_service_multipart_env_keys(
     write_config_file(tmp_path)
 
     # Set up the mock service and call it
-    service = ispyb_connector.EMISPyB(environment={"config": f"{tmp_path}/config.yaml"})
+    service = ispyb_connector.EMISPyB(
+        environment={"config": f"{tmp_path}/config.yaml", "queue": ""}
+    )
     service.transport = offline_transport
     service.start()
     service.insert_into_ispyb(rw=mock_rw, header=header, message=ispyb_test_message)
@@ -249,7 +257,9 @@ def test_ispyb_service_checkpoint(
     write_config_file(tmp_path)
 
     # Set up the mock service and call it
-    service = ispyb_connector.EMISPyB(environment={"config": f"{tmp_path}/config.yaml"})
+    service = ispyb_connector.EMISPyB(
+        environment={"config": f"{tmp_path}/config.yaml", "queue": ""}
+    )
     service.transport = offline_transport
     service.start()
     service.insert_into_ispyb(rw=mock_rw, header=header, message=ispyb_test_message)
@@ -352,7 +362,9 @@ def test_ispyb_multipart_message(
     write_config_file(tmp_path)
 
     # Set up the mock service and call it
-    service = ispyb_connector.EMISPyB(environment={"config": f"{tmp_path}/config.yaml"})
+    service = ispyb_connector.EMISPyB(
+        environment={"config": f"{tmp_path}/config.yaml", "queue": ""}
+    )
     service.transport = offline_transport
     service.start()
     service.insert_into_ispyb(rw=mock_rw, header=header, message=ispyb_test_message)
@@ -442,7 +454,9 @@ def test_ispyb_service_failed_lookup(
     write_config_file(tmp_path)
 
     # Set up the mock service and call it
-    service = ispyb_connector.EMISPyB(environment={"config": f"{tmp_path}/config.yaml"})
+    service = ispyb_connector.EMISPyB(
+        environment={"config": f"{tmp_path}/config.yaml", "queue": ""}
+    )
     service.transport = offline_transport
     service.start()
     service.insert_into_ispyb(rw=mock_rw, header=header, message=ispyb_test_message)

--- a/tests/services/test_membrain_seg.py
+++ b/tests/services/test_membrain_seg.py
@@ -77,7 +77,7 @@ def test_membrain_seg_service_local(
     }
 
     # Set up the mock service
-    service = membrain_seg.MembrainSeg()
+    service = membrain_seg.MembrainSeg(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
 
@@ -180,7 +180,11 @@ def test_membrain_seg_service_slurm(
 
     # Set up the mock service
     service = membrain_seg.MembrainSeg(
-        environment={"config": f"{tmp_path}/config.yaml", "slurm_cluster": "default"}
+        environment={
+            "config": f"{tmp_path}/config.yaml",
+            "slurm_cluster": "default",
+            "queue": "",
+        }
     )
     service.transport = offline_transport
     service.start()

--- a/tests/services/test_motioncorr_service.py
+++ b/tests/services/test_motioncorr_service.py
@@ -130,7 +130,7 @@ def test_motioncor2_service_spa(mock_subprocess, offline_transport, tmp_path):
     output_relion_options["eer_grouping"] = 0
 
     # Set up the mock service
-    service = motioncorr.MotionCorr()
+    service = motioncorr.MotionCorr(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
 
@@ -409,7 +409,7 @@ def test_motioncor_relion_service_spa(mock_subprocess, offline_transport, tmp_pa
         )
 
     # Set up the mock service
-    service = motioncorr.MotionCorr()
+    service = motioncorr.MotionCorr(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
 
@@ -647,7 +647,7 @@ def test_motioncor2_service_tomo(mock_subprocess, offline_transport, tmp_path):
     output_relion_options["eer_grouping"] = 0
 
     # Set up the mock service
-    service = motioncorr.MotionCorr()
+    service = motioncorr.MotionCorr(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
 
@@ -848,7 +848,7 @@ def test_motioncor_relion_service_tomo(mock_subprocess, offline_transport, tmp_p
     output_relion_options["eer_grouping"] = 0
 
     # Set up the mock service
-    service = motioncorr.MotionCorr()
+    service = motioncorr.MotionCorr(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
 
@@ -1028,7 +1028,11 @@ def test_motioncor2_slurm_service_spa(mock_subprocess, offline_transport, tmp_pa
 
     # Set up the mock service
     service = motioncorr.MotionCorr(
-        environment={"config": f"{tmp_path}/config.yaml", "slurm_cluster": "default"}
+        environment={
+            "config": f"{tmp_path}/config.yaml",
+            "slurm_cluster": "default",
+            "queue": "",
+        }
     )
     service.transport = offline_transport
     service.start()
@@ -1153,7 +1157,11 @@ def test_motioncor_superres_does_slurm(mock_subprocess, offline_transport, tmp_p
 
     # Set up the mock service
     service = motioncorr.MotionCorr(
-        environment={"config": f"{tmp_path}/config.yaml", "slurm_cluster": "default"}
+        environment={
+            "config": f"{tmp_path}/config.yaml",
+            "slurm_cluster": "default",
+            "queue": "",
+        }
     )
     service.transport = offline_transport
     service.start()
@@ -1251,7 +1259,11 @@ def test_motioncor2_slurm_parameters(mock_slurm, offline_transport, tmp_path):
 
     # Set up the mock service
     service = motioncorr.MotionCorr(
-        environment={"config": f"{tmp_path}/config.yaml", "slurm_cluster": "default"}
+        environment={
+            "config": f"{tmp_path}/config.yaml",
+            "slurm_cluster": "default",
+            "queue": "",
+        }
     )
     service.transport = offline_transport
     service.start()
@@ -1346,7 +1358,11 @@ def test_motioncor_relion_slurm_parameters(mock_slurm, offline_transport, tmp_pa
 
     # Set up the mock service
     service = motioncorr.MotionCorr(
-        environment={"config": f"{tmp_path}/config.yaml", "slurm_cluster": "default"}
+        environment={
+            "config": f"{tmp_path}/config.yaml",
+            "slurm_cluster": "default",
+            "queue": "",
+        }
     )
     service.transport = offline_transport
     service.start()
@@ -1413,7 +1429,7 @@ def test_parse_motioncor2_output(offline_transport):
     Send test lines to the output parser for MotionCor2
     to check the shift values are being read in
     """
-    service = motioncorr.MotionCorr()
+    service = motioncorr.MotionCorr(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
 
@@ -1442,7 +1458,7 @@ def test_parse_motioncor2_slurm_output(offline_transport, tmp_path):
     Send test lines to the output parser
     to check the shift values are being read in
     """
-    service = motioncorr.MotionCorr()
+    service = motioncorr.MotionCorr(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
 
@@ -1462,7 +1478,7 @@ def test_parse_relion_output(offline_transport, tmp_path):
     Send a test file to the output parser for Relion's motion correction
     to check the shift values are being read in
     """
-    service = motioncorr.MotionCorr()
+    service = motioncorr.MotionCorr(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
 

--- a/tests/services/test_node_creator.py
+++ b/tests/services/test_node_creator.py
@@ -62,7 +62,7 @@ def setup_and_run_node_creation(
     }
 
     # set up the mock service and send the message to it
-    service = node_creator.NodeCreator()
+    service = node_creator.NodeCreator(environment={"queue": ""})
     service.transport = transport
     service.start()
     service.node_creator(None, header=header, message=test_message)
@@ -116,7 +116,7 @@ def test_node_creator_failed_job(offline_transport, tmp_path):
     }
 
     # set up the mock service and send the message to it
-    service = node_creator.NodeCreator()
+    service = node_creator.NodeCreator(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
     service.node_creator(None, header=header, message=test_message)
@@ -166,7 +166,7 @@ def test_node_creator_rerun_job(offline_transport, tmp_path):
     }
 
     # set up the mock service and send the message to it
-    service = node_creator.NodeCreator()
+    service = node_creator.NodeCreator(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
     service.node_creator(None, header=header, message=test_message)

--- a/tests/services/test_postprocess.py
+++ b/tests/services/test_postprocess.py
@@ -74,7 +74,7 @@ def test_postprocess_first_refine_has_symmetry(
     output_relion_options.update(postprocess_test_message["relion_options"])
 
     # Set up the mock service and call it
-    service = postprocess.PostProcess()
+    service = postprocess.PostProcess(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
     service.postprocess(None, header=header, message=postprocess_test_message)
@@ -245,7 +245,7 @@ def test_postprocess_first_refine_without_symmetry(
     output_relion_options.update(postprocess_test_message["relion_options"])
 
     # Set up the mock service and call it
-    service = postprocess.PostProcess()
+    service = postprocess.PostProcess(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
     service.postprocess(None, header=header, message=postprocess_test_message)
@@ -349,7 +349,7 @@ def test_postprocess_bfactor(mock_subprocess, offline_transport, tmp_path):
     output_relion_options.update(postprocess_test_message["relion_options"])
 
     # Set up the mock service and call it
-    service = postprocess.PostProcess()
+    service = postprocess.PostProcess(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
     service.postprocess(None, header=header, message=postprocess_test_message)

--- a/tests/services/test_process_recipe.py
+++ b/tests/services/test_process_recipe.py
@@ -48,7 +48,9 @@ def test_process_recipe_service(mock_recipe, mock_rw, offline_transport, tmp_pat
     }
 
     # Set up the mock service
-    service = process_recipe.ProcessRecipe(environment={"config": config_file})
+    service = process_recipe.ProcessRecipe(
+        environment={"config": config_file, "queue": ""}
+    )
     service.transport = offline_transport
     service.start()
     service.process(None, header=header, message=recipe_test_message)

--- a/tests/services/test_select_classes_service.py
+++ b/tests/services/test_select_classes_service.py
@@ -134,7 +134,7 @@ def test_select_classes_service_first_batch(
     )
 
     # Set up the mock service and send the message to it
-    service = select_classes.SelectClasses()
+    service = select_classes.SelectClasses(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
     service.select_classes(None, header=header, message=select_test_message)
@@ -321,7 +321,7 @@ def test_select_classes_service_batch_threshold(
     )
 
     # Set up the mock service and send the message to it
-    service = select_classes.SelectClasses()
+    service = select_classes.SelectClasses(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
     service.select_classes(None, header=header, message=select_test_message)
@@ -373,7 +373,7 @@ def test_select_classes_service_two_thresholds(
     )
 
     # Set up the mock service and send the message to it
-    service = select_classes.SelectClasses()
+    service = select_classes.SelectClasses(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
     service.select_classes(None, header=header, message=select_test_message)
@@ -426,7 +426,7 @@ def test_select_classes_service_last_threshold(
     )
 
     # Set up the mock service and send the message to it
-    service = select_classes.SelectClasses()
+    service = select_classes.SelectClasses(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
     service.select_classes(None, header=header, message=select_test_message)
@@ -476,7 +476,7 @@ def test_select_classes_service_not_threshold(
     )
 
     # Set up the mock service and send the message to it
-    service = select_classes.SelectClasses()
+    service = select_classes.SelectClasses(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
     service.select_classes(None, header=header, message=select_test_message)
@@ -516,7 +516,7 @@ def test_select_classes_service_past_maximum(
     )
 
     # Set up the mock service and send the message to it
-    service = select_classes.SelectClasses()
+    service = select_classes.SelectClasses(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
     service.select_classes(None, header=header, message=select_test_message)
@@ -538,7 +538,7 @@ def test_parse_combiner_output(offline_transport):
     Send test lines to the output parser
     to check the number of particles are being read in
     """
-    service = select_classes.SelectClasses()
+    service = select_classes.SelectClasses(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
 

--- a/tests/services/test_select_particles_service.py
+++ b/tests/services/test_select_particles_service.py
@@ -64,7 +64,7 @@ def test_select_particles_service(offline_transport, tmp_path):
     }
 
     # Set up the mock service and send the message to it
-    service = select_particles.SelectParticles()
+    service = select_particles.SelectParticles(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
     service.select_particles(None, header=header, message=select_test_message)

--- a/tests/services/test_tomo_align.py
+++ b/tests/services/test_tomo_align.py
@@ -84,7 +84,7 @@ def test_tomo_align_service_file_list(
     output_relion_options["tomo_size_y"] = 3000
 
     # Set up the mock service
-    service = tomo_align.TomoAlign()
+    service = tomo_align.TomoAlign(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
 
@@ -321,7 +321,7 @@ def test_tomo_align_service_file_list_repeated_tilt(
     (tmp_path / "MotionCorr/job002/Movies/input_file_3.mrc").touch()
 
     # Set up the mock service
-    service = tomo_align.TomoAlign()
+    service = tomo_align.TomoAlign(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
 
@@ -442,7 +442,7 @@ def test_tomo_align_service_path_pattern(
     output_relion_options["manual_tilt_offset"] = 10.5
 
     # Set up the mock service
-    service = tomo_align.TomoAlign()
+    service = tomo_align.TomoAlign(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
 
@@ -594,7 +594,7 @@ def test_tomo_align_service_dark_images(
     output_relion_options["tomo_size_y"] = 3000
 
     # Set up the mock service
-    service = tomo_align.TomoAlign()
+    service = tomo_align.TomoAlign(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
 
@@ -762,7 +762,7 @@ def test_tomo_align_service_all_dark(
     }
 
     # Set up the mock service
-    service = tomo_align.TomoAlign()
+    service = tomo_align.TomoAlign(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
 
@@ -820,7 +820,7 @@ def test_parse_tomo_align_output(offline_transport):
     Send test lines to the output parser
     to check the rotations and offsets are being read in
     """
-    service = tomo_align.TomoAlign()
+    service = tomo_align.TomoAlign(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
 

--- a/tests/services/test_tomo_align_slurm.py
+++ b/tests/services/test_tomo_align_slurm.py
@@ -117,7 +117,11 @@ def test_tomo_align_slurm_service(
 
     # Set up the mock service
     service = tomo_align_slurm.TomoAlignSlurm(
-        environment={"config": f"{tmp_path}/config.yaml", "slurm_cluster": "default"}
+        environment={
+            "config": f"{tmp_path}/config.yaml",
+            "slurm_cluster": "default",
+            "queue": "",
+        }
     )
     service.transport = offline_transport
     service.start()
@@ -192,7 +196,7 @@ def test_parse_tomo_align_output(offline_transport, tmp_path):
     Send test lines to the output parser
     to check the rotations and offsets are being read in
     """
-    service = tomo_align_slurm.TomoAlignSlurm()
+    service = tomo_align_slurm.TomoAlignSlurm(environment={"queue": ""})
     service.transport = offline_transport
     service.start()
 


### PR DESCRIPTION
Cryolo is too slow on CPU for tomography, so we need to switch to GPU.

This adds the helm chart parts needed to have a separate GPU cryolo service running for tomography.

To allow the service to connect to different queues for SPA and tomography, the service startup command must accept a  queue name to override the default for the service. (see #111)