### PR TITLE
Allow refinement at any efficiency if symmetry is provided

### DIFF
--- a/src/cryoemservices/wrappers/class3d_wrapper.py
+++ b/src/cryoemservices/wrappers/class3d_wrapper.py
@@ -626,7 +626,7 @@ class Class3DWrapper:
             if (
                 class3d_params.batch_size == 200000
                 and class_resolutions[cid] < 11
-                and class_efficiencies[cid] > 0.65
+                and (class_efficiencies[cid] > 0.65 or class3d_params.symmetry != "C1")
             ):
                 murfey_params["do_refinement"] = True
                 murfey_params["best_class"] = class_ids[cid]


### PR DESCRIPTION
We end up not refining if a symmetry is provided, because the efficiency is low due to the assignment of particles to the symmetry.

I'd suggest we just ignore efficiency if symmetry is provided and refine anything with reasonable resolution.