### PR TITLE
Plot the true particles sizes for tomography

### DIFF
--- a/src/cryoemservices/services/cryolo.py
+++ b/src/cryoemservices/services/cryolo.py
@@ -286,14 +286,12 @@ class CrYOLO(CommonService):
                 "image_command": "picked_particles_3d_apng",
                 "file": cryolo_params.input_path,
                 "coordinates_file": cryolo_params.output_path,
-                "diameter_pixels": cryolo_params.cryolo_box_size,
                 "box_size": cryolo_params.cryolo_box_size,
             }
             central_slice_parameters = {
                 "image_command": "picked_particles_3d_central_slice",
                 "file": cryolo_params.input_path,
                 "coordinates_file": cryolo_params.output_path,
-                "diameter_pixels": cryolo_params.cryolo_box_size,
                 "box_size": cryolo_params.cryolo_box_size,
             }
             rw.send_to("images", movie_parameters)

--- a/src/cryoemservices/services/images.py
+++ b/src/cryoemservices/services/images.py
@@ -1,16 +1,10 @@
 from __future__ import annotations
 
 from importlib.metadata import entry_points
-from typing import Any, Callable, NamedTuple
+from typing import Callable
 
 import workflows.recipe
 from workflows.services.common_service import CommonService
-
-
-class PluginInterface(NamedTuple):
-    rw: workflows.recipe.wrapper.RecipeWrapper
-    parameters: Callable
-    message: dict[str, Any]
 
 
 class Images(CommonService):
@@ -18,10 +12,8 @@ class Images(CommonService):
     A service that generates images and thumbnails.
     Plugin functions can be registered under the entry point
     'cryoemservices.services.images.plugins'. The contract is that a plugin function
-    takes a single argument of type PluginInterface, and returns a truthy value
+    takes a parameters callable, and returns a truthy value
     to acknowledge success, and a falsy value to reject the related message.
