### PR TITLE
Insert manual tilt offset into ispyb + naming fixes for cryolo and ctf output

### DIFF
--- a/src/cryoemservices/services/cryolo.py
+++ b/src/cryoemservices/services/cryolo.py
@@ -164,7 +164,8 @@ class CrYOLO(CommonService):
 
         Path(cryolo_params.output_path).unlink(missing_ok=True)
         (
-            job_dir / f"CBOX/{Path(cryolo_params.output_path).with_suffix('.cbox')}"
+            job_dir
+            / f"CBOX/{Path(cryolo_params.output_path).with_suffix('.cbox').name}"
         ).unlink(missing_ok=True)
 
         # Try and scale out any dark areas, for example gold grids

--- a/src/cryoemservices/services/ispyb_connector.py
+++ b/src/cryoemservices/services/ispyb_connector.py
@@ -84,7 +84,7 @@ class EMISPyB(CommonService):
                 return replace_with_environment(parameter)
 
             # Otherwise look up the parameter value
-            if message.get(parameter):
+            if message.get(parameter) is not None:
                 base_value = message[parameter]
             else:
                 base_value = rw.recipe_step["parameters"].get(parameter)

--- a/src/cryoemservices/services/tomo_align.py
+++ b/src/cryoemservices/services/tomo_align.py
@@ -483,7 +483,9 @@ class TomoAlign(CommonService):
                 "size_y": scaled_y_size,
                 "size_z": scaled_z_size,
                 "pixel_spacing": pixel_spacing,
-                "tilt_angle_offset": str(self.tilt_offset),
+                "tilt_angle_offset": str(
+                    self.tilt_offset or tomo_params.manual_tilt_offset
+                ),
                 "z_shift": rot_centre_z,
                 "file_directory": str(alignment_output_dir),
                 "central_slice_image": central_slice_file,

--- a/src/cryoemservices/util/ispyb_commands.py
+++ b/src/cryoemservices/util/ispyb_commands.py
@@ -22,10 +22,10 @@ def parameters_with_replacement(param: str, message: dict, all_parameters: Calla
     If the value is defined in the command list item then this takes
     precedence.
     """
-    if message.get(param) and "$" not in str(message[param]):
+    if message.get(param) is not None and "$" not in str(message[param]):
         # Precedence for command list items
         value_to_return = message[param]
-    elif message.get(param):
+    elif message.get(param) is not None:
         # Run lookup on dollar parameters
         value_to_return = all_parameters(message[param])
     else:

--- a/src/cryoemservices/util/tomo_output_files.py
+++ b/src/cryoemservices/util/tomo_output_files.py
@@ -358,6 +358,8 @@ def _exclude_tilt_output_files(
         )
 
     # Later extraction jobs require some ctf parameters for the tilts
+    if not ctf_txt_file.is_file():
+        ctf_txt_file = ctf_txt_file.parent / (ctf_txt_file.stem + "_DW.txt")
     with open(ctf_txt_file, "r") as f:
         ctf_results = f.readlines()[-1].split()
 
@@ -459,6 +461,8 @@ def _align_tilt_output_files(
         )
 
     # Later extraction jobs require some ctf parameters for the tilts
+    if not ctf_txt_file.is_file():
+        ctf_txt_file = ctf_txt_file.parent / (ctf_txt_file.stem + "_DW.txt")
     with open(ctf_txt_file, "r") as f:
         ctf_results = f.readlines()[-1].split()
 


### PR DESCRIPTION
If given a tilt offset, AreTomo2 does not calculate it and so it does not appear in the outputs. In that case we should insert the input value into ispyb.

Empirically this happens for angles >= 0.1

Also deals with a naming issue in cryolo, and finds alternative ctf output names for the case where MotionCor2 has been run.