### PR TITLE
Tomogram improvements

### DIFF
--- a/src/cryoemservices/services/images_plugins.py
+++ b/src/cryoemservices/services/images_plugins.py
@@ -230,11 +230,7 @@ def mrc_central_slice(plugin_params: Callable):
     central_slice_data = central_slice_data.astype("uint8")
     im = PIL.Image.fromarray(central_slice_data, mode="L")
     im.thumbnail((512, 512))
-    try:
-        im.save(outfile)
-    except FileNotFoundError:
-        logger.error(f"Trying to save to file {outfile} but directory does not exist")
-        return False
+    im.save(outfile)
     timing = time.perf_counter() - start
 
     logger.info(
@@ -285,7 +281,7 @@ def mrc_to_apng(plugin_params: Callable):
         try:
             im_frame0 = images_to_append[0]
             im_frame0.save(outfile, save_all=True, append_images=images_to_append[1:])
-        except (IndexError, FileNotFoundError):
+        except IndexError:
             logger.error(f"Unable to save movie to file {outfile}")
             return False
     else:
@@ -403,11 +399,7 @@ def picked_particles_3d_central_slice(plugin_params: Callable):
     )
 
     outfile = str(Path(coords_file).with_suffix("")) + "_thumbnail.jpeg"
-    try:
-        colour_im.save(outfile)
-    except FileNotFoundError:
-        logger.error(f"Trying to save to file {outfile} but directory does not exist")
-        return False
+    colour_im.save(outfile)
 
     logger.info(f"3D particle picker central slice {outfile} saved")
     return outfile
@@ -447,7 +439,7 @@ def picked_particles_3d_apng(plugin_params: Callable):
     try:
         im_frame0 = images_to_append[0]
         im_frame0.save(outfile, save_all=True, append_images=images_to_append[1:])
-    except (IndexError, FileNotFoundError):
+    except IndexError:
         logger.error(f"Unable to save movie to file {outfile}")
         return False
 

--- a/src/cryoemservices/services/tomo_align.py
+++ b/src/cryoemservices/services/tomo_align.py
@@ -393,7 +393,7 @@ class TomoAlign(CommonService):
                     "-ou",
                     str(aretomo_output_path),
                     "-size",
-                    f"{scaled_x_size},{scaled_y_size},{scaled_z_size}",
+                    f"{int(scaled_x_size)},{int(scaled_y_size)},{int(scaled_z_size)}",
                     "-a",
                     "90,90,0",
                 ]

--- a/src/cryoemservices/services/tomo_align.py
+++ b/src/cryoemservices/services/tomo_align.py
@@ -531,6 +531,21 @@ class TomoAlign(CommonService):
         rw.send_to("ispyb_connector", ispyb_parameters)
 
         # Forward results to images service
+        self.log.info(f"Sending to images service {tomo_params.stack_file}")
+        rw.send_to(
+            "images",
+            {
+                "image_command": "mrc_central_slice",
+                "file": tomo_params.stack_file,
+            },
+        )
+        rw.send_to(
+            "images",
+            {
+                "image_command": "mrc_to_apng",
+                "file": tomo_params.stack_file,
+            },
+        )
         self.log.info(f"Sending to images service {aretomo_output_path}")
         rw.send_to(
             "images",

--- a/src/cryoemservices/services/tomo_align.py
+++ b/src/cryoemservices/services/tomo_align.py
@@ -606,6 +606,7 @@ class TomoAlign(CommonService):
                 {
                     "image_command": "mrc_to_jpeg",
                     "file": str(projection_mrc),
+                    "pixel_spacing": pixel_spacing,
                 },
             )
 

--- a/src/cryoemservices/services/tomo_align.py
+++ b/src/cryoemservices/services/tomo_align.py
@@ -493,7 +493,11 @@ class TomoAlign(CommonService):
                         {
                             "job_type": "relion.aligntiltseries",
                             "experiment_type": "tomography",
-                            "input_file": str(movie[0]),
+                            "input_file": str(
+                                project_dir
+                                / f"ExcludeTiltImages/job{job_number - 2:03}/tilts"
+                                / Path(movie[0]).name
+                            ),
                             "output_file": str(
                                 project_dir
                                 / f"AlignTiltSeries/job{job_number - 1:03}/tilts"

--- a/src/cryoemservices/services/tomo_align.py
+++ b/src/cryoemservices/services/tomo_align.py
@@ -689,10 +689,19 @@ class TomoAlign(CommonService):
                     "-TiltCor",
                     str(tomo_parameters.tilt_cor),
                     str(tomo_parameters.manual_tilt_offset),
+                    "-VolZ",
+                    str(int(tomo_parameters.vol_z * 4 / 3)),
                 )
             )
         elif tomo_parameters.tilt_cor:
-            command.extend(("-TiltCor", str(tomo_parameters.tilt_cor)))
+            command.extend(
+                (
+                    "-TiltCor",
+                    str(tomo_parameters.tilt_cor),
+                    "-VolZ",
+                    str(tomo_parameters.vol_z),
+                )
+            )
 
         if tomo_parameters.tilt_axis:
             command.extend(
@@ -712,7 +721,6 @@ class TomoAlign(CommonService):
             )
 
         aretomo_flags = {
-            "vol_z": "-VolZ",
             "out_bin": "-OutBin",
             "flip_int": "-FlipInt",
             "flip_vol": "-FlipVol",

--- a/tests/services/test_images_plugins.py
+++ b/tests/services/test_images_plugins.py
@@ -16,12 +16,13 @@ from cryoemservices.services.images_plugins import (
 )
 
 
-def plugin_params(jpeg_path: Path, all_frames: bool):
+def plugin_params(jpeg_path: Path, all_frames: bool, pixel_size: float = 0):
     def params(key):
         p = {
             "parameters": {"images_command": "mrc_to_jpeg"},
             "file": jpeg_path.with_suffix(".mrc"),
             "all_frames": all_frames,
+            "pixel_spacing": pixel_size,
         }
         return p.get(key)
 
@@ -78,6 +79,15 @@ def test_mrc_to_jpeg_2d_ack_when_file_exists(tmp_path):
     with mrcfile.new(jpeg_path.with_suffix(".mrc")) as mrc:
         mrc.set_data(test_data)
     assert mrc_to_jpeg(plugin_params(jpeg_path, False)) == jpeg_path
+    assert jpeg_path.is_file()
+
+
+def test_mrc_to_jpeg_2d_ack_with_scalebar(tmp_path):
+    jpeg_path = tmp_path / "convert_test.jpeg"
+    test_data = np.arange(9, dtype=np.int8).reshape(3, 3)
+    with mrcfile.new(jpeg_path.with_suffix(".mrc")) as mrc:
+        mrc.set_data(test_data)
+    assert mrc_to_jpeg(plugin_params(jpeg_path, False, 1.2)) == jpeg_path
     assert jpeg_path.is_file()
 
 


### PR DESCRIPTION
A few changes to tomo alignment and reconstruction:

- Plot a scale bar for XY and XZ projection images
- Allow for post-reconstruction tomgram rotations to avoid having to use FlipVol in AreTomo which produces varying orientations
- Insert tomogram sizes into ispyb
- AlignTiltSeries jobs should take ExcludeTiltSeries as input
- Make apng images of unaligned stacks
- Increase the reconstruction volume to 1600 if a pre-tilt is given

One question to consider is whether we want apng images of aligned stacks. That would probably required running AreTomo twice - once to get an aligned stack, then again to reconstuct. Or the reconstuction could be done with Relion if the pick locations don't match.

This will conflict with PR #122 and should go in after that