-    Functions may choose to return a list of files that were generated, but
-    this is optional at this time.
     """
 
     # Human readable service name
@@ -69,9 +61,7 @@ class Images(CommonService):
             return
 
         try:
-            result = self.image_functions[command](
-                PluginInterface(rw, parameters, message)
-            )
+            result = self.image_functions[command](parameters)
         except (PermissionError, FileNotFoundError) as e:
             self.log.error(f"Command {command!r} raised {e}", exc_info=True)
             rw.transport.nack(header)

--- a/src/cryoemservices/services/images_plugins.py
+++ b/src/cryoemservices/services/images_plugins.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import time
 from pathlib import Path
+from typing import Callable
 
 import mrcfile
 import numpy as np
@@ -15,9 +16,9 @@ logger = logging.getLogger("cryoemservices.services.images_plugins")
 logger.setLevel(logging.INFO)
 
 
-def mrc_to_jpeg(plugin_params):
-    filename = plugin_params.parameters("file")
-    allframes = plugin_params.parameters("all_frames")
+def mrc_to_jpeg(plugin_params: Callable):
+    filename = plugin_params("file")
+    allframes = plugin_params("all_frames")
     if not filename or filename == "None":
         logger.error("Skipping mrc to jpeg conversion: filename not specified")
         return False
@@ -94,20 +95,20 @@ def mrc_to_jpeg(plugin_params):
     return outfile
 
 
-def picked_particles(plugin_params):
-    basefilename = Path(plugin_params.parameters("file"))
+def picked_particles(plugin_params: Callable):
+    basefilename = Path(plugin_params("file"))
     if basefilename.suffix == ".jpeg":
         logger.info(f"Replacing jpeg extension with mrc extension for {basefilename}")
         basefilename = basefilename.with_suffix(".mrc")
-    coords = plugin_params.parameters("coordinates")
-    selected_coords = plugin_params.parameters("selected_coordinates")
-    pixel_size = plugin_params.parameters("pixel_size")
+    coords = plugin_params("coordinates")
+    selected_coords = plugin_params("selected_coordinates")
+    pixel_size = plugin_params("pixel_size")
     if not pixel_size:
         # Legacy case of zocalo-relion
-        pixel_size = plugin_params.parameters("angpix")
-    diam = plugin_params.parameters("diameter")
-    contrast_factor = plugin_params.parameters("contrast_factor") or 6
-    outfile = plugin_params.parameters("outfile")
+        pixel_size = plugin_params("angpix")
+    diam = plugin_params("diameter")
+    contrast_factor = plugin_params("contrast_factor") or 6
+    outfile = plugin_params("outfile")
     if not outfile:
         logger.error(f"Outfile incorrectly specified: {outfile}")
         return False
@@ -181,9 +182,9 @@ def picked_particles(plugin_params):
     return outfile
 
 
-def mrc_central_slice(plugin_params):
-    filename = plugin_params.parameters("file")
-    skip_rescaling = plugin_params.parameters("skip_rescaling")
+def mrc_central_slice(plugin_params: Callable):
+    filename = plugin_params("file")
+    skip_rescaling = plugin_params("skip_rescaling")
 
     if not filename or filename == "None":
         logger.error("Skipping mrc to jpeg conversion: filename not specified")
@@ -241,9 +242,9 @@ def mrc_central_slice(plugin_params):
     return outfile
 
 
-def mrc_to_apng(plugin_params):
-    filename = plugin_params.parameters("file")
-    skip_rescaling = plugin_params.parameters("skip_rescaling")
+def mrc_to_apng(plugin_params: Callable):
+    filename = plugin_params("file")
+    skip_rescaling = plugin_params("skip_rescaling")
 
     if not filename or filename == "None":
         logger.error("Skipping mrc to jpeg conversion: filename not specified")
@@ -371,10 +372,10 @@ def particles_3d_in_frame(
     return colour_im
 
 
-def picked_particles_3d_central_slice(plugin_params):
-    filename = plugin_params.parameters("file")
-    coords_file = plugin_params.parameters("coordinates_file")
-    box_size = plugin_params.parameters("box_size")
+def picked_particles_3d_central_slice(plugin_params: Callable):
+    filename = plugin_params("file")
+    coords_file = plugin_params("coordinates_file")
+    box_size = plugin_params("box_size")
     radius_box = box_size // 2
     if not Path(filename).is_file() or not Path(coords_file).is_file():
         logger.error(f"File {filename} or {coords_file} not found")
@@ -412,10 +413,10 @@ def picked_particles_3d_central_slice(plugin_params):
     return outfile
 
 
-def picked_particles_3d_apng(plugin_params):
-    filename = plugin_params.parameters("file")
-    coords_file = plugin_params.parameters("coordinates_file")
-    box_size = plugin_params.parameters("box_size")
+def picked_particles_3d_apng(plugin_params: Callable):
+    filename = plugin_params("file")
+    coords_file = plugin_params("coordinates_file")
+    box_size = plugin_params("box_size")
     radius_box = box_size // 2
     if not Path(filename).is_file() or not Path(coords_file).is_file():
         logger.error(f"File {filename} or {coords_file} not found")

--- a/tests/services/test_cryolo_service.py
+++ b/tests/services/test_cryolo_service.py
@@ -295,7 +295,6 @@ def test_cryolo_service_tomography(mock_subprocess, offline_transport, tmp_path)
             "image_command": "picked_particles_3d_apng",
             "file": cryolo_test_message["input_path"],
             "coordinates_file": cryolo_test_message["output_path"],
-            "diameter_pixels": 40,
             "box_size": 40,
         },
     )
@@ -305,7 +304,6 @@ def test_cryolo_service_tomography(mock_subprocess, offline_transport, tmp_path)
             "image_command": "picked_particles_3d_central_slice",
             "file": cryolo_test_message["input_path"],
             "coordinates_file": cryolo_test_message["output_path"],
-            "diameter_pixels": 40,
             "box_size": 40,
         },
     )

--- a/tests/services/test_images_plugins.py
+++ b/tests/services/test_images_plugins.py
@@ -360,6 +360,16 @@ def test_picked_particles_3d_apng_works_without_coords(tmp_path):
     ) == str(tmp_path / "coords_movie.png")
 
 
+def test_interfaces_without_keys():
+    """Test that file path keys are required"""
+    assert not mrc_to_jpeg(lambda x: None)
+    assert not picked_particles(lambda x: None)
+    assert not mrc_central_slice(lambda x: None)
+    assert not mrc_to_apng(lambda x: None)
+    assert not picked_particles_3d_central_slice(lambda x: None)
+    assert not picked_particles_3d_apng(lambda x: None)
+
+
 def test_interfaces_without_files(tmp_path):
     """Assert rejections if files specified do not exist"""
     (tmp_path / "test.mrc").touch()
@@ -371,6 +381,16 @@ def test_interfaces_without_files(tmp_path):
     assert not picked_particles(plugin_params_parpick(tmp_path / "test.mrc", None))
     assert not mrc_central_slice(plugin_params_central(tmp_path / "not.mrc"))
     assert not mrc_to_apng(plugin_params_central(tmp_path / "not.mrc"))
+    assert not picked_particles_3d_central_slice(
+        plugin_params_tomo_pick(
+            tmp_path / "not.mrc", tmp_path / "coords.cbox", "picked_particles_3d_apng"
+        )
+    )
+    assert not picked_particles_3d_central_slice(
+        plugin_params_tomo_pick(
+            tmp_path / "test.mrc", tmp_path / "not.cbox", "picked_particles_3d_apng"
+        )
+    )
     assert not picked_particles_3d_apng(
         plugin_params_tomo_pick(
             tmp_path / "not.mrc", tmp_path / "coords.cbox", "picked_particles_3d_apng"

--- a/tests/services/test_images_plugins.py
+++ b/tests/services/test_images_plugins.py
@@ -358,3 +358,26 @@ def test_picked_particles_3d_apng_works_without_coords(tmp_path):
     assert picked_particles_3d_apng(
         plugin_params_tomo_pick(tmp_mrc_path, coords_file, "picked_particles_3d_apng")
     ) == str(tmp_path / "coords_movie.png")
+
+
+def test_interfaces_without_files(tmp_path):
+    """Assert rejections if files specified do not exist"""
+    (tmp_path / "test.mrc").touch()
+    (tmp_path / "coords.cbox").touch()
+
+    assert not mrc_to_jpeg(plugin_params(tmp_path / "not.mrc", False))
+    assert not picked_particles(plugin_params_parpick(tmp_path / "not.mrc", "test.jpg"))
+    assert not picked_particles(plugin_params_parpick(tmp_path / "test.jpeg", None))
+    assert not picked_particles(plugin_params_parpick(tmp_path / "test.mrc", None))
+    assert not mrc_central_slice(plugin_params_central(tmp_path / "not.mrc"))
+    assert not mrc_to_apng(plugin_params_central(tmp_path / "not.mrc"))
+    assert not picked_particles_3d_apng(
+        plugin_params_tomo_pick(
+            tmp_path / "not.mrc", tmp_path / "coords.cbox", "picked_particles_3d_apng"
+        )
+    )
+    assert not picked_particles_3d_apng(
+        plugin_params_tomo_pick(
+            tmp_path / "test.mrc", tmp_path / "not.cbox", "picked_particles_3d_apng"
+        )
+    )

--- a/tests/services/test_images_plugins.py
+++ b/tests/services/test_images_plugins.py
@@ -69,7 +69,6 @@ def plugin_params_tomo_pick(input_file, coords_file, command):
             "parameters": {"images_command": command},
             "file": input_file,
             "coordinates_file": coords_file,
-            "diameter_pixels": 40,
             "box_size": 40,
         }
         return p.get(key)
@@ -212,7 +211,8 @@ def test_picked_particles_3d_central_slice_works_with_3d(mock_imagedraw, tmp_pat
         cbox.write(
             "data_global\n\n_version 1\n\n"
             "data_cryolo\n\nloop_\n_CoordinateX\n_CoordinateY\n_CoordinateZ\n"
-            "40 50 0\n70 80 1\n"
+            "_EstWidth\n_EstHeight\n_NumBoxes\n"
+            "40 50 0 20 30 2 \n70 80 1 40 50 2\n"
         )
     assert picked_particles_3d_central_slice(
         plugin_params_tomo_pick(
@@ -228,12 +228,12 @@ def test_picked_particles_3d_central_slice_works_with_3d(mock_imagedraw, tmp_pat
     mock_imagedraw.Draw().ellipse.assert_any_call(
         [
             (
-                40 + 20 - np.sqrt(20**2 - 1**2),
-                50 + 20 - np.sqrt(20**2 - 1**2),
+                40 + 20 - np.sqrt(20**2 - 1**2) / 2,
+                50 + 20 - np.sqrt(30**2 - 1**2) / 2,
             ),
             (
-                40 + 20 + np.sqrt(20**2 - 1**2),
-                50 + 20 + np.sqrt(20**2 - 1**2),
+                40 + 20 + np.sqrt(20**2 - 1**2) / 2,
+                50 + 20 + np.sqrt(30**2 - 1**2) / 2,
             ),
         ],
         width=4,
@@ -242,12 +242,12 @@ def test_picked_particles_3d_central_slice_works_with_3d(mock_imagedraw, tmp_pat
     mock_imagedraw.Draw().ellipse.assert_any_call(
         [
             (
-                70,
-                80,
+                70 + 20 - 20,
+                80 + 20 - 25,
             ),
             (
                 70 + 20 + 20,
-                80 + 20 + 20,
+                80 + 20 + 25,
             ),
         ],
         width=4,
@@ -302,7 +302,8 @@ def test_picked_particles_3d_apng_works_with_3d(mock_imagedraw, tmp_path):
         cbox.write(
             "data_global\n\n_version 1\n\n"
             "data_cryolo\n\nloop_\n_CoordinateX\n_CoordinateY\n_CoordinateZ\n"
-            "40 50 0\n70 80 1\n"
+            "_EstWidth\n_EstHeight\n_NumBoxes\n"
+            "40 50 0 20 30 2 \n70 80 1 40 50 2\n"
         )
     assert picked_particles_3d_apng(
         plugin_params_tomo_pick(tmp_mrc_path, coords_file, "picked_particles_3d_apng")
@@ -314,26 +315,12 @@ def test_picked_particles_3d_apng_works_with_3d(mock_imagedraw, tmp_path):
     mock_imagedraw.Draw().ellipse.assert_any_call(
         [
             (
-                40,
-                50,
+                40 + 20 - 10,
+                50 + 20 - 15,
             ),
             (
-                40 + 20 + 20,
-                50 + 20 + 20,
-            ),
-        ],
-        width=4,
-        outline="#f52407",
-    )
-    mock_imagedraw.Draw().ellipse.assert_any_call(
-        [
-            (
-                40 + 20 - np.sqrt(20**2 - 1**2),
-                50 + 20 - np.sqrt(20**2 - 1**2),
-            ),
-            (
-                40 + 20 + np.sqrt(20**2 - 1**2),
-                50 + 20 + np.sqrt(20**2 - 1**2),
+                40 + 20 + 10,
+                50 + 20 + 15,
             ),
         ],
         width=4,
@@ -342,12 +329,26 @@ def test_picked_particles_3d_apng_works_with_3d(mock_imagedraw, tmp_path):
     mock_imagedraw.Draw().ellipse.assert_any_call(
         [
             (
-                70,
-                80,
+                40 + 20 - np.sqrt(20**2 - 1**2) / 2,
+                50 + 20 - np.sqrt(30**2 - 1**2) / 2,
+            ),
+            (
+                40 + 20 + np.sqrt(20**2 - 1**2) / 2,
+                50 + 20 + np.sqrt(30**2 - 1**2) / 2,
+            ),
+        ],
+        width=4,
+        outline="#f52407",
+    )
+    mock_imagedraw.Draw().ellipse.assert_any_call(
+        [
+            (
+                70 + 20 - 20,
+                80 + 20 - 25,
             ),
             (
                 70 + 20 + 20,
-                80 + 20 + 20,
+                80 + 20 + 25,
             ),
         ],
         width=4,
@@ -356,12 +357,12 @@ def test_picked_particles_3d_apng_works_with_3d(mock_imagedraw, tmp_path):
     mock_imagedraw.Draw().ellipse.assert_any_call(
         [
             (
-                70 + 20 - np.sqrt(20**2 - 1**2),
-                80 + 20 - np.sqrt(20**2 - 1**2),
+                70 + 20 - np.sqrt(40**2 - 1**2) / 2,
+                80 + 20 - np.sqrt(50**2 - 1**2) / 2,
             ),
             (
-                70 + 20 + np.sqrt(20**2 - 1**2),
-                80 + 20 + np.sqrt(20**2 - 1**2),
+                70 + 20 + np.sqrt(40**2 - 1**2) / 2,
+                80 + 20 + np.sqrt(50**2 - 1**2) / 2,
             ),
         ],
         width=4,

--- a/tests/services/test_images_service.py
+++ b/tests/services/test_images_service.py
@@ -49,9 +49,7 @@ def test_images_call(mock_picker_image):
     service.image_call(mock_recipe_wrapper, header=header, message=images_test_message)
 
     # Check the correct calls were made
-    mock_picker_image.assert_called_with(
-        images.PluginInterface(mock_recipe_wrapper, mock.ANY, images_test_message)
-    )
+    mock_picker_image.assert_called_once()
     mock_recipe_wrapper.transport.ack.assert_called()
 
 
@@ -83,9 +81,7 @@ def test_images_failed_call(mock_picker_image):
     service.image_call(mock_recipe_wrapper, header=header, message=images_test_message)
 
     # Check the correct calls were made
-    mock_picker_image.assert_called_with(
-        images.PluginInterface(mock_recipe_wrapper, mock.ANY, images_test_message)
-    )
+    mock_picker_image.assert_called_once()
     mock_recipe_wrapper.transport.nack.assert_called()
 
 
@@ -117,9 +113,7 @@ def test_images_file_not_found(mock_picker_image):
     service.image_call(mock_recipe_wrapper, header=header, message=images_test_message)
 
     # Check the correct calls were made
-    mock_picker_image.assert_called_with(
-        images.PluginInterface(mock_recipe_wrapper, mock.ANY, images_test_message)
-    )
+    mock_picker_image.assert_called_once()
     mock_recipe_wrapper.transport.nack.assert_called()
 
 


### PR DESCRIPTION
For tomography, previously the sizes of tomography particles were plotted using the box size given to cryolo. However, the CBOX output files contains the true widths and heights, plus the number of frames and particles appear in. The changes here mean the values in the CBOX are used.

This also cleans up the images plugins, dropping the `PluginInterface` which contained usused attributes, and adding checks that any required parameters are present.