### PR TITLE
Cryodann particles selection fixes

### DIFF
--- a/src/cryoemservices/pipeliner_plugins/combine_star_files.py
+++ b/src/cryoemservices/pipeliner_plugins/combine_star_files.py
@@ -38,9 +38,10 @@ def combine_star_files(files_to_process: List[Path], output_dir: Path):
 
     # Make a temporary star file to get the table headings from
     reference_optics = None
-    with open(files_to_process[0], "r") as full_starfile, open(
-        output_dir / ".particles_tmp.star", "w"
-    ) as tmp_starfile:
+    with (
+        open(files_to_process[0], "r") as full_starfile,
+        open(output_dir / ".particles_tmp.star", "w") as tmp_starfile,
+    ):
         for line_counter in range(50):
             line = full_starfile.readline()
             if line.startswith("opticsGroup"):
@@ -95,9 +96,10 @@ def combine_star_files(files_to_process: List[Path], output_dir: Path):
 
         # Add the particles lines to the final star file
         file_particles_count = 0
-        with open(split_file, "r") as added_starfile, open(
-            output_dir / ".particles_all_tmp.star", "a"
-        ) as particles_file:
+        with (
+            open(split_file, "r") as added_starfile,
+            open(output_dir / ".particles_all_tmp.star", "a") as particles_file,
+        ):
             while True:
                 particle_line = added_starfile.readline()
                 if not particle_line:
@@ -131,12 +133,14 @@ def split_star_file(
     """
 
     # Make a temporary star file to get the table headings from
-    with open(file_to_process, "r") as full_starfile, open(
-        output_dir / ".particles_tmp.star", "w"
-    ) as tmp_starfile:
+    with (
+        open(file_to_process, "r") as full_starfile,
+        open(output_dir / ".particles_tmp.star", "w") as tmp_starfile,
+    ):
         for line_counter in range(50):
             line = full_starfile.readline()
             if not line:
+                line_counter -= 1
                 break
             tmp_starfile.write(line)
 
@@ -144,7 +148,7 @@ def split_star_file(
     (output_dir / ".particles_tmp.star").unlink()
 
     # Find the number of lines in the full file
-    starfile_starter_lines = line_counter - star_dictionary["particles"].shape[0]
+    starfile_starter_lines = line_counter + 1 - star_dictionary["particles"].shape[0]
     count = 0
     with open(file_to_process, "r") as full_starfile:
         for count, line in enumerate(full_starfile):

--- a/tests/services/test_select_classes_service.py
+++ b/tests/services/test_select_classes_service.py
@@ -334,7 +334,7 @@ def test_select_classes_service_cryodann(mock_subprocess, offline_transport, tmp
 
     # Write the output class scores
     with open(tmp_path / "Select/job012/rank_model.star", "w") as rank_star:
-        rank_star.write("data_\n\nloop_\n_rlnClassScore\n5\n4\n3\n2\n1\n")
+        rank_star.write("data_model_classes\n\nloop_\n_rlnClassScore\n5\n4\n3\n2\n1\n")
 
     # Set up the mock service and send the message to it
     service = select_classes.SelectClasses(
@@ -354,12 +354,11 @@ def test_select_classes_service_cryodann(mock_subprocess, offline_transport, tmp
     assert output_data_star["particles"]["rlnParticleScore"][1] == 8
 
     # Check that the correct messages were sent (and no score was sent to murfey)
-    print(offline_transport.send.call_args_list)
-    assert offline_transport.send.call_count == 6
-    assert (
+    assert offline_transport.send.call_count == 7
+    offline_transport.send.assert_any_call(
         "murfey_feedback",
-        {"register": "save_class_selection_score", "class_selection_score": mock.ANY},
-    ) not in offline_transport.send.call_args_list
+        {"register": "save_class_selection_score", "class_selection_score": 3},
+    )
     offline_transport.send.assert_any_call(
         "murfey_feedback",
         {


### PR DESCRIPTION
Murfey always needs a class selection score to flush 2D classification. The score no longer corresponds with selected particles, but this sends the score from the Relion class selection anyway.

Also the last key in the particle batch files was duplicated, due to an issue with line counting, which is fixed here.