### PR TITLE
Exclude images with bad motion correction results from tomogram alignment

### DIFF
--- a/src/cryoemservices/services/tomo_align.py
+++ b/src/cryoemservices/services/tomo_align.py
@@ -286,6 +286,12 @@ class TomoAlign(CommonService):
                         tilts_to_remove.append(
                             self.input_file_list_of_lists.index(tilt)
                         )
+        removed_tilt_numbers = np.array(
+            [
+                _get_tilt_number_v5_12(Path(self.input_file_list_of_lists[index][0]))
+                for index in tilts_to_remove
+            ]
+        )
         for index in sorted(tilts_to_remove, reverse=True):
             self.input_file_list_of_lists.remove(self.input_file_list_of_lists[index])
 
@@ -332,6 +338,7 @@ class TomoAlign(CommonService):
             tilt_index = _get_tilt_number_v5_12(
                 Path(self.input_file_list_of_lists[i][0])
             )
+            tilt_index -= len(np.where(removed_tilt_numbers < tilt_index)[0])
             tilt_angles[tilt_index] = self.input_file_list_of_lists[i][1]
         with open(angle_file, "w") as angfile:
             for tilt_id in tilt_angles.keys():

--- a/src/cryoemservices/util/tomo_output_files.py
+++ b/src/cryoemservices/util/tomo_output_files.py
@@ -26,14 +26,14 @@ def _get_tilt_angle_v5_12(p: Path) -> str:
     return split_name[angle_idx]
 
 
-def _get_tilt_number_v5_12(p: Path) -> str:
+def _get_tilt_number_v5_12(p: Path) -> int:
     split_name = p.stem.split("_")
     angle_idx = _find_angle_index(split_name)
     try:
         int(split_name[angle_idx - 1])
     except ValueError:
-        return "0"
-    return split_name[angle_idx - 1]
+        return 0
+    return int(split_name[angle_idx - 1])
 
 
 def _get_tilt_name_v5_12(p: Path) -> str:
@@ -131,11 +131,7 @@ def _import_output_files(
         str(relion_options.frame_count),
         str(stage_tilt_angle),
         str(relion_options.tilt_axis_angle),
-        str(
-            int(tilt_number)
-            * relion_options.frame_count
-            * relion_options.dose_per_frame
-        ),
+        str(tilt_number * relion_options.frame_count * relion_options.dose_per_frame),
         str(relion_options.defocus),
     ]
 
