### PR TITLE
Where possible, do ispyb inserts last to avoid double-inserts

### DIFF
--- a/src/cryoemservices/services/denoise.py
+++ b/src/cryoemservices/services/denoise.py
@@ -230,14 +230,6 @@ class Denoise(CommonService):
             },
         )
 
-        # Insert the denoised tomogram into ISPyB
-        ispyb_parameters = {
-            "ispyb_command": "insert_processed_tomogram",
-            "file_path": str(denoised_full_path),
-            "processing_type": "Denoised",
-        }
-        rw.send_to("ispyb_connector", ispyb_parameters)
-
         # Send to segmentation and picking
         self.log.info(f"Sending {denoised_full_path} for segmentation and picking")
         if denoise_params.output_dir:
@@ -272,6 +264,14 @@ class Denoise(CommonService):
         }
         rw.send_to("segmentation", segmentation_parameters)
         rw.send_to("cryolo", cryolo_parameters)
+
+        # Insert the denoised tomogram into ISPyB
+        ispyb_parameters = {
+            "ispyb_command": "insert_processed_tomogram",
+            "file_path": str(denoised_full_path),
+            "processing_type": "Denoised",
+        }
+        rw.send_to("ispyb_connector", ispyb_parameters)
 
         self.log.info(f"Done denoising for {denoise_params.volume}")
         rw.transport.ack(header)

--- a/src/cryoemservices/services/tomo_align.py
+++ b/src/cryoemservices/services/tomo_align.py
@@ -600,13 +600,6 @@ class TomoAlign(CommonService):
         for tilt_params in node_creator_params_list:
             rw.send_to("node_creator", tilt_params)
 
-        ispyb_parameters = {
-            "ispyb_command": "multipart_message",
-            "ispyb_command_list": ispyb_command_list,
-        }
-        self.log.info(f"Sending to ispyb {ispyb_parameters}")
-        rw.send_to("ispyb_connector", ispyb_parameters)
-
         # Forward results to images service
         self.log.info(f"Sending to images service {tomo_params.stack_file}")
         rw.send_to(
@@ -664,6 +657,14 @@ class TomoAlign(CommonService):
                 "relion_options": dict(tomo_params.relion_options),
             },
         )
+
+        # Insert tomogram into ispyb
+        ispyb_parameters = {
+            "ispyb_command": "multipart_message",
+            "ispyb_command_list": ispyb_command_list,
+        }
+        self.log.info(f"Sending to ispyb {ispyb_parameters}")
+        rw.send_to("ispyb_connector", ispyb_parameters)
 
         # Update success processing status
         rw.send_to("success", {})

--- a/src/cryoemservices/services/topaz_pick.py
+++ b/src/cryoemservices/services/topaz_pick.py
@@ -191,22 +191,6 @@ class TopazPick(CommonService):
             # Only do the node creator inserts for new files
             rw.send_to("node_creator", node_creator_parameters)
 
-        # Forward results to ISPyB
-        ispyb_parameters_spa: dict = {
-            "ispyb_command": "buffer",
-            "buffer_lookup": {"motion_correction_id": topaz_params.mc_uuid},
-            "buffer_command": {"ispyb_command": "insert_particle_picker"},
-            "buffer_store": topaz_params.picker_uuid,
-            "particle_picking_template": topaz_params.topaz_model,
-            "number_of_particles": n_particles,
-            "summary_image_full_path": str(
-                Path(topaz_params.output_path).with_suffix(".jpeg")
-            ),
-            "particle_diameter": topaz_params.particle_diameter,
-        }
-        self.log.info(f"Sending to ispyb {ispyb_parameters_spa}")
-        rw.send_to("ispyb_connector", ispyb_parameters_spa)
-
         # Read picks for images service
         try:
             with open(topaz_params.output_path, "r") as coords_file:
@@ -255,6 +239,22 @@ class TopazPick(CommonService):
                 "extraction_parameters": extraction_params,
             },
         )
+
+        # Forward results to ISPyB
+        ispyb_parameters_spa: dict = {
+            "ispyb_command": "buffer",
+            "buffer_lookup": {"motion_correction_id": topaz_params.mc_uuid},
+            "buffer_command": {"ispyb_command": "insert_particle_picker"},
+            "buffer_store": topaz_params.picker_uuid,
+            "particle_picking_template": topaz_params.topaz_model,
+            "number_of_particles": n_particles,
+            "summary_image_full_path": str(
+                Path(topaz_params.output_path).with_suffix(".jpeg")
+            ),
+            "particle_diameter": topaz_params.particle_diameter,
+        }
+        self.log.info(f"Sending to ispyb {ispyb_parameters_spa}")
+        rw.send_to("ispyb_connector", ispyb_parameters_spa)
 
         self.log.info(f"Done {self.job_type} for {topaz_params.input_path}.")
         rw.transport.ack(header)


### PR DESCRIPTION
Very occasionally we see motion-corrected results inserted into ispyb twice as the insert is done then the pod crashes.

To minimise the risk of this, this moves ispyb insert calls to the end of the services.