### PR TITLE
Fully resolve symlinks when checking their destination

### DIFF
--- a/src/cryoemservices/services/cryolo.py
+++ b/src/cryoemservices/services/cryolo.py
@@ -167,7 +167,11 @@ class CrYOLO(CommonService):
         job_alias = job_dir.parent / "Live_cryolo"
         if not job_alias.exists():
             job_alias.symlink_to(job_dir)
-        elif not (job_alias.is_symlink() and job_alias.readlink() == job_dir):
+        elif not (
+            job_alias.is_symlink()
+            and (job_alias.parent.resolve() / job_alias.name).resolve()
+            == job_dir.resolve()
+        ):
             self.log.error(f"Symlink {job_alias} already exists")
             rw.transport.nack(header)
             return

--- a/src/cryoemservices/services/cryolo.py
+++ b/src/cryoemservices/services/cryolo.py
@@ -167,11 +167,7 @@ class CrYOLO(CommonService):
         job_alias = job_dir.parent / "Live_cryolo"
         if not job_alias.exists():
             job_alias.symlink_to(job_dir)
-        elif not (
-            job_alias.is_symlink()
-            and (job_alias.parent.resolve() / job_alias.name).resolve()
-            == job_dir.resolve()
-        ):
+        elif not (job_alias.is_symlink() and job_alias.resolve() == job_dir.resolve()):
             self.log.error(f"Symlink {job_alias} already exists")
             rw.transport.nack(header)
             return

--- a/src/cryoemservices/services/ctffind.py
+++ b/src/cryoemservices/services/ctffind.py
@@ -181,7 +181,7 @@ class CTFFind(CommonService):
             job_alias.symlink_to(job_alias.parent / f"job{ctf_job_number:03}")
         elif not (
             job_alias.is_symlink()
-            and (job_alias.parent.resolve() / job_alias.name).resolve()
+            and job_alias.resolve()
             == (job_alias.parent / f"job{ctf_job_number:03}").resolve()
         ):
             self.log.error(f"Symlink {job_alias} already exists")

--- a/src/cryoemservices/services/ctffind.py
+++ b/src/cryoemservices/services/ctffind.py
@@ -181,7 +181,8 @@ class CTFFind(CommonService):
             job_alias.symlink_to(job_alias.parent / f"job{ctf_job_number:03}")
         elif not (
             job_alias.is_symlink()
-            and job_alias.readlink() == job_alias.parent / f"job{ctf_job_number:03}"
+            and (job_alias.parent.resolve() / job_alias.name).resolve()
+            == (job_alias.parent / f"job{ctf_job_number:03}").resolve()
         ):
             self.log.error(f"Symlink {job_alias} already exists")
             rw.transport.nack(header)

--- a/src/cryoemservices/services/extract.py
+++ b/src/cryoemservices/services/extract.py
@@ -127,11 +127,7 @@ class Extract(CommonService):
         job_alias = job_dir.parent / "Live_all_particles"
         if not job_alias.exists():
             job_alias.symlink_to(job_dir)
-        elif not (
-            job_alias.is_symlink()
-            and (job_alias.parent.resolve() / job_alias.name).resolve()
-            == job_dir.resolve()
-        ):
+        elif not (job_alias.is_symlink() and job_alias.resolve() == job_dir.resolve()):
             self.log.error(f"Symlink {job_alias} already exists")
             rw.transport.nack(header)
             return

--- a/src/cryoemservices/services/extract.py
+++ b/src/cryoemservices/services/extract.py
@@ -127,7 +127,11 @@ class Extract(CommonService):
         job_alias = job_dir.parent / "Live_all_particles"
         if not job_alias.exists():
             job_alias.symlink_to(job_dir)
-        elif not (job_alias.is_symlink() and job_alias.readlink() == job_dir):
+        elif not (
+            job_alias.is_symlink()
+            and (job_alias.parent.resolve() / job_alias.name).resolve()
+            == job_dir.resolve()
+        ):
             self.log.error(f"Symlink {job_alias} already exists")
             rw.transport.nack(header)
             return

--- a/src/cryoemservices/services/motioncorr.py
+++ b/src/cryoemservices/services/motioncorr.py
@@ -324,7 +324,7 @@ class MotionCorr(CommonService):
             job_alias.symlink_to(job_alias.parent / f"job{job_number:03}")
         elif not (
             job_alias.is_symlink()
-            and (job_alias.parent.resolve() / job_alias.name).resolve()
+            and job_alias.resolve()
             == (job_alias.parent / f"job{job_number:03}").resolve()
         ):
             self.log.error(f"Symlink {job_alias} already exists")

--- a/src/cryoemservices/services/motioncorr.py
+++ b/src/cryoemservices/services/motioncorr.py
@@ -324,7 +324,8 @@ class MotionCorr(CommonService):
             job_alias.symlink_to(job_alias.parent / f"job{job_number:03}")
         elif not (
             job_alias.is_symlink()
-            and job_alias.readlink() == job_alias.parent / f"job{job_number:03}"
+            and (job_alias.parent.resolve() / job_alias.name).resolve()
+            == (job_alias.parent / f"job{job_number:03}").resolve()
         ):
             self.log.error(f"Symlink {job_alias} already exists")
             rw.transport.nack(header)