@@ -194,11 +190,7 @@ def _motioncorr_output_files(
         str(relion_options.frame_count),
         str(stage_tilt_angle),
         str(relion_options.tilt_axis_angle),
-        str(
-            int(tilt_number)
-            * relion_options.frame_count
-            * relion_options.dose_per_frame
-        ),
+        str(tilt_number * relion_options.frame_count * relion_options.dose_per_frame),
         str(relion_options.defocus),
         str(output_file),
         str(output_file.with_suffix(".star")),
@@ -275,11 +267,7 @@ def _ctffind_output_files(
         str(relion_options.frame_count),
         str(stage_tilt_angle),
         str(relion_options.tilt_axis_angle),
-        str(
-            int(tilt_number)
-            * relion_options.frame_count
-            * relion_options.dose_per_frame
-        ),
+        str(tilt_number * relion_options.frame_count * relion_options.dose_per_frame),
         str(relion_options.defocus),
         str(input_file),
         str(output_file.with_suffix(".ctf")) + ":mrc",
@@ -354,11 +342,7 @@ def _exclude_tilt_output_files(
         str(relion_options.frame_count),
         str(stage_tilt_angle),
         str(relion_options.tilt_axis_angle),
-        str(
-            int(tilt_number)
-            * relion_options.frame_count
-            * relion_options.dose_per_frame
-        ),
+        str(tilt_number * relion_options.frame_count * relion_options.dose_per_frame),
         str(relion_options.defocus),
         str(input_file),
     ]
@@ -437,11 +421,7 @@ def _align_tilt_output_files(
         str(relion_options.frame_count),
         str(stage_tilt_angle),
         str(relion_options.tilt_axis_angle),
-        str(
-            int(tilt_number)
-            * relion_options.frame_count
-            * relion_options.dose_per_frame
-        ),
+        str(tilt_number * relion_options.frame_count * relion_options.dose_per_frame),
         str(relion_options.defocus),
         str(input_file),
         ctf_results[1],

--- a/tests/services/test_tomo_align.py
+++ b/tests/services/test_tomo_align.py
@@ -400,6 +400,152 @@ def test_tomo_align_service_file_list_repeated_tilt(
 @mock.patch("cryoemservices.services.tomo_align.subprocess.run")
 @mock.patch("cryoemservices.services.tomo_align.px.scatter")
 @mock.patch("cryoemservices.services.tomo_align.mrcfile")
+def test_tomo_align_service_file_list_bad_tilts(
+    mock_mrcfile,
+    mock_plotly,
+    mock_subprocess,
+    offline_transport,
+    tmp_path,
+):
+    """
+    Send a test message to TomoAlign with a tilts with bad motion correction
+    This tilt should be removed
+    """
+    mock_subprocess().returncode = 0
+    mock_subprocess().stdout = "stdout".encode("ascii")
+    mock_subprocess().stderr = "stderr".encode("ascii")
+
+    mock_mrcfile.open().__enter__().header = {"nx": 3000, "ny": 4000}
+
+    # Create the Relion star files with different motion model results
+    (tmp_path / "MotionCorr/job002/Movies").mkdir(parents=True)
+    with open(
+        tmp_path / "MotionCorr/job002/Movies/Position_1_001_0.0.star", "w"
+    ) as mc_star:
+        # No local motion model
+        mc_star.write("data_general\n\nloop_\n_rlnMotionModelVersion\n0\n\n")
+    with open(
+        tmp_path / "MotionCorr/job002/Movies/Position_1_002_0.0.star", "w"
+    ) as mc_star:
+        # Local motion model succeeded
+        mc_star.write("data_general\n\nloop_\n_rlnMotionModelVersion\n1\n\n")
+        mc_star.write("data_local_motion_model\n\nloop_\n_rlnMotionModelCoeff\n1\n2\n")
+    with open(
+        tmp_path / "MotionCorr/job002/Movies/Position_1_003_0.0.star", "w"
+    ) as mc_star:
+        # Local motion model failed
+        mc_star.write("data_general\n\nloop_\n_rlnMotionModelVersion\n1\n\n")
+        mc_star.write(
+            "data_local_motion_model\n\nloop_\n_rlnMotionModelCoeff\n1\n2000\n"
+        )
+
+    header = {
+        "message-id": mock.sentinel,
+        "subscription": mock.sentinel,
+    }
+    tomo_align_test_message = {
+        "stack_file": f"{tmp_path}/Tomograms/job006/tomograms/test_stack.st",
+        "input_file_list": str(
+            [
+                [f"{tmp_path}/MotionCorr/job002/Movies/Position_1_001_0.0.mrc", "1.00"],
+                [f"{tmp_path}/MotionCorr/job002/Movies/Position_1_002_0.0.mrc", "2.00"],
+                [f"{tmp_path}/MotionCorr/job002/Movies/Position_1_003_0.0.mrc", "3.00"],
+            ]
+        ),
+        "pixel_size": 1e-10,
+        "relion_options": {},
+    }
+    output_relion_options = dict(RelionServiceOptions())
+    output_relion_options["pixel_size"] = 1e-10
+    output_relion_options["pixel_size_downscaled"] = 4e-10
+    output_relion_options["tomo_size_x"] = 4000
+    output_relion_options["tomo_size_y"] = 3000
+
+    # Set up the mock service
+    service = tomo_align.TomoAlign(environment={"queue": ""})
+    service.transport = offline_transport
+    service.start()
+
+    service.rot_centre_z_list = [1.1, 2.1]
+    service.tilt_offset = 1.1
+    service.alignment_quality = 0.5
+
+    # Set up outputs: stack_Imod file like AreTomo2, no exclusions but with space
+    (tmp_path / "Tomograms/job006/tomograms/test_stack_Imod").mkdir(parents=True)
+    (tmp_path / "Tomograms/job006/tomograms/test_stack_aretomo.mrc").touch()
+    with open(
+        tmp_path / "Tomograms/job006/tomograms/test_stack_Imod/tilt.com", "w"
+    ) as dark_file:
+        dark_file.write("EXCLUDELIST ")
+    with open(tmp_path / "Tomograms/job006/tomograms/test_stack.aln", "w") as aln_file:
+        aln_file.write(
+            "dummy 0 1000 1.2 2.3 5 6 7 8 4.5\ndummy 0 1000 1.2 2.3 5 6 7 8 4.5"
+        )
+
+    # Send a message to the service
+    service.tomo_align(None, header=header, message=tomo_align_test_message)
+
+    # Check the expected calls were made
+    assert mock_plotly.call_count == 1
+    assert mock_subprocess.call_count == 5
+
+    # Check the angle file
+    assert (
+        tmp_path / "Tomograms/job006/tomograms/test_stack_tilt_angles.txt"
+    ).is_file()
+    with open(
+        tmp_path / "Tomograms/job006/tomograms/test_stack_tilt_angles.txt", "r"
+    ) as angfile:
+        angles_data = angfile.read()
+    assert angles_data == "1.00  1\n2.00  2\n"
+
+    # Check the stack file does not have the tilt where motion correction failed
+    with open(
+        tmp_path / "Tomograms/job006/tomograms/test_stack_newstack.txt", "r"
+    ) as newstack_file:
+        newstack_tilts = newstack_file.read()
+    assert newstack_tilts == (
+        f"2\n{tmp_path}/MotionCorr/job002/Movies/Position_1_001_0.0.mrc\n0\n"
+        f"{tmp_path}/MotionCorr/job002/Movies/Position_1_002_0.0.mrc\n0\n"
+    )
+
+    # Look at a sample of the messages to check they use input files 1 and 2
+    assert offline_transport.send.call_count == 12
+    offline_transport.send.assert_any_call(
+        "node_creator",
+        {
+            "job_type": "relion.excludetilts",
+            "experiment_type": "tomography",
+            "input_file": f"{tmp_path}/MotionCorr/job002/Movies/Position_1_001_0.0.mrc",
+            "output_file": f"{tmp_path}/ExcludeTiltImages/job004/tilts/Position_1_001_0.0.mrc",
+            "relion_options": output_relion_options,
+            "command": "",
+            "stdout": "",
+            "stderr": "",
+            "success": True,
+        },
+    )
+    offline_transport.send.assert_any_call(
+        "node_creator",
+        {
+            "job_type": "relion.excludetilts",
+            "experiment_type": "tomography",
+            "input_file": f"{tmp_path}/MotionCorr/job002/Movies/Position_1_002_0.0.mrc",
+            "output_file": f"{tmp_path}/ExcludeTiltImages/job004/tilts/Position_1_002_0.0.mrc",
+            "relion_options": output_relion_options,
+            "command": "",
+            "stdout": "",
+            "stderr": "",
+            "success": True,
+        },
+    )
+    offline_transport.send.assert_any_call("success", {})
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+@mock.patch("cryoemservices.services.tomo_align.subprocess.run")
+@mock.patch("cryoemservices.services.tomo_align.px.scatter")
+@mock.patch("cryoemservices.services.tomo_align.mrcfile")
 def test_tomo_align_service_path_pattern(
     mock_mrcfile,
     mock_plotly,


### PR DESCRIPTION
Relion's motion correction sometimes fails on local alignment and produces abstract images. These then get put into tomogram alignment and disrupt the outputs.

The only way I can readily see to avoid this is to check the star files written out by Relion. 
Firstly, we need to check if the file exists, then if the local motion model was used, and finally when coefficients were found.
I've put a threshold of 1000 on the local alignment coefficients, but this is an arbitrary choice.

This will result in an increase in I/O and maybe slow down alignment slightly.