### PR TITLE
Completely remove the zocalo package dependency

### DIFF
--- a/Dockerfiles/cryolo
+++ b/Dockerfiles/cryolo
@@ -47,7 +47,7 @@ COPY cryolo_models/gmodel_phosnet_202005_N63_c17.h5 gmodel_phosnet_202005_N63_c1
 RUN chown "${userid}":"${groupid}" gmodel_phosnet_202005_N63_c17.h5
 USER "${userid}":"${groupid}"
 
-RUN echo '#!/bin/bash\n\nif [ ! -z ${RECURSION_PROTECTION} ]; then\n    echo "Unintended recursion detected in zocalo indirection ($0)"\n    exit 1\nfi\nexport RECURSION_PROTECTION=1\n\nexport PATH="/install/venv_cryolo/bin:${PATH}"\ncryolo_predict.py "$@"' > /install/venv_services/bin/cryolo_predict.py && \
+RUN echo '#!/bin/bash\n\nif [ ! -z ${RECURSION_PROTECTION} ]; then\n    echo "Unintended recursion detected in indirection ($0)"\n    exit 1\nfi\nexport RECURSION_PROTECTION=1\n\nexport PATH="/install/venv_cryolo/bin:${PATH}"\ncryolo_predict.py "$@"' > /install/venv_services/bin/cryolo_predict.py && \
     chmod +x /install/venv_services/bin/cryolo_predict.py
 
 ENV PATH="/install/venv_services/bin:${PATH}"

