### PR TITLE
Added values used by Murfey's email notification workflow to the message sent back from cryolo

### DIFF
--- a/src/cryoemservices/services/cryolo.py
+++ b/src/cryoemservices/services/cryolo.py
@@ -454,8 +454,6 @@ class CrYOLO(CommonService):
             )
             / (Path(cryolo_params.input_path).stem + "_extract.star")
         )
-        # Load the CTF values returned by the CTFFind service
-        ctf_values: dict[str, Any] = extraction_params["ctf_values"]
 
         # Forward results to murfey
         self.log.info("Sending to Murfey for particle extraction")
@@ -467,9 +465,14 @@ class CrYOLO(CommonService):
                 "micrograph": cryolo_params.input_path,
                 "particle_diameters": list(cryolo_particle_sizes),
                 "particle_count": len(cryolo_particle_sizes),
-                "resolution": ctf_values["CtfMaxResolution"],
-                "astigmatism": ctf_values["DefocusV"] - ctf_values["DefocusU"],
-                "defocus": (ctf_values["DefocusU"] + ctf_values["DefocusV"]) / 2,
+                "resolution": cryolo_params.ctf_values["CtfMaxResolution"],
+                "astigmatism": cryolo_params.ctf_values["DefocusV"]
+                - cryolo_params.ctf_values["DefocusU"],
+                "defocus": (
+                    cryolo_params.ctf_values["DefocusU"]
+                    + cryolo_params.ctf_values["DefocusV"]
+                )
+                / 2,
                 "extraction_parameters": extraction_params,
             },
         )

--- a/src/cryoemservices/services/cryolo.py
+++ b/src/cryoemservices/services/cryolo.py
@@ -468,8 +468,8 @@ class CrYOLO(CommonService):
                 "particle_diameters": list(cryolo_particle_sizes),
                 "particle_count": len(cryolo_particle_sizes),
                 "resolution": ctf_values["CtfMaxResolution"],
-                "astigmatism": ctf_values["DefocusAngle"],
-                "defocus": ((ctf_values["DefocusU"]) + (ctf_values["DefocusV"])) / 2,
+                "astigmatism": ctf_values["DefocusV"] - ctf_values["DefocusU"],
+                "defocus": (ctf_values["DefocusU"] + ctf_values["DefocusV"]) / 2,
                 "extraction_parameters": extraction_params,
             },
         )

--- a/src/cryoemservices/services/cryolo.py
+++ b/src/cryoemservices/services/cryolo.py
@@ -439,7 +439,7 @@ class CrYOLO(CommonService):
         rw.send_to("images", images_parameters)
 
         # Gather results needed for particle extraction
-        extraction_params = {
+        extraction_params: dict[str, Any] = {
             "ctf_values": cryolo_params.ctf_values,
             "micrographs_file": cryolo_params.input_path,
             "coord_list_file": cryolo_params.output_path,
@@ -454,6 +454,8 @@ class CrYOLO(CommonService):
             )
             / (Path(cryolo_params.input_path).stem + "_extract.star")
         )
+        # Load the CTF values returned by the CTFFind service
+        ctf_values: dict[str, Any] = extraction_params["ctf_values"]
 
         # Forward results to murfey
         self.log.info("Sending to Murfey for particle extraction")
@@ -464,6 +466,10 @@ class CrYOLO(CommonService):
                 "motion_correction_id": cryolo_params.mc_uuid,
                 "micrograph": cryolo_params.input_path,
                 "particle_diameters": list(cryolo_particle_sizes),
+                "particle_count": len(cryolo_particle_sizes),
+                "resolution": ctf_values["CtfMaxResolution"],
+                "astigmatism": ctf_values["DefocusAngle"],
+                "defocus": ((ctf_values["DefocusU"]) + (ctf_values["DefocusV"])) / 2,
                 "extraction_parameters": extraction_params,
             },
         )

--- a/tests/services/test_cryolo_service.py
+++ b/tests/services/test_cryolo_service.py
@@ -39,6 +39,11 @@ def test_cryolo_service_spa(mock_subprocess, offline_transport, tmp_path):
 
     output_path = tmp_path / "AutoPick/job007/STAR/sample.star"
     cbox_path = tmp_path / "AutoPick/job007/CBOX/sample.cbox"
+    ctf_test_values = {
+        "CtfMaxResolution": 0.00001,
+        "DefocusU": 0.05,
+        "DefocusV": 0.08,
+    }
     cryolo_test_message = {
         "pixel_size": 0.1,
         "input_path": "MotionCorr/job002/sample.mrc",
@@ -52,7 +57,7 @@ def test_cryolo_service_spa(mock_subprocess, offline_transport, tmp_path):
         "mc_uuid": 0,
         "picker_uuid": 0,
         "particle_diameter": 1.1,
-        "ctf_values": {"dummy": "dummy"},
+        "ctf_values": ctf_test_values,
         "cryolo_command": "cryolo_predict.py",
         "relion_options": {"batch_size": 20000, "downscale": True},
     }
@@ -161,6 +166,10 @@ def test_cryolo_service_spa(mock_subprocess, offline_transport, tmp_path):
             "motion_correction_id": cryolo_test_message["mc_uuid"],
             "micrograph": cryolo_test_message["input_path"],
             "particle_diameters": [10.0, 20.0],
+            "particle_count": 2,
+            "resolution": ctf_test_values["CtfMaxResolution"],
+            "astigmatism": ctf_test_values["DefocusV"] - ctf_test_values["DefocusU"],
+            "defocus": (ctf_test_values["DefocusU"] + ctf_test_values["DefocusV"]) / 2,
             "extraction_parameters": extraction_params,
         },
     )


### PR DESCRIPTION
The PR at https://github.com/DiamondLightSource/python-murfey/pull/484 looks for parameters named `particle_count`, `astigmatism`, `defocus`, and `resolution` in the messages received by the feedback queue, and these values appear to be calculated as part of the CTFFind service, but are not passed on back to Murfey.

This PR adds those values to the message sent by the Cryolo service back to Murfey.