### PR TITLE
Add code to calculate the efficiency of angular distributions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ dev = [
     "clem.lif_to_stack" = "cryoemservices.cli.clem_lif_to_stack:run"
     "clem.tiff_to_stack" = "cryoemservices.cli.clem_tiff_to_stack:run"
     "combine_star_files" = "cryoemservices.pipeliner_plugins.combine_star_files:main"
+    "cryoemservices.angular_efficiency" = "cryoemservices.pipeliner_plugins.angular_efficiency:run"
     "cryoemservices.dlq_rabbitmq" = "cryoemservices.cli.dlq_rabbitmq:run"
     "cryoemservices.find_symmetry" = "cryoemservices.pipeliner_plugins.symmetry_finder:run"
     "cryoemservices.reextract" = "cryoemservices.pipeliner_plugins.reextract:run"

--- a/src/cryoemservices/pipeliner_plugins/angular_efficiency.py
+++ b/src/cryoemservices/pipeliner_plugins/angular_efficiency.py
@@ -7,14 +7,14 @@ import numpy as np
 import starfile
 
 
-def efficiency_from_map(Rmap: np.ndarray, boxsize: int) -> float:
+def efficiency_from_map(psf_map: np.ndarray, boxsize: int) -> float:
     # Discard all entries below the threshold
-    thr = np.max(Rmap) / np.exp(2)
-    Rmap[Rmap < thr] = 0
+    thr = np.max(psf_map) / np.exp(2)
+    psf_map[psf_map < thr] = 0
 
     # Construct binary map of 1 inside boundary, 0 outside
     volume_map = np.zeros((boxsize, boxsize, boxsize))
-    volume_map[Rmap != 0] = 1
+    volume_map[psf_map != 0] = 1
 
     # Find the average surface radius
     area = 0.0
@@ -154,9 +154,7 @@ def find_efficiency(
 
 
 def run():
-    parser = argparse.ArgumentParser(
-        usage="cryoemservices.angular_efficiency [options]"
-    )
+    parser = argparse.ArgumentParser()
     parser.add_argument(
         "-f",
         "--file",
@@ -196,5 +194,5 @@ def run():
         theta_degrees=np.array(theta_array),
         phi_degrees=np.array(phi_array),
         boxsize=int(args.boxsize),
-        bfactor=args.bfactor,
+        bfactor=float(args.bfactor),
     )

--- a/src/cryoemservices/pipeliner_plugins/angular_efficiency.py
+++ b/src/cryoemservices/pipeliner_plugins/angular_efficiency.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import healpy as hp
+import numpy as np
+
+
+def efficiency_from_map(Rmap: np.ndarray, boxsize: int) -> float:
+    # Discard all entries below the threshold
+    thr = np.max(Rmap) / np.exp(2)
+    Rmap[Rmap < thr] = 0
+
+    # Construct binary map of 1 inside boundary, 0 outside
+    volume_map = np.zeros((boxsize, boxsize, boxsize))
+    volume_map[Rmap != 0] = 1
+
+    # Find the average surface radius
+    area = 0.0
+    average = 0.0
+    mean_sq = 0.0
+    for i in range(1, boxsize):
+        for j in range(1, boxsize):
+            for k in range(1, boxsize):
+                res = np.sqrt(
+                    (i - boxsize / 2) ** 2
+                    + (j - boxsize / 2) ** 2
+                    + (k - boxsize / 2) ** 2
+                )
+                if res != 0 and np.sum(
+                    volume_map[i - 1 : i + 1, j - 1 : j + 1, k - 1 : k + 1]
+                ) not in [0, 8]:
+                    # Mixture of 0 and 1 volume values means on surface
+                    area += 1
+                    average += res
+                    mean_sq += res**2
+    average /= area
+    mean_sq /= area
+    stdev = np.sqrt(mean_sq - average**2)
+    return 1 - 2 * stdev / average
+
+
+def map_from_angles(theta, phi, boxsize, pixel_size=0.5, bfactor=160):
+    hp_nside = 64
+
+    pixel_bins = hp.pixelfunc.ang2pix(hp_nside, theta, phi)
+    bin_ids, pixel_counts = np.unique(pixel_bins, return_counts=True)
+    all_bins = np.zeros(hp.nside2npix(hp_nside))
+    all_bins[bin_ids] = pixel_counts
+
+    unique_coords, unique_indexes, all_bins = np.unique(
+        theta * 1000 + phi, return_index=True, return_counts=True
+    )
+    theta = theta[unique_indexes]
+    phi = phi[unique_indexes]
+
+    plane_x = np.sin(theta) * np.cos(phi)
+    plane_y = np.sin(theta) * np.sin(phi)
+    plane_z = np.cos(theta)
+    plane_fits = np.transpose([plane_x, plane_y, plane_z])
+    plane_coeff_squares = (
+        plane_fits[:, 0] ** 2 + plane_fits[:, 1] ** 2 + plane_fits[:, 2] ** 2
+    )
+
+    unscaled_dist_x = plane_fits[:, 0] / plane_coeff_squares
+    unscaled_dist_y = plane_fits[:, 1] / plane_coeff_squares
+    unscaled_dist_z = plane_fits[:, 2] / plane_coeff_squares
+
+    counts = np.ones(len(theta))
+    for i in range(boxsize):
+        for j in range(boxsize):
+            for k in range(boxsize):
+                ijk = np.array([i - boxsize / 2, j - boxsize / 2, k - boxsize / 2])
+                if np.linalg.norm(ijk) < boxsize / 2 - 2:
+                    plane_distances = np.dot(plane_fits, ijk)
+                    dist_x = unscaled_dist_x * plane_distances
+                    dist_y = unscaled_dist_y * plane_distances
+                    dist_z = unscaled_dist_z * plane_distances
+                    plane_matches = (
+                        (np.abs(dist_x) < pixel_size)
+                        * (np.abs(dist_y) < pixel_size)
+                        * (np.abs(dist_z) < pixel_size)
+                    )
+                    counts[plane_matches] += np.ones(len(np.where(plane_matches)[0]))
+
+    k_array = np.zeros((boxsize, boxsize, boxsize))
+    for i in range(boxsize):
+        for j in range(boxsize):
+            for k in range(boxsize):
+                ijk = np.array([i - boxsize / 2, j - boxsize / 2, k - boxsize / 2])
+                if np.linalg.norm(ijk) < boxsize / 2 - 2:
+                    plane_distances = np.dot(plane_fits, ijk)
+                    dist_x = unscaled_dist_x * plane_distances
+                    dist_y = unscaled_dist_y * plane_distances
+                    dist_z = unscaled_dist_z * plane_distances
+                    plane_matches = (
+                        (np.abs(dist_x) <= pixel_size)
+                        * (np.abs(dist_y) <= pixel_size)
+                        * (np.abs(dist_z) <= pixel_size)
+                    )
+                    k_array[i, j, k] = np.sum(
+                        (
+                            all_bins[plane_matches]
+                            * np.exp(
+                                -bfactor / boxsize**2 * np.linalg.norm(ijk) ** 2 / 2
+                            )
+                        )
+                        / counts[plane_matches]
+                    )
+    return k_array
+
+
+def find_efficiency(theta_degrees, phi_degrees, boxsize, bfactor):
+    fourier_map = map_from_angles(
+        theta=theta_degrees * np.pi / 180,
+        phi=phi_degrees * np.pi / 180,
+        boxsize=boxsize,
+        bfactor=bfactor,
+    )
+    normalised_fourier_map = np.sqrt(fourier_map / np.sum(fourier_map))
+
+    shifted_fourier_map = np.zeros((boxsize * 2, boxsize * 2, boxsize * 2))
+    for i in range(int(boxsize / 2), int(boxsize + boxsize / 2)):
+        for j in range(int(boxsize / 2), int(boxsize + boxsize / 2)):
+            for k in range(int(boxsize / 2), int(boxsize + boxsize / 2)):
+                shifted_fourier_map[i, j, k] = normalised_fourier_map[
+                    i - int(boxsize / 2), j - int(boxsize / 2), k - int(boxsize / 2)
+                ]
+
+    # real space psf
+    map_ifft = np.abs(np.fft.ifftn(np.fft.ifftshift(shifted_fourier_map)))
+    psf_map = np.fft.fftshift(map_ifft)[
+        int(boxsize / 2) : int(boxsize + boxsize / 2),
+        int(boxsize / 2) : int(boxsize + boxsize / 2),
+        int(boxsize / 2) : int(boxsize + boxsize / 2),
+    ]
+    normalised_psf = psf_map / np.sqrt(np.sum(psf_map**2))
+
+    eff = efficiency_from_map(normalised_psf, boxsize)
+    print("Efficiency: ", eff)
+    return normalised_psf
+
+
+def Euler2Matrix(phi, theta, psi):
+    sinphi = np.sin(phi * np.pi / 180)
+    cosphi = np.cos(phi * np.pi / 180)
+    sintheta = np.sin(theta * np.pi / 180)
+    costheta = np.cos(theta * np.pi / 180)
+    sinpsi = np.sin(psi * np.pi / 180)
+    cospsi = np.cos(phi * np.pi / 180)
+
+    R = np.zeros((3, 3))
+    R[0, 0] = cospsi * costheta * cosphi - sinpsi * sinphi
+    R[0, 1] = cospsi * costheta * sinphi + sinpsi * cosphi
+    R[0, 2] = -cospsi * sintheta
+    R[1, 0] = -sinpsi * costheta * cosphi - cospsi * sinphi
+    R[1, 1] = cospsi * cosphi - sinpsi * costheta * sinphi
+    R[1, 2] = sinpsi * sintheta
+    R[2, 0] = sintheta * cosphi
+    R[2, 1] = sintheta * sinphi
+    R[2, 2] = costheta
+    return R
+
+
+def suggest_tilt(Rmap, boxsize, tiltmax=45):
+    # Discard all entries below the threshold
+    thr = np.max(Rmap) / np.exp(2)
+    Rmap[Rmap < thr] = 0
+
+    # Construct binary map of 1 inside boundary, 0 outside
+    volume_map = np.zeros((boxsize, boxsize, boxsize))
+    volume_map[Rmap != 0] = 1
+
+    res_worst = 0
+    theta_worst = 0
+    phi_worst = 0
+    for i in range(1, boxsize):
+        for j in range(1, boxsize):
+            for k in range(1, boxsize):
+                res = np.sqrt(
+                    (i - boxsize / 2) ** 2
+                    + (j - boxsize / 2) ** 2
+                    + (k - boxsize / 2) ** 2
+                )
+                if res > res_worst and np.sum(
+                    volume_map[i - 1 : i + 1, j - 1 : j + 1, k - 1 : k + 1]
+                ) not in [0, 8]:
+                    # Mixture of 0 and 1 volume values means on surface
+                    res_worst = res
+                    theta_worst = np.arccos(
+                        (k - boxsize / 2)
+                        / np.sqrt(
+                            (i - boxsize / 2) ** 2
+                            + (j - boxsize / 2) ** 2
+                            + (k - boxsize / 2) ** 2
+                        )
+                    )
+                    phi_worst = np.arctan((j - boxsize / 2) / (i - boxsize / 2 + 1e-10))
+
+    if phi_worst < 0:
+        phi_worst = phi_worst + np.pi
+        theta_worst = np.pi - theta_worst
+
+    print(phi_worst * 180 / np.pi, theta_worst * 180 / np.pi, res_worst)
+
+    # Find the surface radius
+    resmap = np.zeros((180, 180))
+    for i in range(1, boxsize):
+        for j in range(1, boxsize):
+            for k in range(1, boxsize):
+                res = np.sqrt(
+                    (i - boxsize / 2) ** 2
+                    + (j - boxsize / 2) ** 2
+                    + (k - boxsize / 2) ** 2
+                )
+                if res != 0 and np.sum(
+                    volume_map[i - 1 : i + 1, j - 1 : j + 1, k - 1 : k + 1]
+                ) not in [0, 8]:
+                    # Mixture of 0 and 1 volume values means on surface
+                    theta = np.arccos((k - dim / 2) / res) * 180 / np.pi
+                    phi = np.arctan((j - dim / 2) / (i - dim / 2 + 1e-10)) * 180 / np.pi
+                    if phi < 0:
+                        phi = phi + 180
+                        theta = 180 - theta
+                    thetaindex = int(theta)
+                    phiindex = int(phi)
+                    if phiindex == 180:
+                        phiindex = 0
+                    if thetaindex == 180:
+                        thetaindex = 0
+                    resmap[phiindex, thetaindex] = res
+
+    # Interpolation of the resolution map
+    for thetaindex in range(180):
+        for phiindex in range(180):
+            pickout_region = resmap[
+                max(phiindex - 1, 0) : min(phiindex + 2, 179),
+                max(thetaindex - 1, 0) : min(thetaindex + 2, 179),
+            ]
+            resmap[phiindex, thetaindex] = np.mean(pickout_region[pickout_region != 0])
+
+    # pass in theta, phi in radians
+    coverage = np.zeros((180, 180))
+    x1 = np.sin(theta_worst) * np.cos(phi_worst)
+    y1 = np.sin(theta_worst) * np.sin(phi_worst)
+    z1 = np.cos(theta_worst)
+
+    for theta in range(1, tiltmax):
+        for phi in range(180):
+            Rtilt = Euler2Matrix(phi + 90, theta, -90 - phi)
+            x2, y2, z2 = np.dot(Rtilt, [x1, y1, z1])
+            theta2 = np.arccos(z2) * 180 / np.pi
+            phi2 = np.arctan(y2 / x2) * 180 / np.pi
+            if phi2 < 0:
+                phi2 = phi2 + 180
+                theta2 = 180 - theta2
+            thetaindex = int(theta2)
+            phiindex = int(phi2)
+            if phiindex == 180:
+                phiindex = 0
+            if thetaindex == 180:
+                thetaindex = 0
+            coverage[phiindex, thetaindex] = theta * np.pi / 180
+
+    print(np.max(resmap), np.min(resmap[(resmap != 0) * (coverage != 0)]))
+
+    predict_res = resmap / np.cos(coverage)
+    expected_res = min(predict_res[(resmap != 0) * (coverage != 0)])
+    expected_tilt = coverage[predict_res == expected_res]
+    if expected_res < res_worst:
+        print(
+            "Found tilt", expected_tilt * 180 / np.pi, "with resolution", expected_res
+        )
+    else:
+        print("No tilt found")
+    return resmap, coverage
+
+
+if __name__ == "__main__":
+    start_time = datetime.now()
+    dim = 64
+    B = 160
+    inFile = "/dls/tmp/yxd92326/data_cef/phi27.dat"
+    angles_data = np.genfromtxt(inFile)
+    norm_psf = find_efficiency(
+        theta_degrees=angles_data[:, 1],
+        phi_degrees=angles_data[:, 0],
+        boxsize=dim,
+        bfactor=B,
+    )
+
+    resmap, coverage = suggest_tilt(norm_psf, boxsize=dim)
+    end_time = datetime.now()
+    print("Time", (end_time - start_time).total_seconds() / 3600)
+
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(3)
+    # resmap[coverage == 0] = 0
+    ax[0].imshow(resmap)
+    ax[1].imshow(coverage)
+    # plt.imshow(resmap)
+    pred_res = resmap / np.cos(coverage)
+    pred_res[coverage == 0] = 0
+    ax[2].imshow(pred_res)
+    plt.show()
+
+    # import mrcfile
+    # with mrcfile.new("/dls/tmp/yxd92326/cryoEF_v1.1.0/norm_psf.mrc", overwrite=True) as mrc:
+    #    mrc.set_data(norm_psf.astype(np.float32))

--- a/src/cryoemservices/wrappers/class3d_wrapper.py
+++ b/src/cryoemservices/wrappers/class3d_wrapper.py
@@ -15,6 +15,7 @@ from gemmi import cif
 from pydantic import BaseModel, Field, ValidationError
 from zocalo.wrapper import BaseWrapper
 
+from cryoemservices.pipeliner_plugins.angular_efficiency import find_efficiency
 from cryoemservices.util.relion_service_options import (
     RelionServiceOptions,
     update_relion_options,
@@ -478,6 +479,14 @@ class Class3DWrapper(BaseWrapper):
                     )
                 except ValueError as e:
                     self.log.warning(f"Healpix failed with error {e}")
+
+                class_efficiency = find_efficiency(
+                    theta_degrees=angles_tilt[class_numbers == class_id + 1],
+                    phi_degrees=angles_rot[class_numbers == class_id + 1],
+                )
+                self.log.info(
+                    f"Efficiency of class {class_id + 1} is {class_efficiency}"
+                )
 
         # Send classification job information to ispyb
         ispyb_parameters = []

--- a/src/cryoemservices/wrappers/class3d_wrapper.py
+++ b/src/cryoemservices/wrappers/class3d_wrapper.py
@@ -626,7 +626,7 @@ class Class3DWrapper(BaseWrapper):
             if (
                 class3d_params.batch_size == 200000
                 and class_resolutions[cid] < 11
-                and class_completenesses[cid] > 0.9
+                and class_efficiencies[cid] > 0.65
             ):
                 murfey_params["do_refinement"] = True
                 murfey_params["best_class"] = class_ids[cid]

--- a/tests/pipeliner_plugins/test_angular_efficiency.py
+++ b/tests/pipeliner_plugins/test_angular_efficiency.py
@@ -22,7 +22,7 @@ def test_find_efficiency():
     predicted_eff = angular_efficiency.find_efficiency(theta, phi, 10, 160)
 
     # cryoEF gives 0.75 for these angles, the python implementation gives 0.77
-    assert np.abs(predicted_eff - 0.75) < 0.021
+    assert np.abs(predicted_eff - 0.75) < 0.025
 
 
 @mock.patch("cryoemservices.pipeliner_plugins.angular_efficiency.find_efficiency")

--- a/tests/pipeliner_plugins/test_angular_efficiency.py
+++ b/tests/pipeliner_plugins/test_angular_efficiency.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from unittest import mock
+
+import numpy as np
+
+from cryoemservices.pipeliner_plugins import angular_efficiency
+
+
+def test_efficiency_from_map():
+    psf_map = np.arange(1000).reshape((10, 10, 10))
+    predicted_eff = angular_efficiency.efficiency_from_map(psf_map, 10)
+    assert np.isclose(predicted_eff, 0.67, rtol=0.01)
+
+
+def test_find_efficiency():
+    theta = np.arange(0, 45, 45 / 180)
+    phi = np.arange(180)
+
+    predicted_eff = angular_efficiency.find_efficiency(theta, phi, 10, 160)
+
+    # cryoEF gives 0.75 for these angles, the python implementation gives 0.77
+    assert np.abs(predicted_eff - 0.75) < 0.021
+
+
+@mock.patch("cryoemservices.pipeliner_plugins.angular_efficiency.find_efficiency")
+def test_run_find_efficiency(mock_efficiency, tmp_path):
+    data_file = tmp_path / "angles.star"
+    with open(data_file, "w") as f:
+        f.write(
+            "data_global\n\nloop_\n_dummy\n1\n\n"
+            "data_particles\n\nloop_\n_rlnAngleTilt\n_rlnAngleRot\n_rlnClassNumber\n"
+            "1 0.1 1\n2 0.2 1\n3 0.3 2\n"
+        )
+
+    sys.argv = [
+        "cryoemservices.angular_efficiency",
+        "--file",
+        str(data_file),
+        "--class_id",
+        "1",
+        "--boxsize",
+        "128",
+        "--bfactor",
+        "80",
+    ]
+    angular_efficiency.run()
+
+    mock_efficiency.assert_called_once()
+    assert (mock_efficiency.call_args.kwargs["theta_degrees"] == [1, 2]).all()
+    assert (mock_efficiency.call_args.kwargs["phi_degrees"] == [0.1, 0.2]).all()
+    assert mock_efficiency.call_args.kwargs["boxsize"] == 128
+    assert mock_efficiency.call_args.kwargs["bfactor"] == 80
+
+
+def test_find_efficiency_exists():
+    """Test the DLQ check CLI is made"""
+    result = subprocess.run(
+        [
+            "cryoemservices.angular_efficiency",
+            "--help",
+        ],
+        capture_output=True,
+    )
+    assert not result.returncode
+
+    # Find the first line of the help and strip out all the spaces and newlines
+    stdout_as_string = result.stdout.decode("utf8", "replace")
+    cleaned_help_line = (
+        stdout_as_string.split("\n\n")[0].replace("\n", "").replace(" ", "")
+    )
+    assert cleaned_help_line == (
+        "usage:cryoemservices.angular_efficiency[-h]"
+        "-fFILE[-cCLASS_ID][--boxsizeBOXSIZE][--bfactorBFACTOR]"
+    )

--- a/tests/wrappers/test_class3d_wrapper.py
+++ b/tests/wrappers/test_class3d_wrapper.py
@@ -632,12 +632,11 @@ def test_class3d_wrapper_has_initial_model(
 
 
 best_class_test_matrix = (
-    # tuple of Fractions, Resolutions, Completeness, Efficiency, Do refine?, Best class
+    # tuple of Fractions, Resolutions, Efficiency, Do refine?, Best class
     (
         [0.1, 0.2, 0.3, 0.4],
         [8, 9, 10, 11],
-        [0.95, 0.95, 0.95, 0.95],
-        [0.5, 0.5, 0.5, 0.5],
+        [0.7, 0.7, 0.7, 0.7],
         True,
         1,
     ),
@@ -645,17 +644,15 @@ best_class_test_matrix = (
     (
         [0.1, 0.2, 0.3, 0.4],
         [8, 9, 10, 11],
-        [0.8, 0.95, 0.95, 0.95],
-        [0.5, 0.5, 0.5, 0.5],
+        [0.6, 0.7, 0.7, 0.7],
         True,
         2,
     ),
-    # ^ Pick second best resolution due to completeness
+    # ^ Pick second best resolution due to efficiency
     (
         [0.1, 0.2, 0.3, 0.4],
         [8, 8, 8, 9],
-        [0.95, 0.95, 0.95, 0.95],
-        [0.5, 0.6, 0.5, 0.6],
+        [0.7, 0.8, 0.7, 0.8],
         True,
         2,
     ),
@@ -663,8 +660,7 @@ best_class_test_matrix = (
     (
         [0.1, 0.4, 0.3, 0.1],
         [8, 8, 8, 9],
-        [0.95, 0.95, 0.95, 0.95],
-        [0.5, 0.5, 0.5, 0.5],
+        [0.7, 0.7, 0.7, 0.7],
         True,
         1,
     ),
@@ -672,8 +668,7 @@ best_class_test_matrix = (
     (
         [0.1, 0.2, 0.3, 0.4],
         [11, 12, 13, 14],
-        [0.95, 0.95, 0.95, 0.95],
-        [0.5, 0.5, 0.5, 0.5],
+        [0.7, 0.7, 0.7, 0.7],
         False,
         0,
     ),
@@ -681,12 +676,11 @@ best_class_test_matrix = (
     (
         [0.1, 0.2, 0.3, 0.4],
         [8, 9, 8, 11],
-        [0.9, 0.8, 0.7, 0.6],
-        [0.5, 0.5, 0.5, 0.5],
+        [0.5, 0.6, 0.64, 0.5],
         False,
         0,
     ),
-    # ^ Don't refine, bad completeness
+    # ^ Don't refine, bad efficiency
 )
 
 
@@ -699,7 +693,7 @@ def test_class3d_wrapper_for_refinement(
     mock_recwrap_send,
     mock_subprocess,
     mock_efficiency,
-    test_classes: tuple[list[float], list[float], list[float], list[float], bool, int],
+    test_classes: tuple[list[float], list[float], list[float], bool, int],
     offline_transport,
     tmp_path,
 ):
@@ -711,7 +705,7 @@ def test_class3d_wrapper_for_refinement(
     Runs a variety of different cases to test the estimation of the best class
     """
     mock_subprocess().returncode = 0
-    mock_efficiency.side_effect = test_classes[3]
+    mock_efficiency.side_effect = test_classes[2]
 
     # Example recipe wrapper message to run the service with a few parameters varied
     class3d_test_message = {
@@ -786,8 +780,8 @@ def test_class3d_wrapper_for_refinement(
             "register": "done_3d_batch",
             "refine_dir": f"{tmp_path}/Refine3D/job",
             "class3d_dir": f"{tmp_path}/Class3D/job015",
-            "best_class": test_classes[5],
-            "do_refinement": test_classes[4],
+            "best_class": test_classes[4],
+            "do_refinement": test_classes[3],
         },
     )
 

--- a/tests/wrappers/test_class3d_wrapper.py
+++ b/tests/wrappers/test_class3d_wrapper.py
@@ -19,10 +19,11 @@ def offline_transport(mocker):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+@mock.patch("cryoemservices.wrappers.class3d_wrapper.find_efficiency")
 @mock.patch("cryoemservices.wrappers.class3d_wrapper.subprocess.run")
 @mock.patch("workflows.recipe.wrapper.RecipeWrapper.send_to")
 def test_class3d_wrapper_do_initial_model(
-    mock_recwrap_send, mock_subprocess, offline_transport, tmp_path
+    mock_recwrap_send, mock_subprocess, mock_efficiency, offline_transport, tmp_path
 ):
     """
     Send a test message to the Class3D wrapper for a first round of 50000 particles,
@@ -396,12 +397,15 @@ def test_class3d_wrapper_do_initial_model(
         },
     )
 
+    assert mock_efficiency.call_count == 2
+
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+@mock.patch("cryoemservices.wrappers.class3d_wrapper.find_efficiency")
 @mock.patch("cryoemservices.wrappers.class3d_wrapper.subprocess.run")
 @mock.patch("workflows.recipe.wrapper.RecipeWrapper.send_to")
 def test_class3d_wrapper_has_initial_model(
-    mock_recwrap_send, mock_subprocess, offline_transport, tmp_path
+    mock_recwrap_send, mock_subprocess, mock_efficiency, offline_transport, tmp_path
 ):
     """
     Send a test message to the Class3D wrapper for a second round of 100000 particles,
@@ -624,6 +628,8 @@ def test_class3d_wrapper_has_initial_model(
         },
     )
 
+    assert mock_efficiency.call_count == 2
+
 
 best_class_test_matrix = (
     # tuple of Fractions, Resolutions, Completenesses, Do refine?, Best class
@@ -642,11 +648,13 @@ best_class_test_matrix = (
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 @pytest.mark.parametrize("test_classes", best_class_test_matrix)
+@mock.patch("cryoemservices.wrappers.class3d_wrapper.find_efficiency")
 @mock.patch("cryoemservices.wrappers.class3d_wrapper.subprocess.run")
 @mock.patch("workflows.recipe.wrapper.RecipeWrapper.send_to")
 def test_class3d_wrapper_for_refinement(
     mock_recwrap_send,
     mock_subprocess,
+    mock_efficiency,
     test_classes: tuple[list[float], list[float], list[float], bool, int],
     offline_transport,
     tmp_path,
@@ -737,3 +745,5 @@ def test_class3d_wrapper_for_refinement(
             "do_refinement": test_classes[3],
         },
     )
+
+    assert mock_efficiency.call_count == 2


### PR DESCRIPTION
This implements the efficiency part of `cryoEF` using python, without the loop over particles which makes the original C code so slow.

For now, the efficiency is just requested by Class3D and logged as we cannot record into ispyb yet.

When deciding whether to refine, the logic is now:
- best resolution
- or best efficiency
- or lowest particle count
The fourier completeness threshold of 0.9 has been replaced with an efficiency threshold of 0.65