### PR TITLE
Remove mamba.sh from the Dockerfiles

### DIFF
--- a/Dockerfiles/README.md
+++ b/Dockerfiles/README.md
@@ -1,0 +1,42 @@
+# Dockerfiles for services
+
+The following services rely on the `cryoemservices_cpu` dockerfile:
+
+- BFactor
+- CLEMAlignAndMerge
+- CLEMLIFToStack
+- CLEMTIFFToStack
+- ClusterSubmission
+- DenoiseSlurm
+- EMISPyB
+- Extract
+- ExtractClass
+- IceBreaker
+- Images
+- NodeCreator
+- ProcessRecipe
+- SelectParticles
+- TomoAlignSlurm
+
+The remaining services that have dockerfiles are:
+
+- MotionCorr: build using `motioncor2` or `motioncor_relion`
+- CTFFind: build using `ctffind`
+- CrYOLO: build using `cryolo`
+- SelectClasses: build using `class_selection`
+- PostProcess: build using `motioncor_relion`
+- TomoAlign: build using `tomo_align`
+- Denoise: build using `topaz`
+- MembrainSeg: build using `topaz`
+
+The `motioncor2`, `tomo_align` and `topaz` Dockerfiles have GPU support.
+
+Some dependencies are not built in the dockerfiles,
+and are instead assumed to be in a "packages" subfolder
+
+- AreTomo2
+- ctffind-4.1.14
+- ctffind-5.0.2
+- motioncor-1.4.0
+
+For `cryolo`, the `gmodel_phosnet_202005_N63_c17.h5` also needs to be present in a "cryolo_models" folder

--- a/Dockerfiles/class_selection
+++ b/Dockerfiles/class_selection
@@ -9,23 +9,23 @@ ENV PATH=/conda/bin:${PATH}
 
 RUN conda install -c conda-forge conda-pack
 RUN mamba create -c conda-forge -p /install/pythonenv python=3.11 pip libtiff=4.4.0 --override-channels -y
-RUN eval "$('conda' 'shell.bash' 'hook')" && conda activate /install/pythonenv && \
+RUN eval "$(conda shell.bash hook)" && conda activate /install/pythonenv && \
     pip install torch==2.0.1 torchvision==0.15.2 --index-url https://download.pytorch.org/whl/cpu
 
 # Install cryoem-services and pipeliner
-RUN eval "$('conda' 'shell.bash' 'hook')" && conda activate /install/pythonenv && \
+RUN eval "$(conda shell.bash hook)" && conda activate /install/pythonenv && \
     pip install cryoemservices && \
     pip install http://gitlab.com/stephen-riggs/ccpem-pipeliner/-/archive/diamond_tomo/ccpem-pipeliner-diamond_tomo.zip
 
 # Install relion classranker
-RUN eval "$('conda' 'shell.bash' 'hook')" && conda activate /install/pythonenv && \
+RUN eval "$(conda shell.bash hook)" && conda activate /install/pythonenv && \
     pip install https://github.com/3dem/relion-classranker/archive/main.zip
 
 # Pack the environment
 RUN /conda/bin/conda-pack -p /install/pythonenv -o /tmp/env.tar.gz
 RUN mkdir /install/venv
 RUN tar -xzf /tmp/env.tar.gz -C /install/venv
-RUN eval "$('conda' 'shell.bash' 'hook')" && conda activate /install/venv && /install/venv/bin/conda-unpack
+RUN eval "$(conda shell.bash hook)" && conda activate /install/venv && /install/venv/bin/conda-unpack
 
 
 # Second stage builds relion

--- a/Dockerfiles/class_selection
+++ b/Dockerfiles/class_selection
@@ -5,27 +5,27 @@ FROM rockylinux:8 AS conda-build
 # Set up conda environment
 RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
 RUN bash Miniforge3-$(uname)-$(uname -m).sh -b -p "conda"
+ENV PATH=/conda/bin:${PATH}
 
-RUN source "/conda/etc/profile.d/conda.sh" && conda install -c conda-forge conda-pack
-RUN source "/conda/etc/profile.d/conda.sh" && source "/conda/etc/profile.d/mamba.sh" && \
-    mamba create -c conda-forge -p /install/pythonenv python=3.11 pip libtiff=4.4.0 --override-channels -y
-RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/pythonenv && \
+RUN conda install -c conda-forge conda-pack
+RUN mamba create -c conda-forge -p /install/pythonenv python=3.11 pip libtiff=4.4.0 --override-channels -y
+RUN eval "$('conda' 'shell.bash' 'hook')" && conda activate /install/pythonenv && \
     pip install torch==2.0.1 torchvision==0.15.2 --index-url https://download.pytorch.org/whl/cpu
 
 # Install cryoem-services and pipeliner
-RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/pythonenv && \
+RUN eval "$('conda' 'shell.bash' 'hook')" && conda activate /install/pythonenv && \
     pip install cryoemservices && \
     pip install http://gitlab.com/stephen-riggs/ccpem-pipeliner/-/archive/diamond_tomo/ccpem-pipeliner-diamond_tomo.zip
 
 # Install relion classranker
-RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/pythonenv && \
+RUN eval "$('conda' 'shell.bash' 'hook')" && conda activate /install/pythonenv && \
     pip install https://github.com/3dem/relion-classranker/archive/main.zip
 
 # Pack the environment
 RUN /conda/bin/conda-pack -p /install/pythonenv -o /tmp/env.tar.gz
 RUN mkdir /install/venv
 RUN tar -xzf /tmp/env.tar.gz -C /install/venv
-RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/venv && /install/venv/bin/conda-unpack
+RUN eval "$('conda' 'shell.bash' 'hook')" && conda activate /install/venv && /install/venv/bin/conda-unpack
 
 
 # Second stage builds relion

--- a/Dockerfiles/cryoemservices_cpu
+++ b/Dockerfiles/cryoemservices_cpu
@@ -1,7 +1,7 @@
 # This Dockerfile is used for the services that can run on CPU
 FROM docker.io/library/python:3.11-slim-bookworm as base
 
-# Install Vim and PostgreSQL dependencies in base image
+# Install Vim in base image
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
@@ -36,7 +36,7 @@ RUN apt-get update && \
     mkdir imod && \
     ./imod_5.1.0_RHEL8-64_CUDA12.0.sh -dir imod -skip -y
 
-# Transfer copmleted build to base image
+# Transfer completed build to base image
 FROM base
 
 ARG groupid

--- a/Dockerfiles/cryolo
+++ b/Dockerfiles/cryolo
@@ -12,19 +12,19 @@ RUN mamba create -p /install/services_env -c conda-forge python=3.11 --override-
     mamba create -p /install/cryolo_env -c conda-forge pyqt=5 python=3.7 cudatoolkit=10.0.130 cudnn=7.6.5 numpy==1.18.5 libtiff wxPython=4.1.1 --override-channels -y
 
 # Install cryoem-services and Cryolo in their own environments
-RUN eval "$('conda' 'shell.bash' 'hook')" && conda activate /install/services_env && pip install cryoemservices
-RUN eval "$('conda' 'shell.bash' 'hook')" && conda activate /install/cryolo_env && pip install cryolo[cpu]
+RUN eval "$(conda shell.bash hook)" && conda activate /install/services_env && pip install cryoemservices
+RUN eval "$(conda shell.bash hook)" && conda activate /install/cryolo_env && pip install cryolo[cpu]
 
 # Pack the environments
 RUN /conda/bin/conda-pack -p /install/services_env -o /tmp/services_env.tar.gz
 RUN mkdir /install/venv_services
 RUN tar -xzf /tmp/services_env.tar.gz -C /install/venv_services
-RUN eval "$('conda' 'shell.bash' 'hook')" && conda activate /install/venv_services && /install/venv_services/bin/conda-unpack
+RUN eval "$(conda shell.bash hook)" && conda activate /install/venv_services && /install/venv_services/bin/conda-unpack
 
 RUN /conda/bin/conda-pack -p /install/cryolo_env -o /tmp/cryolo_env.tar.gz
 RUN mkdir /install/venv_cryolo
 RUN tar -xzf /tmp/cryolo_env.tar.gz -C /install/venv_cryolo
-RUN eval "$('conda' 'shell.bash' 'hook')" && conda activate /install/venv_cryolo && /install/venv_cryolo/bin/conda-unpack
+RUN eval "$(conda shell.bash hook)" && conda activate /install/venv_cryolo && /install/venv_cryolo/bin/conda-unpack
 
 
 # Second stage extracts the conda environments

--- a/Dockerfiles/cryolo
+++ b/Dockerfiles/cryolo
@@ -4,28 +4,27 @@ FROM rockylinux:9 AS conda-build
 # Set up conda environment
 RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
 RUN bash Miniforge3-$(uname)-$(uname -m).sh -b -p "conda"
+ENV PATH=/conda/bin:${PATH}
 
 # Create different conda environments for cryoem-services and cryolo
