### PR TITLE
Fix scaling of apng images

### DIFF
--- a/src/cryoemservices/services/images_plugins.py
+++ b/src/cryoemservices/services/images_plugins.py
@@ -275,6 +275,8 @@ def mrc_to_apng(plugin_params: Callable):
                 clipped_frame = np.random.choice([0, 1], np.shape(frame))
                 clipped_frame[2:-2, 2:-2] = frame[2:-2, 2:-2]
                 frame = clipped_frame.astype("uint8")
+            else:
+                frame = frame.astype("uint8")
             im = PIL.Image.fromarray(frame, mode="L")
             im.thumbnail((512, 512))
             images_to_append.append(im)

--- a/tests/services/test_images_plugins.py
+++ b/tests/services/test_images_plugins.py
@@ -183,8 +183,13 @@ def test_mrc_to_apng_skip_rescaling(mock_pil, tmp_path):
     # Check the image creation
     assert mock_pil.fromarray.call_count == 2
     mock_pil.fromarray.assert_called_with(mock.ANY, mode="L")
-    assert (mock_pil.fromarray.mock_calls[0][1] == data_3d[0] * 255 / 24).all()
-    assert (mock_pil.fromarray.mock_calls[2][1] == (data_3d[1] - 25) * 255 / 24).all()
+    assert (
+        mock_pil.fromarray.mock_calls[0][1] == (data_3d[0] * 255 / 24).astype("uint8")
+    ).all()
+    assert (
+        mock_pil.fromarray.mock_calls[2][1]
+        == ((data_3d[1] - 25) * 255 / 24).astype("uint8")
+    ).all()
     mock_pil.fromarray().thumbnail.assert_called_with((512, 512))
 
 

--- a/tests/services/test_images_service.py
+++ b/tests/services/test_images_service.py
@@ -27,7 +27,7 @@ def test_plugins_exist():
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
 @mock.patch("cryoemservices.services.images_plugins.picked_particles")
-def test_images_call(mock_picker_image):
+def test_images_call_rw(mock_picker_image):
     """
     Send a test message to the images service
     """
@@ -51,6 +51,30 @@ def test_images_call(mock_picker_image):
     # Check the correct calls were made
     mock_picker_image.assert_called_once()
     mock_recipe_wrapper.transport.ack.assert_called()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+@mock.patch("cryoemservices.services.images_plugins.picked_particles")
+def test_images_call_simple_message(mock_picker_image):
+    """
+    Send a test message to the images service
+    """
+    header = {
+        "message-id": mock.sentinel,
+        "subscription": mock.sentinel,
+    }
+    images_test_message = {"image_command": "picked_particles"}
+
+    # Set up the mock service
+    service = images.Images(environment={"queue": ""})
+    service.transport = mock.Mock()
+    service.start()
+
+    # Send a message to the service
+    service.image_call(None, header=header, message=images_test_message)
+
+    # Check the correct calls were made
+    mock_picker_image.assert_called_once()
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")


### PR DESCRIPTION
A previous change resulted in some apng images not being of uint8 format, which displayed wrong.

This corrects that, and also allows the images service to take in simple messages.