### PR TITLE
Do not flatten picked images in the class selection service

### DIFF
--- a/src/cryoemservices/services/cryolo.py
+++ b/src/cryoemservices/services/cryolo.py
@@ -560,7 +560,7 @@ def flatten_grid_bars(micrograph_mrc: Path) -> Path:
         full_image = mrc.data
 
     new_image_data = grid_bar_histogram(full_image)
-    if new_image_data:
+    if new_image_data is not None:
         flat_micrograph = micrograph_mrc.parent / (micrograph_mrc.stem + "_flat.mrc")
         with mrcfile.new(flat_micrograph, overwrite=True) as mrc:
             mrc.set_data(new_image_data)

--- a/src/cryoemservices/services/images_plugins.py
+++ b/src/cryoemservices/services/images_plugins.py
@@ -138,7 +138,7 @@ def picked_particles(plugin_params: Callable):
 
     if plugin_params("flatten_image"):
         flat_data = grid_bar_histogram(data)
-        if flat_data:
+        if flat_data is not None:
             contrast_factor = 1
             data = flat_data
 

--- a/src/cryoemservices/services/images_plugins.py
+++ b/src/cryoemservices/services/images_plugins.py
@@ -12,6 +12,8 @@ import PIL.Image
 import starfile
 from PIL import ImageDraw, ImageEnhance, ImageFilter, ImageFont
 
+from cryoemservices.services.cryolo import grid_bar_histogram
+
 logger = logging.getLogger("cryoemservices.services.images_plugins")
 logger.setLevel(logging.INFO)
 
@@ -133,6 +135,13 @@ def picked_particles(plugin_params: Callable):
             f"File {basefilename} could not be opened. It may be corrupted or not in mrc format"
         )
         return False
+
+    if plugin_params("flatten_image"):
+        flat_data = grid_bar_histogram(data)
+        if flat_data:
+            contrast_factor = 1
+            data = flat_data
+
     mean = np.mean(data)
     sdev = np.std(data)
     sigma_min = mean - 3 * sdev

--- a/src/cryoemservices/services/select_classes.py
+++ b/src/cryoemservices/services/select_classes.py
@@ -20,7 +20,6 @@ from cryoemservices.pipeliner_plugins.combine_star_files import (
     split_star_file,
 )
 from cryoemservices.services.common_service import CommonService
-from cryoemservices.services.cryolo import flatten_grid_bars
 from cryoemservices.util.models import MockRW
 from cryoemservices.util.relion_service_options import RelionServiceOptions
 
@@ -510,32 +509,19 @@ class SelectClasses(CommonService):
             except FileNotFoundError:
                 coords = []
 
-            # Try and scale out any dark areas, for example gold grids
-            try:
-                scaled_input_path = flatten_grid_bars(motioncorr_file)
-            except IndexError as e:
-                self.log.error(f"Making flat image failed with error: {e}")
-                scaled_input_path = motioncorr_file
-
             # Generate image of selected and non-selected picks
             rw.send_to(
                 "images",
                 {
                     "image_command": "picked_particles",
-                    "file": str(scaled_input_path),
+                    "file": str(motioncorr_file),
                     "coordinates": coords,
                     "selected_coordinates": selected_coords,
                     "pixel_size": original_pixel_size,
                     "diameter": autoselect_params.particle_diameter,
                     "outfile": str(Path(cryolo_output_path).with_suffix(".jpeg")),
-                    "remove_input": (
-                        True
-                        if str(scaled_input_path) != str(motioncorr_file)
-                        else False
-                    ),
-                    "contrast_factor": (
-                        1 if str(scaled_input_path) != str(motioncorr_file) else 6
-                    ),
+                    "remove_input": False,
+                    "flatten_image": True,
                 },
             )
 

--- a/tests/services/test_images_plugins.py
+++ b/tests/services/test_images_plugins.py
@@ -36,6 +36,7 @@ def plugin_params_central(jpeg_path, skip_rescaling=False, jitter_edge=False):
             "file": jpeg_path.with_suffix(".mrc"),
             "skip_rescaling": skip_rescaling,
             "jitter_edge": jitter_edge,
+            "flatten_image": True,
         }
         return p.get(key)
 

--- a/tests/services/test_images_plugins.py
+++ b/tests/services/test_images_plugins.py
@@ -36,7 +36,6 @@ def plugin_params_central(jpeg_path, skip_rescaling=False, jitter_edge=False):
             "file": jpeg_path.with_suffix(".mrc"),
             "skip_rescaling": skip_rescaling,
             "jitter_edge": jitter_edge,
-            "flatten_image": True,
         }
         return p.get(key)
 
@@ -52,6 +51,7 @@ def plugin_params_parpick(jpeg_path, outfile):
             "angpix": 0.5,
             "diameter": 190,
             "outfile": outfile,
+            "flatten_image": True,
         }
         return p.get(key) or default
 

--- a/tests/services/test_select_classes_service.py
+++ b/tests/services/test_select_classes_service.py
@@ -270,7 +270,7 @@ def test_select_classes_service_first_batch(
             "diameter": 100.0,
             "outfile": f"{tmp_path}/AutoPick/job007/STAR/movie.jpeg",
             "remove_input": False,
-            "contrast_factor": 6,
+            "flatten_image": True,
         },
     )
     offline_transport.send.assert_any_call(


### PR DESCRIPTION
The class selection service has to process too many images for it to be viable to run the flattening in there.

This instead gets the images service to do it.