### PR TITLE
Tomogram re-run star file fixes

### DIFF
--- a/src/cryoemservices/services/tomo_align.py
+++ b/src/cryoemservices/services/tomo_align.py
@@ -371,7 +371,7 @@ class TomoAlign(CommonService):
         )
 
         if not job_is_rerun:
-            # Send to node creator
+            # Send to node creator if this is the first time this tomogram is made
             self.log.info("Sending tomo align to node creator")
             node_creator_parameters = {
                 "experiment_type": "tomography",

--- a/src/cryoemservices/services/tomo_align.py
+++ b/src/cryoemservices/services/tomo_align.py
@@ -362,27 +362,32 @@ class TomoAlign(CommonService):
 
         # Do alignment with AreTomo
         aretomo_output_path = alignment_output_dir / f"{stack_name}_aretomo.mrc"
+        if aretomo_output_path.is_file():
+            job_is_rerun = True
+        else:
+            job_is_rerun = False
         aretomo_result, aretomo_command = self.aretomo(
             tomo_params, aretomo_output_path, angle_file
         )
 
-        # Send to node creator
-        self.log.info("Sending tomo align to node creator")
-        node_creator_parameters = {
-            "experiment_type": "tomography",
-            "job_type": self.job_type,
-            "input_file": self.input_file_list_of_lists[0][0],
-            "output_file": str(aretomo_output_path),
-            "relion_options": dict(tomo_params.relion_options),
-            "command": " ".join(aretomo_command),
-            "stdout": aretomo_result.stdout.decode("utf8", "replace"),
-            "stderr": aretomo_result.stderr.decode("utf8", "replace"),
-        }
-        if aretomo_result.returncode:
-            node_creator_parameters["success"] = False
-        else:
-            node_creator_parameters["success"] = True
-        rw.send_to("node_creator", node_creator_parameters)
+        if not job_is_rerun:
+            # Send to node creator
+            self.log.info("Sending tomo align to node creator")
+            node_creator_parameters = {
+                "experiment_type": "tomography",
+                "job_type": self.job_type,
+                "input_file": self.input_file_list_of_lists[0][0],
+                "output_file": str(aretomo_output_path),
+                "relion_options": dict(tomo_params.relion_options),
+                "command": " ".join(aretomo_command),
+                "stdout": aretomo_result.stdout.decode("utf8", "replace"),
+                "stderr": aretomo_result.stderr.decode("utf8", "replace"),
+            }
+            if aretomo_result.returncode:
+                node_creator_parameters["success"] = False
+            else:
+                node_creator_parameters["success"] = True
+            rw.send_to("node_creator", node_creator_parameters)
 
         # Stop here if the job failed
         if aretomo_result.returncode or not aretomo_output_path.is_file():

--- a/src/cryoemservices/util/tomo_output_files.py
+++ b/src/cryoemservices/util/tomo_output_files.py
@@ -397,8 +397,20 @@ def _exclude_tilt_output_files(
         movies_loop.add_row(added_line)
         output_cif.write_file(str(movies_file), style=cif.Style.Simple)
     else:
-        with open(movies_file, "a") as output_cif:
-            output_cif.write(" ".join(added_line) + "\n")
+        tilt_cif_doc = cif.read_file(str(movies_file))
+        tilt_loop = list(tilt_cif_doc.sole_block().find_loop("_rlnMicrographName"))
+
+        if micrograph_name not in tilt_loop:
+            with open(movies_file, "a") as output_cif:
+                output_cif.write(" ".join(added_line) + "\n")
+        else:
+            index_to_replace = tilt_loop.index(micrograph_name)
+            tilt_cif_item = tilt_cif_doc.sole_block()[0]
+            tilt_cif_table = tilt_cif_doc.sole_block().item_as_table(tilt_cif_item)
+            tilt_cif_table.remove_row(index_to_replace)
+            tilt_cif_table.append_row(added_line)
+            movies_file.unlink()
+            tilt_cif_doc.write_file(str(movies_file))
 
     return {
         f"{job_dir}/selected_tilt_series.star": ["TomogramGroupMetadata", ["relion"]]
@@ -510,8 +522,20 @@ def _align_tilt_output_files(
         movies_loop.add_row(added_line)
         output_cif.write_file(str(movies_file), style=cif.Style.Simple)
     else:
-        with open(movies_file, "a") as output_cif:
-            output_cif.write(" ".join(added_line) + "\n")
+        tilt_cif_doc = cif.read_file(str(movies_file))
+        tilt_loop = list(tilt_cif_doc.sole_block().find_loop("_rlnMicrographName"))
+
+        if micrograph_name not in tilt_loop:
+            with open(movies_file, "a") as output_cif:
+                output_cif.write(" ".join(added_line) + "\n")
+        else:
+            index_to_replace = tilt_loop.index(micrograph_name)
+            tilt_cif_item = tilt_cif_doc.sole_block()[0]
+            tilt_cif_table = tilt_cif_doc.sole_block().item_as_table(tilt_cif_item)
+            tilt_cif_table.remove_row(index_to_replace)
+            tilt_cif_table.append_row(added_line)
+            movies_file.unlink()
+            tilt_cif_doc.write_file(str(movies_file))
 
     return {
         f"{job_dir}/aligned_tilt_series.star": ["TomogramGroupMetadata", ["relion"]]


### PR DESCRIPTION
In the existing setup, if a tomogram is processed twice it will get inserted into star files twice. This resolves that and provides only a single insert.

For tomograms, denoising and segmentation this is as simple as not re-sending the node creator request.

For alignment parameters and picks we need to first remove the existing values from the star files, then add in the new values instead.