### PR TITLE
Adjustments to star files written by tomography

### DIFF
--- a/src/cryoemservices/services/node_creator.py
+++ b/src/cryoemservices/services/node_creator.py
@@ -465,24 +465,29 @@ class NodeCreator(CommonService):
         extra_output_nodes = None
         if job_info.success:
             # Write the output files which Relion produces
-            if job_info.experiment_type == "spa":
-                extra_output_nodes = create_spa_output_files(
-                    job_type=job_info.job_type,
-                    job_dir=relative_job_dir,
-                    input_file=relative_input_file,
-                    output_file=relative_output_file,
-                    relion_options=job_info.relion_options,
-                    results=job_info.results,
-                )
-            else:
-                extra_output_nodes = create_tomo_output_files(
-                    job_type=job_info.job_type,
-                    job_dir=relative_job_dir,
-                    input_file=relative_input_file,
-                    output_file=relative_output_file,
-                    relion_options=job_info.relion_options,
-                    results=job_info.results,
-                )
+            try:
+                if job_info.experiment_type == "spa":
+                    extra_output_nodes = create_spa_output_files(
+                        job_type=job_info.job_type,
+                        job_dir=relative_job_dir,
+                        input_file=relative_input_file,
+                        output_file=relative_output_file,
+                        relion_options=job_info.relion_options,
+                        results=job_info.results,
+                    )
+                else:
+                    extra_output_nodes = create_tomo_output_files(
+                        job_type=job_info.job_type,
+                        job_dir=relative_job_dir,
+                        input_file=relative_input_file,
+                        output_file=relative_output_file,
+                        relion_options=job_info.relion_options,
+                        results=job_info.results,
+                    )
+            except FileNotFoundError as e:
+                self.log.error(f"Cannot find expected file: {e}", exc_info=True)
+                rw.transport.ack(header)
+                return
             if extra_output_nodes:
                 # Add any extra nodes if they are not already present
                 existing_nodes = []

--- a/src/cryoemservices/services/node_creator.py
+++ b/src/cryoemservices/services/node_creator.py
@@ -486,7 +486,7 @@ class NodeCreator(CommonService):
                     )
             except FileNotFoundError as e:
                 self.log.error(f"Cannot find expected file: {e}", exc_info=True)
-                rw.transport.ack(header)
+                rw.transport.nack(header)
                 return
             if extra_output_nodes:
                 # Add any extra nodes if they are not already present

--- a/src/cryoemservices/services/tomo_align.py
+++ b/src/cryoemservices/services/tomo_align.py
@@ -523,9 +523,12 @@ class TomoAlign(CommonService):
         (project_dir / f"ExcludeTiltImages/job{job_number - 2:03}").mkdir(
             parents=True, exist_ok=True
         )
-        (project_dir / f"ExcludeTiltImages/job{job_number - 2:03}/tilts").symlink_to(
-            project_dir / "MotionCorr/job002/Movies"
-        )
+        if not (
+            project_dir / f"ExcludeTiltImages/job{job_number - 2:03}/tilts"
+        ).exists():
+            (
+                project_dir / f"ExcludeTiltImages/job{job_number - 2:03}/tilts"
+            ).symlink_to(project_dir / "MotionCorr/job002/Movies")
         (project_dir / f"AlignTiltSeries/job{job_number - 1:03}").mkdir(
             parents=True, exist_ok=True
         )