-RUN source "/conda/etc/profile.d/conda.sh" && conda install -c conda-forge conda-pack
-RUN source "/conda/etc/profile.d/conda.sh" && source "/conda/etc/profile.d/mamba.sh" && \
-    mamba create -p /install/services_env -c conda-forge python=3.11 --override-channels -y && \
+RUN conda install -c conda-forge conda-pack
+RUN mamba create -p /install/services_env -c conda-forge python=3.11 --override-channels -y && \
     mamba create -p /install/cryolo_env -c conda-forge pyqt=5 python=3.7 cudatoolkit=10.0.130 cudnn=7.6.5 numpy==1.18.5 libtiff wxPython=4.1.1 --override-channels -y
 
 # Install cryoem-services and Cryolo in their own environments
-RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/services_env && \
-    pip install --cache-dir /tmp cryoemservices
-RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/cryolo_env && pip install cryolo[cpu]
+RUN eval "$('conda' 'shell.bash' 'hook')" && conda activate /install/services_env && pip install cryoemservices
+RUN eval "$('conda' 'shell.bash' 'hook')" && conda activate /install/cryolo_env && pip install cryolo[cpu]
 
 # Pack the environments
 RUN /conda/bin/conda-pack -p /install/services_env -o /tmp/services_env.tar.gz
 RUN mkdir /install/venv_services
 RUN tar -xzf /tmp/services_env.tar.gz -C /install/venv_services
-RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/venv_services && /install/venv_services/bin/conda-unpack
+RUN eval "$('conda' 'shell.bash' 'hook')" && conda activate /install/venv_services && /install/venv_services/bin/conda-unpack
 
 RUN /conda/bin/conda-pack -p /install/cryolo_env -o /tmp/cryolo_env.tar.gz
 RUN mkdir /install/venv_cryolo
 RUN tar -xzf /tmp/cryolo_env.tar.gz -C /install/venv_cryolo
-RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/venv_cryolo && /install/venv_cryolo/bin/conda-unpack
+RUN eval "$('conda' 'shell.bash' 'hook')" && conda activate /install/venv_cryolo && /install/venv_cryolo/bin/conda-unpack
 
 
 # Second stage extracts the conda environments

--- a/Dockerfiles/motioncor2
+++ b/Dockerfiles/motioncor2
@@ -4,20 +4,19 @@ FROM rockylinux:8 AS conda-build
 # Set up conda environment
 RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
 RUN bash Miniforge3-$(uname)-$(uname -m).sh -b -p "conda"
+ENV PATH=/conda/bin:${PATH}
 
-RUN source "/conda/etc/profile.d/conda.sh" && conda install -c conda-forge conda-pack
-RUN source "/conda/etc/profile.d/conda.sh" && source "/conda/etc/profile.d/mamba.sh" && \
-    mamba create -c conda-forge -p /install/pythonenv python=3.11 pip libtiff=4.4.0 numpy=1.26.4 --override-channels -y
+RUN conda install -c conda-forge conda-pack
+RUN mamba create -c conda-forge -p /install/pythonenv python=3.11 pip libtiff=4.4.0 numpy=1.26.4 --override-channels -y
 
 # Install cryoem-services
-RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/pythonenv && \
-    pip install --cache-dir /tmp cryoemservices
+RUN eval "$('conda' 'shell.bash' 'hook')" && conda activate /install/pythonenv && pip install cryoemservices
 
 # Pack the environment
 RUN /conda/bin/conda-pack -p /install/pythonenv -o /tmp/env.tar.gz
 RUN mkdir /install/venv
 RUN tar -xzf /tmp/env.tar.gz -C /install/venv
-RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/venv && /install/venv/bin/conda-unpack
+RUN eval "$('conda' 'shell.bash' 'hook')" && conda activate /install/venv && /install/venv/bin/conda-unpack
 
 
 # Second stage extracts the conda environment

--- a/Dockerfiles/motioncor2
+++ b/Dockerfiles/motioncor2
@@ -10,13 +10,13 @@ RUN conda install -c conda-forge conda-pack
 RUN mamba create -c conda-forge -p /install/pythonenv python=3.11 pip libtiff=4.4.0 numpy=1.26.4 --override-channels -y
 
 # Install cryoem-services
-RUN eval "$('conda' 'shell.bash' 'hook')" && conda activate /install/pythonenv && pip install cryoemservices
+RUN eval "$(conda shell.bash hook)" && conda activate /install/pythonenv && pip install cryoemservices
 
 # Pack the environment
 RUN /conda/bin/conda-pack -p /install/pythonenv -o /tmp/env.tar.gz
 RUN mkdir /install/venv
 RUN tar -xzf /tmp/env.tar.gz -C /install/venv
-RUN eval "$('conda' 'shell.bash' 'hook')" && conda activate /install/venv && /install/venv/bin/conda-unpack
+RUN eval "$(conda shell.bash hook)" && conda activate /install/venv && /install/venv/bin/conda-unpack
 
 
 # Second stage extracts the conda environment