--- a/README.md
+++ b/README.md
@@ -87,8 +87,7 @@ using [Relion](https://relion.readthedocs.io).
 # Running services
 
 The services in this package are run using
-[zocalo](https://github.com/DiamondLightSource/python-zocalo)
-and [python-workflows](https://github.com/DiamondLightSource/python-workflows).
+[python-workflows](https://github.com/DiamondLightSource/python-workflows).
 They consume messages off a [RabbitMQ](https://www.rabbitmq.com/)
 instance and processing happens in sequences defined by the recipes in the `recipes` folder.
 To start a service run the `cryoemservices.service` command and specify the service name.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ dependencies = [
     "stomp-py==8.1.0",
     "tifffile", # CLEM workflow
     "workflows>=3",
-    "zocalo>=1.2",
 ]
 [project.optional-dependencies]
 dev = [

--- a/recipes/clem-align-and-merge.json
+++ b/recipes/clem-align-and-merge.json
@@ -38,10 +38,7 @@
       "workingdir": "{session_dir}/processed/"
     },
     "queue": "cluster.submission",
-    "service": "ALIGN-AND-MERGE",
-    "wrapper": {
-      "task_information": "align-and-merge"
-    }
+    "service": "ALIGN-AND-MERGE"
   },
   "2": {
     "parameters": {

--- a/recipes/clem-lif-to-stack.json
+++ b/recipes/clem-lif-to-stack.json
@@ -33,10 +33,7 @@
       "workingdir": "{session_dir}/processed/"
     },
     "queue": "cluster.submission",
-    "service": "LIF2STACK",
-    "wrapper": {
-      "task_information": "lif-to-stack"
-    }
+    "service": "LIF2STACK"
   },
   "2": {
     "parameters": {

--- a/recipes/clem-tiff-to-stack.json
+++ b/recipes/clem-tiff-to-stack.json
@@ -35,10 +35,7 @@
       "workingdir": "{session_dir}/processed/"
     },
     "queue": "cluster.submission",
-    "service": "TIFF2STACK",
-    "wrapper": {
-      "task_information": "tiff-to-stack"
-    }
+    "service": "TIFF2STACK"
   },
   "2": {
     "parameters": {

--- a/recipes/em-spa-bfactor.json
+++ b/recipes/em-spa-bfactor.json
@@ -60,10 +60,7 @@
       "workingdir": "{bfactor_directory}/"
     },
     "queue": "cluster.submission",
-    "service": "RefineWrapper",
-    "wrapper": {
-      "task_information": "Refine3D"
-    }
+    "service": "RefineWrapper"
   },
   "4": {
     "output": {

--- a/recipes/em-spa-class2d.json
+++ b/recipes/em-spa-class2d.json
@@ -54,10 +54,7 @@
       "workingdir": "{class2d_dir}/"
     },
     "queue": "cluster.submission",
-    "service": "Class2DWrapper",
-    "wrapper": {
-      "task_information": "Class2D"
-    }
+    "service": "Class2DWrapper"
   },
   "2": {
     "queue": "node_creator",

--- a/recipes/em-spa-class3d.json
+++ b/recipes/em-spa-class3d.json
@@ -53,10 +53,7 @@
       "workingdir": "{class3d_dir}/"
     },
     "queue": "cluster.submission",
-    "service": "Class3DWrapper",
-    "wrapper": {
-      "task_information": "Class3D"
-    }
+    "service": "Class3DWrapper"
   },
   "2": {
     "queue": "node_creator",

--- a/recipes/em-spa-refine.json
+++ b/recipes/em-spa-refine.json
@@ -59,10 +59,7 @@
       "workingdir": "{refine_job_dir}/"
     },
     "queue": "cluster.submission",
-    "service": "RefineWrapper",
-    "wrapper": {
-      "task_information": "Refine3D"
-    }
+    "service": "RefineWrapper"
   },
   "4": {
     "output": {
@@ -134,10 +131,7 @@
       "workingdir": "{refine_job_dir}/"
     },
     "queue": "cluster.submission",
-    "service": "RefineWrapper",
-    "wrapper": {
-      "task_information": "Refine3D"
-    }
+    "service": "RefineWrapper"
   },
   "8": {
     "output": {

--- a/src/cryoemservices/cli/dlq_rabbitmq.py
+++ b/src/cryoemservices/cli/dlq_rabbitmq.py
@@ -8,12 +8,30 @@ from functools import partial
 from pathlib import Path
 from queue import Empty, Queue
 
+import requests
+from pydantic import BaseModel
 from workflows.transport.pika_transport import PikaTransport
-from zocalo.util.rabbitmq import RabbitMQAPI
 
 from cryoemservices.util.config import config_from_file
 
 dlq_dump_path = Path("./DLQ")
+
+
+class QueueInfo(BaseModel):
+    name: str
+    vhost: str
+    messages: int
+
+
+class RabbitMQAPI:
+    def __init__(self, url: str, user: str, password: str):
+        self._url = url
+        self._session = requests.Session()
+        self._session.auth = (user, password)
+
+    def queues(self) -> list[QueueInfo]:
+        response = self._session.get(f"{self._url}/queues")
+        return [QueueInfo(**qi) for qi in response.json()]
 
 
 def check_dlq_rabbitmq(rabbitmq_credentials: Path) -> dict:

--- a/src/cryoemservices/services/cluster_submission.py
+++ b/src/cryoemservices/services/cluster_submission.py
@@ -12,11 +12,73 @@ from typing import Optional
 import requests
 import workflows.recipe
 import yaml
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, RootModel
 from workflows.services.common_service import CommonService
-from zocalo.util import slurm
 
 from cryoemservices.util.config import ServiceConfig, config_from_file
+
+
+class UintNoVal(BaseModel):
+    set: bool = True
+    infinite: bool = False
+    number: int
+
+
+class StringArray(RootModel[list[str]]):
+    root: list[str]
+
+
+class JobParams(BaseModel):
+    cpus_per_task: Optional[int] = None
+    current_working_directory: Optional[str] = None
+    environment: Optional[StringArray] = None
+    name: Optional[str] = None
+    nodes: Optional[str] = None
+    partition: Optional[str] = None
+    prefer: Optional[str] = None
+    tasks: Optional[int] = None
+
+    memory_per_cpu: Optional[UintNoVal] = None
+    memory_per_node: Optional[UintNoVal] = None
+    time_limit: Optional[UintNoVal] = None
+    tres_per_node: Optional[str] = None
+    tres_per_job: Optional[str] = None
+
+
+class JobSubmitResponseMsg(BaseModel):
+    job_id: Optional[int] = None
+    step_id: Optional[str] = None
+    error_code: Optional[int] = None
+    error: Optional[str] = None
+    job_submit_user_msg: Optional[str] = None
+
+
+class SlurmRestApi:
+    def __init__(
+        self,
+        url: str,
+        user_name: str,
+        user_token: Path,
+        version: str = "v0.0.40",
+    ):
+        self.url = url
+        self.version = version
+        self.session = requests.Session()
+        self.session.headers["X-SLURM-USER-NAME"] = user_name
+        if user_token.is_file():
+            with open(user_token, "r") as f:
+                self.session.headers["X-SLURM-USER-TOKEN"] = f.read().strip()
+        else:
+            # We got passed a path, but it isn't a valid one
+            raise RuntimeError(f"SLURM: API token file {user_token} does not exist")
+
+    def submit_job(self, script: str, job: JobParams) -> JobSubmitResponseMsg:
+        response = self.session.post(
+            url=f"{self.url}/slurm/{self.version}/job/submit",
+            json={"script": script, "job": job},
+        )
+        response.raise_for_status()
+        return JobSubmitResponseMsg(**response.json())
 
 
 class JobSubmissionParameters(BaseModel):
@@ -52,11 +114,11 @@ def submit_to_slurm(
         return None
     with open(slurm_credentials, "r") as f:
         slurm_rest = yaml.safe_load(f)
-    api = slurm.SlurmRestApi(
+    api = SlurmRestApi(
         url=slurm_rest["url"],
-        version=slurm_rest["api_version"],
         user_name=slurm_rest["user"],
         user_token=slurm_rest["user_token"],
+        version=slurm_rest["api_version"],
     )
 
     script = params.commands
@@ -88,28 +150,22 @@ def submit_to_slurm(
         "tasks": params.tasks,
     }
     if params.min_memory_per_cpu:
-        jdm_params["memory_per_cpu"] = slurm.models.Uint64NoVal(
-            number=params.min_memory_per_cpu, set=True
-        )
+        jdm_params["memory_per_cpu"] = UintNoVal(number=params.min_memory_per_cpu)
     if params.memory_per_node:
-        jdm_params["memory_per_node"] = slurm.models.Uint64NoVal(
-            number=params.memory_per_node, set=True
-        )
+        jdm_params["memory_per_node"] = UintNoVal(number=params.memory_per_node)
     if params.time_limit:
         time_limit_minutes = math.ceil(params.time_limit.total_seconds() / 60)
-        jdm_params["time_limit"] = slurm.models.Uint32NoVal(
-            number=time_limit_minutes, set=True
-        )
+        jdm_params["time_limit"] = UintNoVal(number=time_limit_minutes)
     if params.gpus_per_node:
         jdm_params["tres_per_node"] = f"gres/gpu:{params.gpus_per_node}"
     if params.gpus:
         jdm_params["tres_per_job"] = f"gres/gpu:{params.gpus}"
 
-    job_submission = slurm.models.JobSubmitReq(
-        script=script, job=slurm.models.JobDescMsg(**jdm_params)
-    )
     try:
-        response = api.submit_job(job_submission)
+        response = api.submit_job(
+            script=script,
+            job=JobParams(**jdm_params),
+        )
     except requests.HTTPError as e:
         logger.error(f"Failed Slurm job submission: {e}\n" f"{e.response.text}")
         return None

--- a/src/cryoemservices/wrappers/class2d_wrapper.py
+++ b/src/cryoemservices/wrappers/class2d_wrapper.py
@@ -11,7 +11,6 @@ from typing import Optional
 import numpy as np
 from gemmi import cif
 from pydantic import BaseModel, Field, ValidationError
-from zocalo.wrapper import BaseWrapper
 
 from cryoemservices.util.relion_service_options import (
     RelionServiceOptions,
@@ -64,7 +63,7 @@ class Class2DParameters(BaseModel):
     relion_options: RelionServiceOptions
 
 
-class Class2DWrapper(BaseWrapper):
+class Class2DWrapper:
     """
     A wrapper for the Relion 2D classification job.
     """
@@ -73,9 +72,9 @@ class Class2DWrapper(BaseWrapper):
     previous_total_count = 0
     total_count = 0
 
-    # Values for ISPyB lookups
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, recwrap):
+        self.log = logging.LoggerAdapter(logger)
+        self.recwrap = recwrap
         self.class_uuids_dict = {}
         self.class_uuids_keys = []
 
@@ -83,9 +82,6 @@ class Class2DWrapper(BaseWrapper):
         """
         Run the 2D classification and register results
         """
-        if not hasattr(self, "recwrap"):
-            logger.error("No recipewrapper object found")
-            return False
         params_dict = self.recwrap.recipe_step["job_parameters"]
         try:
             class2d_params = Class2DParameters(**params_dict)

--- a/src/cryoemservices/wrappers/class3d_wrapper.py
+++ b/src/cryoemservices/wrappers/class3d_wrapper.py
@@ -13,7 +13,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 from gemmi import cif
 from pydantic import BaseModel, Field, ValidationError
-from zocalo.wrapper import BaseWrapper
 
 from cryoemservices.util.relion_service_options import (
     RelionServiceOptions,
@@ -74,7 +73,7 @@ class Class3DParameters(BaseModel):
     relion_options: RelionServiceOptions
 
 
-class Class3DWrapper(BaseWrapper):
+class Class3DWrapper:
     """
     A wrapper for the Relion 3D classification job.
     """
@@ -97,8 +96,9 @@ class Class3DWrapper(BaseWrapper):
     }
 
     # Values for ISPyB lookups
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, recwrap):
+        self.log = logging.LoggerAdapter(logger)
+        self.recwrap = recwrap
         self.class_uuids_dict = {}
         self.class_uuids_keys = []
 
@@ -297,9 +297,6 @@ class Class3DWrapper(BaseWrapper):
         """
         Run the 3D classification and register results
         """
-        if not hasattr(self, "recwrap"):
-            logger.error("No recipewrapper object found")
-            return False
         params_dict = self.recwrap.recipe_step["job_parameters"]
         try:
             class3d_params = Class3DParameters(**params_dict)

--- a/src/cryoemservices/wrappers/class3d_wrapper.py
+++ b/src/cryoemservices/wrappers/class3d_wrapper.py
@@ -95,7 +95,6 @@ class Class3DWrapper:
         "threads": "--j",
     }
 
-    # Values for ISPyB lookups
     def __init__(self, recwrap):
         self.log = logging.LoggerAdapter(logger)
         self.recwrap = recwrap

--- a/src/cryoemservices/wrappers/clem_align_and_merge.py
+++ b/src/cryoemservices/wrappers/clem_align_and_merge.py
@@ -22,7 +22,6 @@ import numpy as np
 from defusedxml.ElementTree import parse
 from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 from tifffile import TiffFile, imwrite
-from zocalo.wrapper import BaseWrapper
 
 from cryoemservices.util.clem_array_functions import (
     align_image_to_reference,
@@ -504,7 +503,11 @@ class AlignAndMergeParameters(BaseModel):
         return value
 
 
-class AlignAndMergeWrapper(BaseWrapper):
+class AlignAndMergeWrapper:
+    def __init__(self, recwrap):
+        self.log = logging.LoggerAdapter(logger)
+        self.recwrap = recwrap
+
     def run(self) -> bool:
         """
         Reads the Zocalo wrapper recipe, loads the parameters, and pass them to the
@@ -512,9 +515,6 @@ class AlignAndMergeWrapper(BaseWrapper):
         them back to Murfey for the next stage in the workflow.
         """
 
-        if not hasattr(self, "recwrap"):
-            logger.error("No RecipeWrapper object found")
-            return False
         params_dict = self.recwrap.recipe_step["job_parameters"]
         try:
             params = AlignAndMergeParameters(**params_dict)

--- a/src/cryoemservices/wrappers/clem_process_raw_tiffs.py
+++ b/src/cryoemservices/wrappers/clem_process_raw_tiffs.py
@@ -16,7 +16,6 @@ import numpy as np
 from defusedxml.ElementTree import parse
 from PIL import Image
 from pydantic import BaseModel, ValidationError, field_validator, model_validator
-from zocalo.wrapper import BaseWrapper
 
 from cryoemservices.util.clem_array_functions import (
     estimate_int_dtype,
@@ -361,16 +360,17 @@ class TIFFToStackParameters(BaseModel):
         return model
 
 
-class TIFFToStackWrapper(BaseWrapper):
+class TIFFToStackWrapper:
+    def __init__(self, recwrap):
+        self.log = logging.LoggerAdapter(logger)
+        self.recwrap = recwrap
+
     def run(self) -> bool:
         """
         Reads the Zocalo wrapper recipe, loads the parameters, and passes them to the
         TIFF file processing function. Upon collecting the results, it sends them back
         to Murfey for the next stage of the workflow.
         """
-        if not hasattr(self, "recwrap"):
-            logger.error("No RecipeWrapper object found")
-            return False
         params_dict = self.recwrap.recipe_step["job_parameters"]
         try:
             params = TIFFToStackParameters(**params_dict)

--- a/src/cryoemservices/wrappers/refine3d_wrapper.py
+++ b/src/cryoemservices/wrappers/refine3d_wrapper.py
@@ -11,7 +11,6 @@ import healpy as hp
 import matplotlib.pyplot as plt
 import mrcfile
 import numpy as np
-import zocalo.wrapper
 from gemmi import cif
 from pydantic import BaseModel, Field, ValidationError
 
@@ -93,7 +92,7 @@ class RefineParameters(BaseModel):
     relion_options: RelionServiceOptions
 
 
-class Refine3DWrapper(zocalo.wrapper.BaseWrapper):
+class Refine3DWrapper:
     """
     A wrapper for the Relion 3D refinement pipeline.
     """
@@ -102,13 +101,14 @@ class Refine3DWrapper(zocalo.wrapper.BaseWrapper):
     refine_job_type = "relion.refine3d"
     mask_job_type = "relion.maskcreate"
 
+    def __init__(self, recwrap):
+        self.log = logging.LoggerAdapter(logger)
+        self.recwrap = recwrap
+
     def run(self):
         """
         Run 3D refinement and postprocessing
         """
-        if not hasattr(self, "recwrap"):
-            logger.error("No recipewrapper object found")
-            return False
         params_dict = self.recwrap.recipe_step["job_parameters"]
         params_dict.update(self.recwrap.payload)
         try:

--- a/tests/cli/test_run_wrapper.py
+++ b/tests/cli/test_run_wrapper.py
@@ -38,12 +38,7 @@ def test_run_wrapper(mock_rw, mock_transport, mock_class2d, tmp_path):
     mock_transport().connect.assert_called()
     mock_rw.assert_called_with(message={"test": "test"}, transport=mock_transport())
 
-    mock_class2d.assert_called()
-    mock_class2d().set_recipe_wrapper.assert_called()
-    mock_class2d().prepare.assert_called_with({"status_message": "Starting processing"})
+    mock_class2d.assert_called_once()
     mock_class2d().run.assert_called()
-    mock_class2d().success.assert_called_with(
-        {"status_message": "Finished processing", "status": "success"}
-    )
 
     mock_transport().disconnect.assert_called()

--- a/tests/services/test_cluster_submission.py
+++ b/tests/services/test_cluster_submission.py
@@ -6,6 +6,7 @@ import sys
 from unittest import mock
 
 import pytest
+from requests import Response
 from workflows.transport.offline_transport import OfflineTransport
 
 from cryoemservices.services import cluster_submission
@@ -34,19 +35,24 @@ def cluster_submission_configuration(tmp_path):
         slurm_creds.write("url: /slurm/url\n")
         slurm_creds.write("api_version: v0.0.40\n")
         slurm_creds.write("user: user\n")
-        slurm_creds.write("user_token: /path/to/token.txt\n")
+        slurm_creds.write(f"user_token: {tmp_path}/token.txt\n")
     with open(tmp_path / "slurm_credentials_extra.yaml", "w") as slurm_creds:
         slurm_creds.write("url: /slurm/extra/url\n")
         slurm_creds.write("api_version: v0.0.41\n")
         slurm_creds.write("user: user2\n")
-        slurm_creds.write("user_token: /path/to/token_user2.txt\n")
+        slurm_creds.write(f"user_token: {tmp_path}/token_user2.txt\n")
+
+    with open(tmp_path / "token.txt", "w") as token_file:
+        token_file.write("token")
+    with open(tmp_path / "token_user2.txt", "w") as token_file:
+        token_file.write("token2")
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 @mock.patch("workflows.recipe.RecipeWrapper")
-@mock.patch("cryoemservices.services.cluster_submission.slurm")
+@mock.patch("cryoemservices.services.cluster_submission.requests")
 def test_cluster_submission_recipeless(
-    mock_restapi, mock_rw, offline_transport, tmp_path
+    mock_requests, mock_rw, offline_transport, tmp_path
 ):
     """
     Send a test message to ClusterSubmission without any recipe information
@@ -54,8 +60,12 @@ def test_cluster_submission_recipeless(
     cluster_submission_configuration(tmp_path)
 
     # Set up the returned job number
-    mock_restapi.SlurmRestApi().submit_job().error = ""
-    mock_restapi.SlurmRestApi().submit_job().job_id = 1
+    response_object = Response()
+    response_object._content = (
+        '{"job_id": 1, "step_id": "0", "error_code": 0, "error": "", "job_submit_user_msg": "message"}'
+    ).encode("utf8")
+    response_object.status_code = 200
+    mock_requests.Session().post.return_value = response_object
 
     header = {
         "message-id": mock.sentinel,
@@ -95,36 +105,39 @@ def test_cluster_submission_recipeless(
     service.run_submit_job(mock_rw, header=header, message={})
 
     # Check the calls to the job setup and submission
-    mock_restapi.SlurmRestApi.assert_called_with(
-        url="/slurm/url",
-        version="v0.0.40",
-        user_name="user",
-        user_token="/path/to/token.txt",
+    mock_requests.Session.assert_called()
+    mock_requests.Session().headers.__setitem__.assert_any_call(
+        "X-SLURM-USER-NAME", "user"
     )
-    mock_restapi.models.Uint64NoVal.assert_any_call(number=10, set=True)
-    mock_restapi.models.Uint64NoVal.assert_called_with(number=20, set=True)
-    mock_restapi.models.Uint32NoVal.assert_called_with(number=5, set=True)
-    mock_restapi.models.JobDescMsg.assert_called_with(
-        cpus_per_task=3,
-        current_working_directory=str(tmp_path),
-        environment=["USER=user"],
-        memory_per_cpu=mock_restapi.models.Uint64NoVal(),
-        memory_per_node=mock_restapi.models.Uint64NoVal(),
-        name="test_job",
-        nodes="1",
-        partition="part",
-        prefer="preferred_part",
-        tasks=2,
-        time_limit=mock_restapi.models.Uint32NoVal(),
-        tres_per_node="gres/gpu:4",
-        tres_per_job="gres/gpu:4",
+    mock_requests.Session().headers.__setitem__.assert_any_call(
+        "X-SLURM-USER-TOKEN", "token"
     )
-    mock_restapi.models.JobSubmitReq.assert_called_with(
-        script="#!/bin/bash\n. /etc/profile.d/modules.sh\nsrun job",
-        job=mock_restapi.models.JobDescMsg(),
-    )
-    mock_restapi.SlurmRestApi().submit_job.assert_called_with(
-        mock_restapi.models.JobSubmitReq()
+    mock_requests.Session().post.assert_called_with(
+        url="/slurm/url/slurm/v0.0.40/job/submit",
+        json={
+            "job": cluster_submission.JobParams(
+                cpus_per_task=3,
+                current_working_directory=str(tmp_path),
+                environment=["USER=user"],
+                name="test_job",
+                nodes="1",
+                partition="part",
+                prefer="preferred_part",
+                tasks=2,
+                memory_per_cpu=cluster_submission.SlurmInt(
+                    set=True, infinite=False, number=10
+                ),
+                memory_per_node=cluster_submission.SlurmInt(
+                    set=True, infinite=False, number=20
+                ),
+                time_limit=cluster_submission.SlurmInt(
+                    set=True, infinite=False, number=5
+                ),
+                tres_per_node="gres/gpu:4",
+                tres_per_job="gres/gpu:4",
+            ),
+            "script": "#!/bin/bash\n. /etc/profile.d/modules.sh\nsrun job",
+        },
     )
 
     # Check the service registered success
@@ -134,9 +147,9 @@ def test_cluster_submission_recipeless(
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 @mock.patch("workflows.recipe.RecipeWrapper")
-@mock.patch("cryoemservices.services.cluster_submission.slurm")
+@mock.patch("cryoemservices.services.cluster_submission.requests")
 def test_cluster_submission_recipefile(
-    mock_restapi, mock_rw, offline_transport, tmp_path
+    mock_requests, mock_rw, offline_transport, tmp_path
 ):
     """
     Send a test message to ClusterSubmission with a recipefile set
@@ -144,8 +157,12 @@ def test_cluster_submission_recipefile(
     cluster_submission_configuration(tmp_path)
 
     # Set up the returned job number
-    mock_restapi.SlurmRestApi().submit_job().error = ""
-    mock_restapi.SlurmRestApi().submit_job().job_id = 1
+    response_object = Response()
+    response_object._content = (
+        '{"job_id": 1, "step_id": "0", "error_code": 0, "error": "", "job_submit_user_msg": "message"}'
+    ).encode("utf8")
+    response_object.status_code = 200
+    mock_requests.Session().post.return_value = response_object
 
     header = {
         "message-id": mock.sentinel,
@@ -184,9 +201,21 @@ def test_cluster_submission_recipefile(
     # Check the calls to the job setup and submission
     assert (tmp_path / "recipefile").is_file()
     mock_rw.recipe.pretty.assert_called()
-    mock_restapi.models.JobSubmitReq.assert_called_with(
-        script=f"#!/bin/bash\n. /etc/profile.d/modules.sh\nsrun {tmp_path}/recipefile",
-        job=mock_restapi.models.JobDescMsg(),
+    mock_requests.Session().post.assert_called_with(
+        url="/slurm/url/slurm/v0.0.40/job/submit",
+        json={
+            "job": cluster_submission.JobParams(
+                cpus_per_task=3,
+                current_working_directory=str(tmp_path),
+                environment=["USER=user"],
+                name="test_job",
+                nodes="1",
+                partition="part",
+                prefer="preferred_part",
+                tasks=2,
+            ),
+            "script": f"#!/bin/bash\n. /etc/profile.d/modules.sh\nsrun {tmp_path}/recipefile",
+        },
     )
 
     # Check the service registered success
@@ -196,9 +225,9 @@ def test_cluster_submission_recipefile(
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 @mock.patch("workflows.recipe.RecipeWrapper")
-@mock.patch("cryoemservices.services.cluster_submission.slurm")
+@mock.patch("cryoemservices.services.cluster_submission.requests")
 def test_cluster_submission_recipeenvironment(
-    mock_restapi, mock_rw, offline_transport, tmp_path
+    mock_requests, mock_rw, offline_transport, tmp_path
 ):
     """
     Send a test message to ClusterSubmission with a recipeenvironment set
@@ -206,8 +235,12 @@ def test_cluster_submission_recipeenvironment(
     cluster_submission_configuration(tmp_path)
 
     # Set up the returned job number
-    mock_restapi.SlurmRestApi().submit_job().error = ""
-    mock_restapi.SlurmRestApi().submit_job().job_id = 1
+    response_object = Response()
+    response_object._content = (
+        '{"job_id": 1, "step_id": "0", "error_code": 0, "error": "", "job_submit_user_msg": "message"}'
+    ).encode("utf8")
+    response_object.status_code = 200
+    mock_requests.Session().post.return_value = response_object
 
     header = {
         "message-id": mock.sentinel,
@@ -245,9 +278,21 @@ def test_cluster_submission_recipeenvironment(
 
     # Check the calls to the job setup and submission
     assert (tmp_path / "recipe_env").is_file()
-    mock_restapi.models.JobSubmitReq.assert_called_with(
-        script=f"#!/bin/bash\n. /etc/profile.d/modules.sh\nsrun job {tmp_path}/recipe_env",
-        job=mock_restapi.models.JobDescMsg(),
+    mock_requests.Session().post.assert_called_with(
+        url="/slurm/url/slurm/v0.0.40/job/submit",
+        json={
+            "job": cluster_submission.JobParams(
+                cpus_per_task=3,
+                current_working_directory=str(tmp_path),
+                environment=["USER=user"],
+                name="test_job",
+                nodes="1",
+                partition="part",
+                prefer="preferred_part",
+                tasks=2,
+            ),
+            "script": f"#!/bin/bash\n. /etc/profile.d/modules.sh\nsrun job {tmp_path}/recipe_env",
+        },
     )
 
     # Check the service registered success
@@ -257,9 +302,9 @@ def test_cluster_submission_recipeenvironment(
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 @mock.patch("workflows.recipe.RecipeWrapper")
-@mock.patch("cryoemservices.services.cluster_submission.slurm")
+@mock.patch("cryoemservices.services.cluster_submission.requests")
 def test_cluster_submission_recipewrapper(
-    mock_restapi, mock_rw, offline_transport, tmp_path
+    mock_requests, mock_rw, offline_transport, tmp_path
 ):
     """
     Send a test message to ClusterSubmission with a recipewrapper set
@@ -267,8 +312,12 @@ def test_cluster_submission_recipewrapper(
     cluster_submission_configuration(tmp_path)
 
     # Set up the returned job number
-    mock_restapi.SlurmRestApi().submit_job().error = ""
-    mock_restapi.SlurmRestApi().submit_job().job_id = 1
+    response_object = Response()
+    response_object._content = (
+        '{"job_id": 1, "step_id": "0", "error_code": 0, "error": "", "job_submit_user_msg": "message"}'
+    ).encode("utf8")
+    response_object.status_code = 200
+    mock_requests.Session().post.return_value = response_object
 
     header = {
         "message-id": mock.sentinel,
@@ -319,9 +368,21 @@ def test_cluster_submission_recipewrapper(
     assert output_json["recipe-path"] == "/path/to/recipe"
     assert output_json["payload"] == "payload"
 
-    mock_restapi.models.JobSubmitReq.assert_called_with(
-        script=f"#!/bin/bash\n. /etc/profile.d/modules.sh\nsrun job {tmp_path}/recipe_wrapper",
-        job=mock_restapi.models.JobDescMsg(),
+    mock_requests.Session().post.assert_called_with(
+        url="/slurm/url/slurm/v0.0.40/job/submit",
+        json={
+            "job": cluster_submission.JobParams(
+                cpus_per_task=3,
+                current_working_directory=str(tmp_path),
+                environment=["USER=user"],
+                name="test_job",
+                nodes="1",
+                partition="part",
+                prefer="preferred_part",
+                tasks=2,
+            ),
+            "script": f"#!/bin/bash\n. /etc/profile.d/modules.sh\nsrun job {tmp_path}/recipe_wrapper",
+        },
     )
 
     # Check the service registered success
@@ -331,9 +392,9 @@ def test_cluster_submission_recipewrapper(
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 @mock.patch("workflows.recipe.RecipeWrapper")
-@mock.patch("cryoemservices.services.cluster_submission.slurm")
+@mock.patch("cryoemservices.services.cluster_submission.requests")
 def test_cluster_submission_extra_cluster(
-    mock_restapi, mock_rw, offline_transport, tmp_path
+    mock_requests, mock_rw, offline_transport, tmp_path
 ):
     """
     Send a test message to ClusterSubmission for the second configured cluster
@@ -341,8 +402,12 @@ def test_cluster_submission_extra_cluster(
     cluster_submission_configuration(tmp_path)
 
     # Set up the returned job number
-    mock_restapi.SlurmRestApi().submit_job().error = ""
-    mock_restapi.SlurmRestApi().submit_job().job_id = 1
+    response_object = Response()
+    response_object._content = (
+        '{"job_id": 1, "step_id": "0", "error_code": 0, "error": "", "job_submit_user_msg": "message"}'
+    ).encode("utf8")
+    response_object.status_code = 200
+    mock_requests.Session().post.return_value = response_object
 
     header = {
         "message-id": mock.sentinel,
@@ -382,11 +447,38 @@ def test_cluster_submission_extra_cluster(
     service.run_submit_job(mock_rw, header=header, message={})
 
     # Check the calls to the job setup and submission
-    mock_restapi.SlurmRestApi.assert_called_with(
-        url="/slurm/extra/url",
-        version="v0.0.41",
-        user_name="user2",
-        user_token="/path/to/token_user2.txt",
+    mock_requests.Session().headers.__setitem__.assert_any_call(
+        "X-SLURM-USER-NAME", "user2"
+    )
+    mock_requests.Session().headers.__setitem__.assert_any_call(
+        "X-SLURM-USER-TOKEN", "token2"
+    )
+    mock_requests.Session().post.assert_called_with(
+        url="/slurm/extra/url/slurm/v0.0.41/job/submit",
+        json={
+            "job": cluster_submission.JobParams(
+                cpus_per_task=3,
+                current_working_directory=str(tmp_path),
+                environment=["USER=user"],
+                name="test_job",
+                nodes="1",
+                partition="part",
+                prefer="preferred_part",
+                tasks=2,
+                memory_per_cpu=cluster_submission.SlurmInt(
+                    set=True, infinite=False, number=10
+                ),
+                memory_per_node=cluster_submission.SlurmInt(
+                    set=True, infinite=False, number=20
+                ),
+                time_limit=cluster_submission.SlurmInt(
+                    set=True, infinite=False, number=5
+                ),
+                tres_per_node="gres/gpu:4",
+                tres_per_job="gres/gpu:4",
+            ),
+            "script": "#!/bin/bash\n. /etc/profile.d/modules.sh\nsrun job",
+        },
     )
 
     # Check the service registered success

--- a/tests/services/test_cluster_submission.py
+++ b/tests/services/test_cluster_submission.py
@@ -115,27 +115,21 @@ def test_cluster_submission_recipeless(
     mock_requests.Session().post.assert_called_with(
         url="/slurm/url/slurm/v0.0.40/job/submit",
         json={
-            "job": cluster_submission.JobParams(
-                cpus_per_task=3,
-                current_working_directory=str(tmp_path),
-                environment=["USER=user"],
-                name="test_job",
-                nodes="1",
-                partition="part",
-                prefer="preferred_part",
-                tasks=2,
-                memory_per_cpu=cluster_submission.SlurmInt(
-                    set=True, infinite=False, number=10
-                ),
-                memory_per_node=cluster_submission.SlurmInt(
-                    set=True, infinite=False, number=20
-                ),
-                time_limit=cluster_submission.SlurmInt(
-                    set=True, infinite=False, number=5
-                ),
-                tres_per_node="gres/gpu:4",
-                tres_per_job="gres/gpu:4",
-            ),
+            "job": {
+                "cpus_per_task": 3,
+                "current_working_directory": str(tmp_path),
+                "environment": ["USER=user"],
+                "name": "test_job",
+                "nodes": "1",
+                "partition": "part",
+                "prefer": "preferred_part",
+                "tasks": 2,
+                "memory_per_cpu": {"set": True, "infinite": False, "number": 10},
+                "memory_per_node": {"set": True, "infinite": False, "number": 20},
+                "time_limit": {"set": True, "infinite": False, "number": 5},
+                "tres_per_node": "gres/gpu:4",
+                "tres_per_job": "gres/gpu:4",
+            },
             "script": "#!/bin/bash\n. /etc/profile.d/modules.sh\nsrun job",
         },
     )
@@ -204,16 +198,16 @@ def test_cluster_submission_recipefile(
     mock_requests.Session().post.assert_called_with(
         url="/slurm/url/slurm/v0.0.40/job/submit",
         json={
-            "job": cluster_submission.JobParams(
-                cpus_per_task=3,
-                current_working_directory=str(tmp_path),
-                environment=["USER=user"],
-                name="test_job",
-                nodes="1",
-                partition="part",
-                prefer="preferred_part",
-                tasks=2,
-            ),
+            "job": {
+                "cpus_per_task": 3,
+                "current_working_directory": str(tmp_path),
+                "environment": ["USER=user"],
+                "name": "test_job",
+                "nodes": "1",
+                "partition": "part",
+                "prefer": "preferred_part",
+                "tasks": 2,
+            },
             "script": f"#!/bin/bash\n. /etc/profile.d/modules.sh\nsrun {tmp_path}/recipefile",
         },
     )
@@ -281,16 +275,16 @@ def test_cluster_submission_recipeenvironment(
     mock_requests.Session().post.assert_called_with(
         url="/slurm/url/slurm/v0.0.40/job/submit",
         json={
-            "job": cluster_submission.JobParams(
-                cpus_per_task=3,
-                current_working_directory=str(tmp_path),
-                environment=["USER=user"],
-                name="test_job",
-                nodes="1",
-                partition="part",
-                prefer="preferred_part",
-                tasks=2,
-            ),
+            "job": {
+                "cpus_per_task": 3,
+                "current_working_directory": str(tmp_path),
+                "environment": ["USER=user"],
+                "name": "test_job",
+                "nodes": "1",
+                "partition": "part",
+                "prefer": "preferred_part",
+                "tasks": 2,
+            },
             "script": f"#!/bin/bash\n. /etc/profile.d/modules.sh\nsrun job {tmp_path}/recipe_env",
         },
     )
@@ -371,16 +365,16 @@ def test_cluster_submission_recipewrapper(
     mock_requests.Session().post.assert_called_with(
         url="/slurm/url/slurm/v0.0.40/job/submit",
         json={
-            "job": cluster_submission.JobParams(
-                cpus_per_task=3,
-                current_working_directory=str(tmp_path),
-                environment=["USER=user"],
-                name="test_job",
-                nodes="1",
-                partition="part",
-                prefer="preferred_part",
-                tasks=2,
-            ),
+            "job": {
+                "cpus_per_task": 3,
+                "current_working_directory": str(tmp_path),
+                "environment": ["USER=user"],
+                "name": "test_job",
+                "nodes": "1",
+                "partition": "part",
+                "prefer": "preferred_part",
+                "tasks": 2,
+            },
             "script": f"#!/bin/bash\n. /etc/profile.d/modules.sh\nsrun job {tmp_path}/recipe_wrapper",
         },
     )
@@ -456,27 +450,21 @@ def test_cluster_submission_extra_cluster(
     mock_requests.Session().post.assert_called_with(
         url="/slurm/extra/url/slurm/v0.0.41/job/submit",
         json={
-            "job": cluster_submission.JobParams(
-                cpus_per_task=3,
-                current_working_directory=str(tmp_path),
-                environment=["USER=user"],
-                name="test_job",
-                nodes="1",
-                partition="part",
-                prefer="preferred_part",
-                tasks=2,
-                memory_per_cpu=cluster_submission.SlurmInt(
-                    set=True, infinite=False, number=10
-                ),
-                memory_per_node=cluster_submission.SlurmInt(
-                    set=True, infinite=False, number=20
-                ),
-                time_limit=cluster_submission.SlurmInt(
-                    set=True, infinite=False, number=5
-                ),
-                tres_per_node="gres/gpu:4",
-                tres_per_job="gres/gpu:4",
-            ),
+            "job": {
+                "cpus_per_task": 3,
+                "current_working_directory": str(tmp_path),
+                "environment": ["USER=user"],
+                "name": "test_job",
+                "nodes": "1",
+                "partition": "part",
+                "prefer": "preferred_part",
+                "tasks": 2,
+                "memory_per_cpu": {"set": True, "infinite": False, "number": 10},
+                "memory_per_node": {"set": True, "infinite": False, "number": 20},
+                "time_limit": {"set": True, "infinite": False, "number": 5},
+                "tres_per_node": "gres/gpu:4",
+                "tres_per_job": "gres/gpu:4",
+            },
             "script": "#!/bin/bash\n. /etc/profile.d/modules.sh\nsrun job",
         },
     )

--- a/tests/wrappers/test_class2d_wrapper.py
+++ b/tests/wrappers/test_class2d_wrapper.py
@@ -123,8 +123,7 @@ def test_class2d_wrapper_incomplete_batch(
     )
 
     # Set up and run the mock service
-    service_wrapper = class2d_wrapper.Class2DWrapper()
-    service_wrapper.set_recipe_wrapper(recipe_wrapper)
+    service_wrapper = class2d_wrapper.Class2DWrapper(recipe_wrapper)
     service_wrapper.run()
 
     # Check the expected command was run
@@ -331,8 +330,7 @@ def test_class2d_wrapper_complete_batch(
     )
 
     # Set up and run the mock service
-    service_wrapper = class2d_wrapper.Class2DWrapper()
-    service_wrapper.set_recipe_wrapper(recipe_wrapper)
+    service_wrapper = class2d_wrapper.Class2DWrapper(recipe_wrapper)
     service_wrapper.run()
 
     # Check the expected command was run
@@ -467,8 +465,7 @@ def test_class2d_wrapper_rerun_buffer_lookup(
     )
 
     # Set up and run the mock service
-    service_wrapper = class2d_wrapper.Class2DWrapper()
-    service_wrapper.set_recipe_wrapper(recipe_wrapper)
+    service_wrapper = class2d_wrapper.Class2DWrapper(recipe_wrapper)
     service_wrapper.run()
 
     # Check the expected message send to ispyb
@@ -572,8 +569,7 @@ def test_class2d_wrapper_failure_releases_hold(
     )
 
     # Set up and run the mock service
-    service_wrapper = class2d_wrapper.Class2DWrapper()
-    service_wrapper.set_recipe_wrapper(recipe_wrapper)
+    service_wrapper = class2d_wrapper.Class2DWrapper(recipe_wrapper)
     service_wrapper.run()
 
     # Check the expected message sends to the node creator and murfey

--- a/tests/wrappers/test_class3d_wrapper.py
+++ b/tests/wrappers/test_class3d_wrapper.py
@@ -144,8 +144,7 @@ def test_class3d_wrapper_do_initial_model(
     )
 
     # Set up and run the mock service
-    service_wrapper = class3d_wrapper.Class3DWrapper()
-    service_wrapper.set_recipe_wrapper(recipe_wrapper)
+    service_wrapper = class3d_wrapper.Class3DWrapper(recipe_wrapper)
     service_wrapper.run()
 
     # Check the initial model command
@@ -481,8 +480,7 @@ def test_class3d_wrapper_has_initial_model(
     )
 
     # Set up and run the mock service
-    service_wrapper = class3d_wrapper.Class3DWrapper()
-    service_wrapper.set_recipe_wrapper(recipe_wrapper)
+    service_wrapper = class3d_wrapper.Class3DWrapper(recipe_wrapper)
     service_wrapper.run()
 
     # Check the expected 3D classifcation command was run
@@ -720,8 +718,7 @@ def test_class3d_wrapper_for_refinement(
     )
 
     # Set up and run the mock service
-    service_wrapper = class3d_wrapper.Class3DWrapper()
-    service_wrapper.set_recipe_wrapper(recipe_wrapper)
+    service_wrapper = class3d_wrapper.Class3DWrapper(recipe_wrapper)
     service_wrapper.run()
 
     # No need to check classification command and ispyb messages again

--- a/tests/wrappers/test_clem_align_and_merge.py
+++ b/tests/wrappers/test_clem_align_and_merge.py
@@ -350,11 +350,10 @@ def test_align_and_merge_wrapper(
     }
 
     # Set a recipe wrapper with the correct dictionaries
-    recipe_wraper = RecipeWrapper(message=message, transport=offline_transport)
+    recipe_wrapper = RecipeWrapper(message=message, transport=offline_transport)
 
     # Manually start up the function wrapper
-    align_and_merge_wrapper = AlignAndMergeWrapper()
-    align_and_merge_wrapper.set_recipe_wrapper(recipe_wraper)
+    align_and_merge_wrapper = AlignAndMergeWrapper(recipe_wrapper)
     result = align_and_merge_wrapper.run()
 
     # Start checking the calls that take place within the function

--- a/tests/wrappers/test_clem_process_raw_lifs.py
+++ b/tests/wrappers/test_clem_process_raw_lifs.py
@@ -400,8 +400,7 @@ def test_lif_to_stack_wrapper(
     recipe_wrapper = RecipeWrapper(message=message, transport=offline_transport)
 
     # Manually start up the function wrapper
-    lif_to_stack_wrapper = LIFToStackWrapper()
-    lif_to_stack_wrapper.set_recipe_wrapper(recipe_wrapper)
+    lif_to_stack_wrapper = LIFToStackWrapper(recipe_wrapper)
     return_code = lif_to_stack_wrapper.run()
 
     # Start checking the calls that take place when running the function

--- a/tests/wrappers/test_clem_process_raw_tiffs.py
+++ b/tests/wrappers/test_clem_process_raw_tiffs.py
@@ -86,8 +86,7 @@ def test_tiff_to_stack_wrapper(
     recipe_wrapper = RecipeWrapper(message=message, transport=offline_transport)
 
     # Manually start up the function wrapper
-    tiff_to_stack_wrapper = TIFFToStackWrapper()
-    tiff_to_stack_wrapper.set_recipe_wrapper(recipe_wrapper)
+    tiff_to_stack_wrapper = TIFFToStackWrapper(recipe_wrapper)
     return_code = tiff_to_stack_wrapper.run()
 
     # Start checking the calls that take place when running the function

--- a/tests/wrappers/test_refine3d_wrapper.py
+++ b/tests/wrappers/test_refine3d_wrapper.py
@@ -137,8 +137,7 @@ def test_refine3d_wrapper_with_mask(
     )
 
     # Set up and run the mock service
-    service_wrapper = refine3d_wrapper.Refine3DWrapper()
-    service_wrapper.set_recipe_wrapper(recipe_wrapper)
+    service_wrapper = refine3d_wrapper.Refine3DWrapper(recipe_wrapper)
     service_wrapper.run()
 
     # Check the expected refinement command was run
@@ -341,8 +340,7 @@ def test_refine3d_wrapper_no_mask(
     )
 
     # Set up and run the mock service
-    service_wrapper = refine3d_wrapper.Refine3DWrapper()
-    service_wrapper.set_recipe_wrapper(recipe_wrapper)
+    service_wrapper = refine3d_wrapper.Refine3DWrapper(recipe_wrapper)
     service_wrapper.run()
 
     # Check the expected refinement command was run


### PR DESCRIPTION
The dependency on zocalo is not needed now, as we were just importing a few classes which we don't need many of the attributes from. This adds what we need of them to this repo, so we can remove the dependency.

One complication which needs addressing in future is we still have an ex-zocalo `cluster_submission.py` service as well as a `slurm_submission.py` which other services access.