--- a/src/cryoemservices/services/node_creator.py
+++ b/src/cryoemservices/services/node_creator.py
@@ -522,9 +522,6 @@ class NodeCreator(CommonService):
             except FileNotFoundError:
                 self.log.warning("No job lock found to remove")
 
-        if job_info.alias:
-            (job_dir.parent / job_info.alias).unlink(missing_ok=True)
-
         # Create the node and default_pipeline.star files in the project directory
         with CachedProjectGraph(
             read_only=False, pipeline_dir=str(project_dir), name="default"
@@ -561,9 +558,6 @@ class NodeCreator(CommonService):
             "relion.select.class2dauto",
             "icebreaker.micrograph_analysis.particles",
         ]:
-            if job_info.alias:
-                # Unlink the alias again as it will be recreated
-                (job_dir.parent / job_info.alias).unlink(missing_ok=True)
             # Set up a "short_pipeline.star" for SPA which excludes the 2D batches
             with CachedProjectGraph(
                 read_only=False,

--- a/src/cryoemservices/services/select_classes.py
+++ b/src/cryoemservices/services/select_classes.py
@@ -344,7 +344,11 @@ class SelectClasses(CommonService):
         job_alias = Path(project_dir / "Select/Live_best_particles")
         if not job_alias.exists():
             job_alias.symlink_to(combine_star_dir)
-        elif not (job_alias.is_symlink() and job_alias.readlink() == combine_star_dir):
+        elif not (
+            job_alias.is_symlink()
+            and (job_alias.parent.resolve() / job_alias.name).resolve()
+            == combine_star_dir.resolve()
+        ):
             self.log.error(f"Symlink {job_alias} already exists")
             rw.transport.nack(header)
             return

--- a/src/cryoemservices/services/select_classes.py
+++ b/src/cryoemservices/services/select_classes.py
@@ -345,9 +345,7 @@ class SelectClasses(CommonService):
         if not job_alias.exists():
             job_alias.symlink_to(combine_star_dir)
         elif not (
-            job_alias.is_symlink()
-            and (job_alias.parent.resolve() / job_alias.name).resolve()
-            == combine_star_dir.resolve()
+            job_alias.is_symlink() and job_alias.resolve() == combine_star_dir.resolve()
         ):
             self.log.error(f"Symlink {job_alias} already exists")
             rw.transport.nack(header)

--- a/src/cryoemservices/services/select_particles.py
+++ b/src/cryoemservices/services/select_particles.py
@@ -96,9 +96,7 @@ class SelectParticles(CommonService):
         if not job_alias.exists():
             job_alias.symlink_to(select_dir)
         elif not (
-            job_alias.is_symlink()
-            and (job_alias.parent.resolve() / job_alias.name).resolve()
-            == select_dir.resolve()
+            job_alias.is_symlink() and job_alias.resolve() == select_dir.resolve()
         ):
             self.log.error(f"Symlink {job_alias} already exists")
             rw.transport.nack(header)

--- a/src/cryoemservices/services/select_particles.py
+++ b/src/cryoemservices/services/select_particles.py
@@ -95,7 +95,11 @@ class SelectParticles(CommonService):
         job_alias = select_dir.parent / "Live_particle_batches"
         if not job_alias.exists():
             job_alias.symlink_to(select_dir)
-        elif not (job_alias.is_symlink() and job_alias.readlink() == select_dir):
+        elif not (
+            job_alias.is_symlink()
+            and (job_alias.parent.resolve() / job_alias.name).resolve()
+            == select_dir.resolve()
+        ):
             self.log.error(f"Symlink {job_alias} already exists")
             rw.transport.nack(header)
             return

--- a/src/cryoemservices/services/topaz_pick.py
+++ b/src/cryoemservices/services/topaz_pick.py
@@ -121,7 +121,7 @@ class TopazPick(CommonService):
             job_alias.symlink_to(job_alias.parent / f"job{job_number:03}")
         elif not (
             job_alias.is_symlink()
-            and (job_alias.parent.resolve() / job_alias.name).resolve()
+            and job_alias.resolve()
             == (job_alias.parent / f"job{job_number:03}").resolve()
         ):
             self.log.error(f"Symlink {job_alias} already exists")

--- a/src/cryoemservices/services/topaz_pick.py
+++ b/src/cryoemservices/services/topaz_pick.py
@@ -121,7 +121,8 @@ class TopazPick(CommonService):
             job_alias.symlink_to(job_alias.parent / f"job{job_number:03}")
         elif not (
             job_alias.is_symlink()
-            and job_alias.readlink() == job_alias.parent / f"job{job_number:03}"
+            and (job_alias.parent.resolve() / job_alias.name).resolve()
+            == (job_alias.parent / f"job{job_number:03}").resolve()
         ):
             self.log.error(f"Symlink {job_alias} already exists")
             rw.transport.nack(header)


### PR DESCRIPTION
`readlink()` does not evaluate links of the form `../MotionCorr/job002` correctly as they end up relative to CWD.

This fixes the issue by resolving the link parent first and then adding the link location.