--- a/Dockerfiles/motioncor_relion
+++ b/Dockerfiles/motioncor_relion
@@ -9,7 +9,7 @@ RUN yum install fftw-devel libtiff-devel libpng-devel libjpeg-devel zlib-devel -
 # Build Relion - need to be on the ver5.0-mc-devolve branch
 RUN mkdir -p /install/relion5.0
 RUN curl -L -o relion.tar.gz https://github.com/d-j-hatton/relion/archive/ver5.0-mc-devolve.tar.gz
-RUN tar -xf relion.tar.gz -C /install
+RUN tar -C /install -xf relion.tar.gz
 RUN mkdir /install/relion-ver5.0-mc-devolve/build
 
 RUN cmake -DCMAKE_INSTALL_PREFIX=/install/relion5.0 -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++ -DMPI_C_COMPILER=/usr/lib64/openmpi/bin/mpicc -DMPI_CXX_COMPILER=/usr/lib64/openmpi/bin/mpicxx -DMPI_C_LIBRARIES=/usr/lib64/openmpi/lib/libmpi.so -DMPI_CXX_LIBRARIES=/usr/lib64/openmpi/lib/libmpi.so -DGUI=OFF -DALTCPU=ON -DDoublePrec_CPU=OFF -DFORCE_OWN_FFTW=ON -DAMDFFTW=ON -B/install/relion-ver5.0-mc-devolve/build -S/install/relion-ver5.0-mc-devolve

--- a/Dockerfiles/tomo_align
+++ b/Dockerfiles/tomo_align
@@ -4,20 +4,19 @@ FROM rockylinux:8 AS conda-build
 # Set up conda environment
 RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
 RUN bash Miniforge3-$(uname)-$(uname -m).sh -b -p "conda"
+ENV PATH=/conda/bin:${PATH}
 
-RUN source "/conda/etc/profile.d/conda.sh" && conda install -c conda-forge conda-pack
-RUN source "/conda/etc/profile.d/conda.sh" && source "/conda/etc/profile.d/mamba.sh" && \
-    mamba create -c conda-forge -p /install/pythonenv python=3.11 pip libtiff=4.4.0 numpy=1.26.4 --override-channels -y
+RUN conda install -c conda-forge conda-pack
+RUN mamba create -c conda-forge -p /install/pythonenv python=3.11 pip libtiff=4.4.0 numpy=1.26.4 --override-channels -y
 
 # Install cryoem-services
-RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/pythonenv && \
-    pip install --cache-dir /tmp cryoemservices
+RUN eval "$('conda' 'shell.bash' 'hook')" && conda activate /install/pythonenv && pip install cryoemservices
 
 # Pack the environment
 RUN /conda/bin/conda-pack -p /install/pythonenv -o /tmp/env.tar.gz
 RUN mkdir /install/venv
 RUN tar -xzf /tmp/env.tar.gz -C /install/venv
-RUN source "/conda/etc/profile.d/conda.sh" && conda activate /install/venv && /install/venv/bin/conda-unpack
+RUN eval "$('conda' 'shell.bash' 'hook')" && conda activate /install/venv && /install/venv/bin/conda-unpack
 
 
 # Second stage extracts the conda environment

--- a/Dockerfiles/tomo_align
+++ b/Dockerfiles/tomo_align
@@ -10,13 +10,13 @@ RUN conda install -c conda-forge conda-pack
 RUN mamba create -c conda-forge -p /install/pythonenv python=3.11 pip libtiff=4.4.0 numpy=1.26.4 --override-channels -y
 
 # Install cryoem-services
-RUN eval "$('conda' 'shell.bash' 'hook')" && conda activate /install/pythonenv && pip install cryoemservices
+RUN eval "$(conda shell.bash hook)" && conda activate /install/pythonenv && pip install cryoemservices
 
 # Pack the environment
 RUN /conda/bin/conda-pack -p /install/pythonenv -o /tmp/env.tar.gz
 RUN mkdir /install/venv
 RUN tar -xzf /tmp/env.tar.gz -C /install/venv
-RUN eval "$('conda' 'shell.bash' 'hook')" && conda activate /install/venv && /install/venv/bin/conda-unpack
+RUN eval "$(conda shell.bash hook)" && conda activate /install/venv && /install/venv/bin/conda-unpack
 
 
 # Second stage extracts the conda environment


### PR DESCRIPTION
Some dockerfiles have been giving warnings about mamba.sh being removed after 30th Sept. This addresses that by removing references to mamba.sh and conda.sh, instead directly calling the command that normally happens during "conda init"

I've also added a few notes about the dockerfiles. More can be added in future and the dockerfiles want improvement as well.