### PR TITLE
Send smartem results to murfey

### DIFF
--- a/recipes/ispyb/em-spa-preprocess.json
+++ b/recipes/ispyb/em-spa-preprocess.json
@@ -18,9 +18,11 @@
       "icebreaker": 6,
       "images": 5,
       "ispyb_connector": 4,
-      "node_creator": 3
+      "node_creator": 3,
+      "smartem": 10
     },
     "parameters": {
+      "app_id": "{autoproc_program_id}",
       "do_icebreaker_jobs": "{do_icebreaker_jobs}",
       "dose_per_frame": "{fm_dose}",
       "eer_sampling": 1,
@@ -78,11 +80,15 @@
     "service": "IceBreaker"
   },
   "8": {
+    "parameters": {
+      "app_id": "{autoproc_program_id}"
+    },
     "output": {
       "cryolo": 9,
       "images": 5,
       "ispyb_connector": 4,
-      "node_creator": 3
+      "node_creator": 3,
+      "smartem": 10
     },
     "queue": "ctffind",
     "service": "CTFFind"
@@ -95,6 +101,7 @@
       "node_creator": 3
     },
     "parameters": {
+      "app_id": "{autoproc_program_id}",
       "particle_diameter": "{particle_diameter}",
       "cryolo_model_weights": "{cryolo_model_weights}",
       "retained_fraction": "0.7"

--- a/src/cryoemservices/services/ctffind.py
+++ b/src/cryoemservices/services/ctffind.py
@@ -354,7 +354,8 @@ class CTFFind(CommonService):
                 rw.send_to(
                     "smartem",
                     {
-                        "ctf_max_resolution_estimate": self.estimated_resolution,
+                        "register": "spa.ctf_estimated",
+                        "ctf_max_resolution": self.estimated_resolution,
                         "ice_ring_density": ice_ring_density,
                         "app_id": ctf_params.app_id,
                         "mc_uuid": ctf_params.mc_uuid,

--- a/src/cryoemservices/services/motioncorr.py
+++ b/src/cryoemservices/services/motioncorr.py
@@ -737,6 +737,7 @@ class MotionCorr(CommonService):
             rw.send_to(
                 "smartem",
                 {
+                    "register": "spa.motion_corrected",
                     "total_motion": total_motion,
                     "average_motion": average_motion_per_frame,
                     "app_id": mc_params.app_id,


### PR DESCRIPTION
Pairs with https://github.com/DiamondLightSource/python-murfey/pull/772

Instead of sending to smartem, send the results from motion correction and ctffind to murfey