### PR TITLE
Skipped pre-commit checks on deployment.yaml files 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,4 +80,5 @@ repos:
     hooks:
       - id: prettier
         name: Formatting other file types according to Prettier
+        exclude: Helm/charts/.*?/templates/deployment\.yaml
         # types_or: [css, html, json, yaml]


### PR DESCRIPTION
These files are not written in pure YAML, so the pre-commit checks will understandably raise errors when dealing with them.

This PR excludes those files from the relevant YAML-related pre-commit checks.