--- a/src/cryoemservices/services/tomo_align.py
+++ b/src/cryoemservices/services/tomo_align.py
@@ -549,7 +549,9 @@ class TomoAlign(CommonService):
                         {
                             "job_type": "relion.excludetilts",
                             "experiment_type": "tomography",
-                            "input_file": str(movie[0]),
+                            "input_file": movie[0].replace(
+                                "MotionCorr/job002", "CtfFind/job003"
+                            ),
                             "output_file": str(
                                 project_dir
                                 / f"ExcludeTiltImages/job{job_number - 2:03}/tilts"

--- a/src/cryoemservices/services/tomo_align.py
+++ b/src/cryoemservices/services/tomo_align.py
@@ -523,9 +523,14 @@ class TomoAlign(CommonService):
         (project_dir / f"ExcludeTiltImages/job{job_number - 2:03}").mkdir(
             parents=True, exist_ok=True
         )
+        (project_dir / f"ExcludeTiltImages/job{job_number - 2:03}/tilts").symlink_to(
+            project_dir / "MotionCorr/job002/Movies"
+        )
         (project_dir / f"AlignTiltSeries/job{job_number - 1:03}").mkdir(
             parents=True, exist_ok=True
         )
+        if self.rot:
+            tomo_params.relion_options.tilt_axis_angle = self.rot
         for im, movie in enumerate(self.input_file_list_of_lists):
             if im + 1 in missing_indices:
                 im_diff += 1

--- a/src/cryoemservices/util/tomo_output_files.py
+++ b/src/cryoemservices/util/tomo_output_files.py
@@ -350,8 +350,12 @@ def _exclude_tilt_output_files(
             / (f"CtfFind/job{job_number + 1:03}")
             / relative_tilt.with_suffix(".txt")
         )
+        micrograph_name = str(input_file)
     else:
         ctf_txt_file = input_file.with_suffix(".txt")
+        micrograph_name = str(input_file.with_suffix(".mrc")).replace(
+            "CtfFind/job003", "MotionCorr/job002"
+        )
 
     # Later extraction jobs require some ctf parameters for the tilts
     with open(ctf_txt_file, "r") as f:
@@ -363,7 +367,7 @@ def _exclude_tilt_output_files(
         str(relion_options.tilt_axis_angle),
         str(tilt_number * relion_options.frame_count * relion_options.dose_per_frame),
         str(relion_options.defocus),
-        str(input_file),
+        micrograph_name,
         ctf_results[1],
         ctf_results[2],
         ctf_results[3],

--- a/src/cryoemservices/util/tomo_output_files.py
+++ b/src/cryoemservices/util/tomo_output_files.py
@@ -347,7 +347,7 @@ def _exclude_tilt_output_files(
         )
         ctf_txt_file = (
             job_dir.parent.parent
-            / (f"CtfFind/job{job_number + 1:03}")
+            / f"CtfFind/job{job_number + 1:03}"
             / relative_tilt.with_suffix(".txt")
         )
         micrograph_name = str(input_file)
@@ -429,19 +429,34 @@ def _align_tilt_output_files(
         (job_dir / "tilt_series").mkdir()
 
     # Try and figure out where the CTF output files will be
-    mc_job_num_search = re.search("/job[0-9]+", str(input_file))
-    if "MotionCorr" in input_file.parts and mc_job_num_search:
-        job_number = int(mc_job_num_search[0][4:])
+    job_num_search = re.search("/job[0-9]+", str(input_file))
+    if "MotionCorr" in input_file.parts and job_num_search:
+        job_number = int(job_num_search[0][4:])
         relative_tilt = input_file.relative_to(
             f"{job_dir.parent.parent}/MotionCorr/job{job_number:03}"
         )
         ctf_txt_file = (
             job_dir.parent.parent
-            / (f"CtfFind/job{job_number + 1:03}")
+            / f"CtfFind/job{job_number + 1:03}"
             / relative_tilt.with_suffix(".txt")
         )
+        micrograph_name = str(input_file)
+    elif "ExcludeTiltImages" in input_file.parts and job_num_search:
+        job_number = int(job_num_search[0][4:])
+        relative_tilt = input_file.relative_to(
+            f"{job_dir.parent.parent}/ExcludeTiltImages/job{job_number:03}/tilts"
+        )
+        ctf_txt_file = (
+            job_dir.parent.parent
+            / f"CtfFind/job{job_number - 1:03}/Movies"
+            / relative_tilt.with_suffix(".txt")
+        )
+        micrograph_name = str(input_file)
     else:
         ctf_txt_file = input_file.with_suffix(".txt")
+        micrograph_name = str(input_file.with_suffix(".mrc")).replace(
+            "CtfFind/job003", "MotionCorr/job002"
+        )
 
     # Later extraction jobs require some ctf parameters for the tilts
     with open(ctf_txt_file, "r") as f:
@@ -453,7 +468,7 @@ def _align_tilt_output_files(
         str(relion_options.tilt_axis_angle),
         str(tilt_number * relion_options.frame_count * relion_options.dose_per_frame),
         str(relion_options.defocus),
-        str(input_file),
+        micrograph_name,
         ctf_results[1],
         ctf_results[2],
         ctf_results[3],

--- a/src/cryoemservices/util/tomo_output_files.py
+++ b/src/cryoemservices/util/tomo_output_files.py
@@ -354,11 +354,8 @@ def _exclude_tilt_output_files(
         ctf_txt_file = input_file.with_suffix(".txt")
 
     # Later extraction jobs require some ctf parameters for the tilts
-    if ctf_txt_file.is_file():
-        with open(ctf_txt_file, "r") as f:
-            ctf_results = f.readlines()[-1].split()
-    else:
-        ctf_results = ["error", "ctf", "not", "found"]
+    with open(ctf_txt_file, "r") as f:
+        ctf_results = f.readlines()[-1].split()
 
     added_line = [
         str(relion_options.frame_count),
@@ -443,11 +440,8 @@ def _align_tilt_output_files(
         ctf_txt_file = input_file.with_suffix(".txt")
 
     # Later extraction jobs require some ctf parameters for the tilts
-    if ctf_txt_file.is_file():
-        with open(ctf_txt_file, "r") as f:
-            ctf_results = f.readlines()[-1].split()
-    else:
-        ctf_results = ["error", "ctf", "not", "found"]
+    with open(ctf_txt_file, "r") as f:
+        ctf_results = f.readlines()[-1].split()
 
     added_line = [
         str(relion_options.frame_count),

--- a/tests/services/test_node_creator.py
+++ b/tests/services/test_node_creator.py
@@ -1252,6 +1252,14 @@ def test_node_creator_excludetilts(offline_transport, tmp_path):
     output_file = tmp_path / job_dir / "tilts/Position_1_2_001_1.50_fractions.mrc"
     relion_options = RelionServiceOptions()
 
+    # Make ctf output file
+    ctf_output_file = (
+        tmp_path / "CtfFind/job003/Movies/Position_1_2_001_1.50_fractions.ctf"
+    )
+    ctf_output_file.parent.mkdir(parents=True)
+    with open(ctf_output_file.with_suffix(".txt"), "w") as f:
+        f.write("0.0 1.0 2.0 3.0 4.0 5.0 6.0")
+
     # .Nodes directory doesn't get made by this job
     (tmp_path / ".Nodes").mkdir()
 
@@ -1298,6 +1306,9 @@ def test_node_creator_excludetilts(offline_transport, tmp_path):
     assert list(tilts_block.find_loop("_rlnMicrographName")) == [
         "MotionCorr/job002/Movies/Position_1_2_001_1.50_fractions.mrc"
     ]
+    assert list(tilts_block.find_loop("_rlnDefocusU")) == ["1.0"]
+    assert list(tilts_block.find_loop("_rlnDefocusV")) == ["2.0"]
+    assert list(tilts_block.find_loop("_rlnDefocusAngle")) == ["3.0"]
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
@@ -1316,7 +1327,6 @@ def test_node_creator_aligntiltseries(offline_transport, tmp_path):
     ctf_output_file = (
         tmp_path / "CtfFind/job003/Movies/Position_1_2_001_1.50_fractions.ctf"
     )
-
     ctf_output_file.parent.mkdir(parents=True)
     with open(ctf_output_file.with_suffix(".txt"), "w") as f:
         f.write("0.0 1.0 2.0 3.0 4.0 5.0 6.0")
@@ -1380,6 +1390,7 @@ def test_node_creator_aligntiltseries(offline_transport, tmp_path):
     ]
     assert list(tilts_block.find_loop("_rlnDefocusU")) == ["1.0"]
     assert list(tilts_block.find_loop("_rlnDefocusV")) == ["2.0"]
+    assert list(tilts_block.find_loop("_rlnDefocusAngle")) == ["3.0"]
     assert list(tilts_block.find_loop("_rlnTomoXTilt")) == ["0.00"]
     assert list(tilts_block.find_loop("_rlnTomoYTilt")) == ["4.00"]
     assert list(tilts_block.find_loop("_rlnTomoZRot")) == ["83.5"]

--- a/tests/services/test_node_creator.py
+++ b/tests/services/test_node_creator.py
@@ -1240,7 +1240,7 @@ def test_node_creator_ctffind_tomo(offline_transport, tmp_path):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
-def test_node_creator_excludetilts(offline_transport, tmp_path):
+def test_node_creator_excludetilts_mc_input(offline_transport, tmp_path):
     """
     Send a test message to the node creator for
     relion.excludetilts
@@ -1258,6 +1258,72 @@ def test_node_creator_excludetilts(offline_transport, tmp_path):
     )
     ctf_output_file.parent.mkdir(parents=True)
     with open(ctf_output_file.with_suffix(".txt"), "w") as f:
+        f.write("0.0 1.0 2.0 3.0 4.0 5.0 6.0")
+
+    # .Nodes directory doesn't get made by this job
+    (tmp_path / ".Nodes").mkdir()
+
+    setup_and_run_node_creation(
+        relion_options,
+        offline_transport,
+        tmp_path,
+        job_dir,
+        "relion.excludetilts",
+        input_file,
+        output_file,
+        experiment_type="tomography",
+    )
+
+    # Check the output file structure
+    assert (tmp_path / job_dir / "selected_tilt_series.star").exists()
+    tilt_series_file = cif.read_file(
+        str(tmp_path / job_dir / "selected_tilt_series.star")
+    )
+
+    global_block = tilt_series_file.find_block("global")
+    assert list(global_block.find_loop("_rlnTomoName")) == ["Position_1_2"]
+    assert list(global_block.find_loop("_rlnTomoTiltSeriesStarFile")) == [
+        f"{job_dir}/tilt_series/Position_1_2.star"
+    ]
+
+    assert (tmp_path / job_dir / "tilt_series/Position_1_2.star").exists()
+    tilts_file = cif.read_file(
+        str(tmp_path / job_dir / "tilt_series/Position_1_2.star")
+    )
+
+    tilts_block = tilts_file.sole_block()
+    assert list(tilts_block.find_loop("_rlnTomoTiltMovieFrameCount")) == [
+        str(relion_options.frame_count)
+    ]
+    assert list(tilts_block.find_loop("_rlnTomoNominalStageTiltAngle")) == ["1.50"]
+    assert list(tilts_block.find_loop("_rlnTomoNominalTiltAxisAngle")) == [
+        str(relion_options.tilt_axis_angle)
+    ]
+    assert list(tilts_block.find_loop("_rlnMicrographPreExposure")) == ["12.77"]
+    assert list(tilts_block.find_loop("_rlnTomoNominalDefocus")) == [
+        str(relion_options.defocus)
+    ]
+    assert list(tilts_block.find_loop("_rlnMicrographName")) == [
+        "MotionCorr/job002/Movies/Position_1_2_001_1.50_fractions.mrc"
+    ]
+    assert list(tilts_block.find_loop("_rlnDefocusU")) == ["1.0"]
+    assert list(tilts_block.find_loop("_rlnDefocusV")) == ["2.0"]
+    assert list(tilts_block.find_loop("_rlnDefocusAngle")) == ["3.0"]
+
+
+def test_node_creator_excludetilts_ctf_input(offline_transport, tmp_path):
+    """
+    Send a test message to the node creator for
+    relion.excludetilts
+    """
+    job_dir = "ExcludeTiltImages/job004"
+    output_file = tmp_path / job_dir / "tilts/Position_1_2_001_1.50_fractions.mrc"
+    relion_options = RelionServiceOptions()
+
+    # Make ctf output file
+    input_file = f"{tmp_path}/CtfFind/job003/Movies/Position_1_2_001_1.50_fractions.ctf"
+    Path(input_file).parent.mkdir(parents=True)
+    with open(Path(input_file).with_suffix(".txt"), "w") as f:
         f.write("0.0 1.0 2.0 3.0 4.0 5.0 6.0")
 
     # .Nodes directory doesn't get made by this job

--- a/tests/services/test_tomo_align.py
+++ b/tests/services/test_tomo_align.py
@@ -177,7 +177,7 @@ def test_tomo_align_service_file_list(
         {
             "job_type": "relion.excludetilts",
             "experiment_type": "tomography",
-            "input_file": f"{tmp_path}/MotionCorr/job002/Movies/Position_1_001_0.0.mrc",
+            "input_file": f"{tmp_path}/CtfFind/job003/Movies/Position_1_001_0.0.mrc",
             "output_file": f"{tmp_path}/ExcludeTiltImages/job004/tilts/Position_1_001_0.0.mrc",
             "relion_options": output_relion_options,
             "command": "",
@@ -432,7 +432,7 @@ def test_tomo_align_service_file_list_repeated_tilt(
         {
             "job_type": "relion.excludetilts",
             "experiment_type": "tomography",
-            "input_file": f"{tmp_path}/MotionCorr/job002/Movies/Position_1_003_0.0.mrc",
+            "input_file": f"{tmp_path}/CtfFind/job003/Movies/Position_1_003_0.0.mrc",
             "output_file": f"{tmp_path}/ExcludeTiltImages/job004/tilts/Position_1_003_0.0.mrc",
             "relion_options": output_relion_options,
             "command": "",
@@ -639,7 +639,7 @@ def test_tomo_align_service_file_list_bad_tilts(
         {
             "job_type": "relion.excludetilts",
             "experiment_type": "tomography",
-            "input_file": f"{tmp_path}/MotionCorr/job002/Movies/Position_1_001_0.0.mrc",
+            "input_file": f"{tmp_path}/CtfFind/job003/Movies/Position_1_001_0.0.mrc",
             "output_file": f"{tmp_path}/ExcludeTiltImages/job004/tilts/Position_1_001_0.0.mrc",
             "relion_options": output_relion_options,
             "command": "",
@@ -653,7 +653,7 @@ def test_tomo_align_service_file_list_bad_tilts(
         {
             "job_type": "relion.excludetilts",
             "experiment_type": "tomography",
-            "input_file": f"{tmp_path}/MotionCorr/job002/Movies/Position_1_002_0.0.mrc",
+            "input_file": f"{tmp_path}/CtfFind/job003/Movies/Position_1_002_0.0.mrc",
             "output_file": f"{tmp_path}/ExcludeTiltImages/job004/tilts/Position_1_002_0.0.mrc",
             "relion_options": output_relion_options,
             "command": "",
@@ -985,7 +985,7 @@ def test_tomo_align_service_dark_images(
             {
                 "job_type": "relion.excludetilts",
                 "experiment_type": "tomography",
-                "input_file": f"{tmp_path}/MotionCorr/job002/Movies/Position_1_00{image}_0.0.mrc",
+                "input_file": f"{tmp_path}/CtfFind/job003/Movies/Position_1_00{image}_0.0.mrc",
                 "output_file": f"{tmp_path}/ExcludeTiltImages/job004/tilts/Position_1_00{image}_0.0.mrc",
                 "relion_options": output_relion_options,
                 "command": "",

--- a/tests/services/test_tomo_align.py
+++ b/tests/services/test_tomo_align.py
@@ -88,6 +88,7 @@ def test_tomo_align_service_file_list(
     )
     output_relion_options["tomo_size_x"] = 3000
     output_relion_options["tomo_size_y"] = 4000
+    output_relion_options["tilt_axis_angle"] = 86.0
 
     # Set up the mock service
     service = tomo_align.TomoAlign(
@@ -103,7 +104,7 @@ def test_tomo_align_service_file_list(
     ) as dark_file:
         dark_file.write("EXCLUDELIST ")
     with open(tmp_path / "Tomograms/job006/tomograms/test_stack.aln", "w") as aln_file:
-        aln_file.write("dummy 0 1000 1.2 2.3 5 6 7 8 4.5")
+        aln_file.write("dummy 86.0 1000 1.2 2.3 5 6 7 8 4.5")
 
     # Send a message to the service
     service.tomo_align(None, header=header, message=tomo_align_test_message)
@@ -172,7 +173,7 @@ def test_tomo_align_service_file_list(
 
     # Check that the correct messages were sent
     assert offline_transport.send.call_count == 12
-    offline_transport.send.assert_any_call(
+    """offline_transport.send.assert_any_call(
         "node_creator",
         {
             "job_type": "relion.excludetilts",
@@ -185,7 +186,7 @@ def test_tomo_align_service_file_list(
             "stderr": "",
             "success": True,
         },
-    )
+    )"""
     offline_transport.send.assert_any_call(
         "node_creator",
         {
@@ -200,7 +201,7 @@ def test_tomo_align_service_file_list(
             "results": {
                 "TomoXTilt": "0.00",
                 "TomoYTilt": "4.5",
-                "TomoZRot": "0.0",
+                "TomoZRot": "86.0",
                 "TomoXShiftAngst": "1.2",
                 "TomoYShiftAngst": "2.3",
             },
@@ -214,7 +215,7 @@ def test_tomo_align_service_file_list(
             "job_type": "relion.reconstructtomograms",
             "input_file": f"{tmp_path}/MotionCorr/job002/Movies/Position_1_001_0.0.mrc",
             "output_file": f"{tmp_path}/Tomograms/job006/tomograms/test_stack_aretomo.mrc",
-            "relion_options": output_relion_options,
+            "relion_options": output_relion_options | {"tilt_axis_angle": 85.0},
             "command": " ".join(aretomo_command),
             "stdout": (
                 "Rot center Z 100.0 200.0 3.1\n"
@@ -254,7 +255,7 @@ def test_tomo_align_service_file_list(
                     "psd_file": None,
                     "refined_magnification": "1000.0",
                     "refined_tilt_angle": "4.5",
-                    "refined_tilt_axis": "0.0",
+                    "refined_tilt_axis": "86.0",
                     "path": f"{tmp_path}/MotionCorr/job002/Movies/Position_1_001_0.0.mrc",
                 },
             ],


### PR DESCRIPTION
We're not currently matching relion 5 in all the tomography star files. This addresses some issues, although there may be more to find.

- Input to ExcludeTiltSeries should be CtfFind
- ExcludeTiltSeries jobs should have CTF outputs in the tilt series star files
- If CTF output does not exist, do not make star files (in future we could include ctf directly in the workflow to ensure this is true)
- Inputs will be relative to /.../project/MotionCorr, not just MotionCorr