### PR TITLE
Coordinate corrections for tomograms

### DIFF
--- a/src/cryoemservices/util/tomo_output_files.py
+++ b/src/cryoemservices/util/tomo_output_files.py
@@ -731,7 +731,8 @@ def _cryolo_output_files(
         with open(particles_file, "w") as pf:
             pf.write(
                 "data_particles\n\nloop_\n"
-                "_rlnTomoName\n_rlnCoordinateX\n_rlnCoordinateY\n_rlnCoordinateZ\n"
+                "_rlnTomoName\n_rlnCenteredCoordinateXAngst\n"
+                "_rlnCenteredCoordinateYAngst\n_rlnCenteredCoordinateZAngst\n"
             )
 
     # Read in the output particles
@@ -752,17 +753,31 @@ def _cryolo_output_files(
     # Append all the particles to the particles file
     with open(particles_file, "a") as output_cif:
         for particle in range(len(loop_x)):
+            # x and y coordinates are a corner, so need shifting by half the box size
+            x_particle_center = (
+                float(loop_x[particle]) + float(loop_width[particle]) / 2
+            ) * scaling_factor
+            y_particle_center = (
+                float(loop_y[particle]) + float(loop_height[particle]) / 2
+            ) * scaling_factor
+            if -45 < relion_options.tilt_axis_angle < 45:
+                # If given tilt axis of around 0, x and y are unchanged
+                x_tomo_centered = x_particle_center - relion_options.tomo_size_x / 2
+                y_tomo_centered = y_particle_center - relion_options.tomo_size_y / 2
+            else:
+                # Otherwise we need to flip x and y
+                x_tomo_centered = y_particle_center - relion_options.tomo_size_y / 2
+                y_tomo_centered = relion_options.tomo_size_x / 2 - y_particle_center
+
+            # z coordinate is the mid-point so just needs scaling and centering
+            z_particle_center = float(loop_z[particle]) * scaling_factor
+            z_tomo_centered = z_particle_center - relion_options.vol_z / 2
+
             added_line = [
                 tilt_series_name,
-                str(
-                    (float(loop_x[particle]) + float(loop_width[particle]) / 2)
-                    * scaling_factor
-                ),
-                str(
-                    (float(loop_y[particle]) + float(loop_height[particle]) / 2)
-                    * scaling_factor
-                ),
-                str(float(loop_z[particle]) * scaling_factor),
+                str(x_tomo_centered * relion_options.pixel_size),
+                str(y_tomo_centered * relion_options.pixel_size),
+                str(z_tomo_centered * relion_options.pixel_size),
             ]
             output_cif.write(" ".join(added_line) + "\n")
 

--- a/src/cryoemservices/util/tomo_output_files.py
+++ b/src/cryoemservices/util/tomo_output_files.py
@@ -743,8 +743,8 @@ def _cryolo_output_files(
     loop_x = cryolo_block.find_loop("_CoordinateX")
     loop_y = cryolo_block.find_loop("_CoordinateY")
     loop_z = cryolo_block.find_loop("_CoordinateZ")
-    loop_width = cryolo_block.find_loop("_EstWidth")
-    loop_height = cryolo_block.find_loop("_EstHeight")
+    loop_width = cryolo_block.find_loop("_Width")
+    loop_height = cryolo_block.find_loop("_Height")
 
     # Scale coordinates back to original tilt size
     scaling_factor = relion_options.pixel_size_downscaled / relion_options.pixel_size

--- a/src/cryoemservices/util/tomo_output_files.py
+++ b/src/cryoemservices/util/tomo_output_files.py
@@ -767,7 +767,7 @@ def _cryolo_output_files(
             else:
                 # Otherwise we need to flip x and y
                 x_tomo_centered = y_particle_center - relion_options.tomo_size_y / 2
-                y_tomo_centered = relion_options.tomo_size_x / 2 - y_particle_center
+                y_tomo_centered = relion_options.tomo_size_x / 2 - x_particle_center
 
             # z coordinate is the mid-point so just needs scaling and centering
             z_particle_center = float(loop_z[particle]) * scaling_factor

--- a/tests/services/test_node_creator.py
+++ b/tests/services/test_node_creator.py
@@ -1958,6 +1958,14 @@ def test_node_creator_cryolo_tomo_0axis(offline_transport, tmp_path):
     (tmp_path / job_dir / "DISTR").mkdir(parents=True)
     (tmp_path / job_dir / "DISTR/confidence_distribution_summary_1.txt").touch()
 
+    # Have pre-made particles file for this one
+    with open(tmp_path / job_dir / "particles.star", "w") as pf:
+        pf.write(
+            "data_particles\n\nloop_\n"
+            "_rlnTomoName\n_rlnCenteredCoordinateXAngst\n"
+            "_rlnCenteredCoordinateYAngst\n_rlnCenteredCoordinateZAngst\n"
+        )
+
     setup_and_run_node_creation(
         relion_options,
         offline_transport,

--- a/tests/services/test_node_creator.py
+++ b/tests/services/test_node_creator.py
@@ -1842,8 +1842,7 @@ def test_node_creator_membrain(offline_transport, tmp_path):
     ]
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
-def test_node_creator_cryolo_tomo(offline_transport, tmp_path):
+def test_node_creator_cryolo_tomo_90axis(offline_transport, tmp_path):
     """
     Send a test message to the node creator for
     cryolo.autopick running on a tomogram
@@ -1860,6 +1859,10 @@ def test_node_creator_cryolo_tomo(offline_transport, tmp_path):
     relion_options.cryolo_config_file = str(tmp_path / job_dir / "cryolo_config.json")
     relion_options.pixel_size = 1.2
     relion_options.pixel_size_downscaled = 4.8
+    relion_options.tilt_axis_angle = 86
+    relion_options.tomo_size_x = 6000
+    relion_options.tomo_size_y = 4000
+    relion_options.vol_z = 1600
     (tmp_path / job_dir / "cryolo_config.json").touch()
 
     with open(
@@ -1868,7 +1871,7 @@ def test_node_creator_cryolo_tomo(offline_transport, tmp_path):
         particles_file.write(
             "data_global\n\n_cbox_format_version   1.0\n"
             "data_cryolo\n\nloop_\n"
-            "_CoordinateX\n_CoordinateY\n_CoordinateZ\n_EstWidth\n_EstHeight\n"
+            "_CoordinateX\n_CoordinateY\n_CoordinateZ\n_Width\n_Height\n"
             "60 70 80 5 6\n90 100 110 8 10\n"
         )
 
@@ -1904,15 +1907,95 @@ def test_node_creator_cryolo_tomo(offline_transport, tmp_path):
         "Position_1_2",
         "Position_1_2",
     ]
-    x_coords = list(particles_block.find_loop("_rlnCoordinateX"))
-    y_coords = list(particles_block.find_loop("_rlnCoordinateY"))
-    z_coords = list(particles_block.find_loop("_rlnCoordinateZ"))
+    x_coords = list(particles_block.find_loop("_rlnCenteredCoordinateXAngst"))
+    y_coords = list(particles_block.find_loop("_rlnCenteredCoordinateYAngst"))
+    z_coords = list(particles_block.find_loop("_rlnCenteredCoordinateZAngst"))
     assert len(x_coords) == 2
-    assert float(x_coords[0]) == 62.5 * 4
-    assert float(x_coords[1]) == 94.0 * 4
+    assert float(x_coords[0]) == (73 * 4 - 2000) * 1.2
+    assert float(x_coords[1]) == (105 * 4 - 2000) * 1.2
     assert len(y_coords) == 2
-    assert float(y_coords[0]) == 73 * 4
-    assert float(y_coords[1]) == 105 * 4
+    assert float(y_coords[0]) == (3000 - 62.5 * 4) * 1.2
+    assert float(y_coords[1]) == (3000 - 94.0 * 4) * 1.2
     assert len(z_coords) == 2
-    assert float(z_coords[0]) == 80 * 4
-    assert float(z_coords[1]) == 110 * 4
+    assert float(z_coords[0]) == (80 * 4 - 800) * 1.2
+    assert float(z_coords[1]) == (110 * 4 - 800) * 1.2
+
+
+def test_node_creator_cryolo_tomo_0axis(offline_transport, tmp_path):
+    """
+    Send a test message to the node creator for
+    cryolo.autopick running on a tomogram
+    x and y flipped relative to above
+    """
+    job_dir = "AutoPick/job009"
+    (tmp_path / job_dir / "CBOX_3D").mkdir(parents=True)
+
+    input_file = f"{tmp_path}/Denoise/job007/Movies/tomograms/Position_1_2_stack_aretomo.denoised.mrc"
+    output_file = (
+        tmp_path / job_dir / "CBOX_3D/Position_1_2_stack_aretomo.denoised.cbox"
+    )
+    relion_options = RelionServiceOptions()
+
+    relion_options.cryolo_config_file = str(tmp_path / job_dir / "cryolo_config.json")
+    relion_options.pixel_size = 1.2
+    relion_options.pixel_size_downscaled = 4.8
+    relion_options.tilt_axis_angle = 4
+    relion_options.tomo_size_x = 6000
+    relion_options.tomo_size_y = 4000
+    relion_options.vol_z = 1600
+    (tmp_path / job_dir / "cryolo_config.json").touch()
+
+    with open(
+        tmp_path / job_dir / "CBOX_3D/Position_1_2_stack_aretomo.denoised.cbox", "w"
+    ) as particles_file:
+        particles_file.write(
+            "data_global\n\n_cbox_format_version   1.0\n"
+            "data_cryolo\n\nloop_\n"
+            "_CoordinateX\n_CoordinateY\n_CoordinateZ\n_Width\n_Height\n"
+            "60 70 80 5 6\n90 100 110 8 10\n"
+        )
+
+    (tmp_path / job_dir / "DISTR").mkdir(parents=True)
+    (tmp_path / job_dir / "DISTR/confidence_distribution_summary_1.txt").touch()
+
+    setup_and_run_node_creation(
+        relion_options,
+        offline_transport,
+        tmp_path,
+        job_dir,
+        "cryolo.autopick.tomo",
+        input_file,
+        output_file,
+        experiment_type="tomography",
+    )
+
+    # Check the output file structure
+    assert (tmp_path / job_dir / "optimisation_set.star").exists()
+    optimiser_file = cif.read_file(str(tmp_path / job_dir / "optimisation_set.star"))
+    optimiser_block = optimiser_file.find_block("optimisation_set")
+    assert list(optimiser_block.find_loop("_rlnTomoParticlesFile")) == [
+        "AutoPick/job009/particles.star"
+    ]
+    assert list(optimiser_block.find_loop("_rlnTomoTomogramsFile")) == [
+        "Denoise/job007/tomograms.star"
+    ]
+
+    assert (tmp_path / job_dir / "particles.star").exists()
+    particles_file = cif.read_file(str(tmp_path / job_dir / "particles.star"))
+    particles_block = particles_file.find_block("particles")
+    assert list(particles_block.find_loop("_rlnTomoName")) == [
+        "Position_1_2",
+        "Position_1_2",
+    ]
+    x_coords = list(particles_block.find_loop("_rlnCenteredCoordinateXAngst"))
+    y_coords = list(particles_block.find_loop("_rlnCenteredCoordinateYAngst"))
+    z_coords = list(particles_block.find_loop("_rlnCenteredCoordinateZAngst"))
+    assert len(x_coords) == 2
+    assert float(x_coords[0]) == (62.5 * 4 - 3000) * 1.2
+    assert float(x_coords[1]) == (94.0 * 4 - 3000) * 1.2
+    assert len(y_coords) == 2
+    assert float(y_coords[0]) == (73 * 4 - 2000) * 1.2
+    assert float(y_coords[1]) == (105 * 4 - 2000) * 1.2
+    assert len(z_coords) == 2
+    assert float(z_coords[0]) == (80 * 4 - 800) * 1.2
+    assert float(z_coords[1]) == (110 * 4 - 800) * 1.2


### PR DESCRIPTION
Relion particle extraction failed to recognise the particle positions when un-centered in the tomogram. This applies the centering and unit conversion to the `particles.star` file made after picking.

Doing this requires more of the `relion_options` to be set. These *should* be set by the `tomo_align` service prior to picking, but they could be passed into picking as inputs if we wanted to be more sure of them being set.

These coordinate corrections appear to work for tomograms without a pre-tilt. The case of a pre-tilt is still to be investigated but these changes are useful enough to go in now anyway.