### PR TITLE
Rotate the tomograms differently if the tilt axis is zero

### DIFF
--- a/src/cryoemservices/services/motioncorr.py
+++ b/src/cryoemservices/services/motioncorr.py
@@ -285,6 +285,7 @@ class MotionCorr(CommonService):
 
         # Check if the gain file exists:
         if mc_params.gain_ref and not Path(mc_params.gain_ref).is_file():
+            self.log.warning(f"Gain reference {mc_params.gain_ref} does not exist")
             mc_params.gain_ref = ""
 
         # Generate the plotting paths

--- a/src/cryoemservices/services/tomo_align.py
+++ b/src/cryoemservices/services/tomo_align.py
@@ -413,6 +413,12 @@ class TomoAlign(CommonService):
 
         # Flip the volume if AreTomo has not done this
         if tomo_params.flip_vol_post_reconstruction and not tomo_params.flip_vol:
+            if tomo_params.tilt_axis is not None and -45 < tomo_params.tilt_axis < 45:
+                # If given tilt axis of around 0, don't do rotations
+                angles_to_flip = "0,0,-90"
+            else:
+                # Otherwise assume we need to flip (which is the behaviour for axis 90)
+                angles_to_flip = "90,-90,0"
             rotate_result = subprocess.run(
                 [
                     "rotatevol",
@@ -423,7 +429,7 @@ class TomoAlign(CommonService):
                     "-size",
                     f"{int(scaled_x_size)},{int(scaled_y_size)},{int(scaled_z_size)}",
                     "-a",
-                    "90,-90,0",
+                    angles_to_flip,
                 ]
             )
             if rotate_result.returncode:


### PR DESCRIPTION
On the talos we had orientation issues with the tomograms due to a tilt axis of zero (previously it was assumed the axis was around 90). This adds a fix for the zero case.

Also removes the edge effect on 3D apngs which we no longer need