### PR TITLE
Fixed RabbitMQ DLQ message reinjection CLI

### DIFF
--- a/src/cryoemservices/cli/dlq_rabbitmq.py
+++ b/src/cryoemservices/cli/dlq_rabbitmq.py
@@ -55,9 +55,7 @@ def check_dlq_rabbitmq(rabbitmq_credentials: Path) -> dict:
     return {
         q.name: q.messages
         for q in rmq.queues()
-        if q.name.startswith("dlq.")
-        and q.vhost == rabbitmq_connection["vhost"]
-        and q.messages
+        if q.name.startswith("dlq.") and q.messages
     }
 
 


### PR DESCRIPTION
After the recent overhaul to our RabbitMQ service, we apparently no longer use the `vhost` key in our config file. This breaks the CLI tool, which still looks for `vhost` in the dictionary it receives. This PR fixes that by removing that requirement.