### PR TITLE
B24 display fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ murfey_db = [
 torch = [
     "membrain-seg",
     "topaz-em",
+    "torch==2.11.0",
 ]
 [project.urls]
     Bug-Tracker = "https://github.com/DiamondLightSource/cryoem-services/issues"

--- a/recipes/ispyb/sxt-aretomo.json
+++ b/recipes/ispyb/sxt-aretomo.json
@@ -23,9 +23,9 @@
     },
     "parameters": {
       "dark_tol": 0,
-      "manual_tilt_offset": 0,
+      "manual_tilt_offset": "{manual_tilt_offset}",
       "out_bin": 1,
-      "pixel_size": 100,
+      "pixel_size": "{pixel_size}",
       "relion_options": {},
       "stack_file": "{stack_file}",
       "tilt_axis": 0,

--- a/src/cryoemservices/services/images_plugins.py
+++ b/src/cryoemservices/services/images_plugins.py
@@ -884,17 +884,38 @@ def tilt_series_alignment(plugin_params: Callable):
         )
 
     # Text to record outliers and colour key
+    text_scaling = flat_size[0] / 4096
     if outliers:
         dim.text(
-            (100, cen[1] * 2 - 200),
+            (100 * text_scaling, cen[1] * 2 - 200 * text_scaling),
             "Outliers (deg): " + " ".join(outliers),
             fill="#f52407",
-            font_size=150,
+            font_size=150 * text_scaling,
         )
-    dim.text((100, 10), "Shift over 100 nm", fill="#f52407", font_size=150)
-    dim.text((100, 160), "Shift 10 to 100 nm", fill="#f5a927", font_size=150)
-    dim.text((100, 320), "Shift 1 to 10 nm", fill="#f5e90a", font_size=150)
-    dim.text((100, 460), "Shift under 1 nm", fill="#0af549", font_size=150)
+    dim.text(
+        (100 * text_scaling, 10),
+        "Shift over 100 nm",
+        fill="#f52407",
+        font_size=150 * text_scaling,
+    )
+    dim.text(
+        (100 * text_scaling, 10 + 150 * text_scaling),
+        "Shift 10 to 100 nm",
+        fill="#f5a927",
+        font_size=150 * text_scaling,
+    )
+    dim.text(
+        (100 * text_scaling, 10 + 300 * text_scaling),
+        "Shift 1 to 10 nm",
+        fill="#f5e90a",
+        font_size=150 * text_scaling,
+    )
+    dim.text(
+        (100 * text_scaling, 10 + 450 * text_scaling),
+        "Shift under 1 nm",
+        fill="#0af549",
+        font_size=150 * text_scaling,
+    )
     colour_im.thumbnail((1024, 1024))
     colour_im.save(outfile)
     timing = time.perf_counter() - start

--- a/src/cryoemservices/services/tomo_align.py
+++ b/src/cryoemservices/services/tomo_align.py
@@ -869,7 +869,7 @@ class TomoAlign(CommonService):
                     txrm_ole.openstream("ImageInfo/PixelSize").getvalue(),
                     np.float32,
                 ).tolist()
-                pixel_size_angstroms = pixel_size_microns[0] * 1e4
+                pixel_size_angstroms = round(pixel_size_microns[0] * 1e4, 2)
 
         # Convert the txrm to a tiff stack, then convert to mrc for aretomo
         tifftomo = Path(stack_file).with_suffix(".tiff")

--- a/src/cryoemservices/services/tomo_align.py
+++ b/src/cryoemservices/services/tomo_align.py
@@ -601,6 +601,11 @@ class TomoAlign(CommonService):
                 )
 
         # Forward tomogram (one per-tilt-series)
+        side_projection = (
+            "YZ"
+            if tomo_params.tilt_axis is not None and -45 < tomo_params.tilt_axis < 45
+            else "XZ"
+        )
         ispyb_command_list = [
             {
                 "ispyb_command": "insert_tomogram",
@@ -621,7 +626,7 @@ class TomoAlign(CommonService):
                 "tomogram_movie": stack_name + "_Vol_movie.png",
                 "xy_shift_plot": plot_file,
                 "proj_xy": stack_name + "_Vol_projXY.jpeg",
-                "proj_xz": stack_name + "_Vol_projXZ.jpeg",
+                "proj_xz": stack_name + f"_Vol_proj{side_projection}.jpeg",
                 "alignment_quality": str(self.alignment_quality),
             }
         ]
@@ -800,11 +805,6 @@ class TomoAlign(CommonService):
         )
 
         self.log.info("Sending to images service for XY and XZ projections")
-        side_projection = (
-            "YZ"
-            if tomo_params.tilt_axis is not None and -45 < tomo_params.tilt_axis < 45
-            else "XZ"
-        )
         for projection_type in ["XY", side_projection]:
             images_call_params: dict[str, str | float] = {
                 "image_command": "mrc_projection",

--- a/src/cryoemservices/services/tomo_align.py
+++ b/src/cryoemservices/services/tomo_align.py
@@ -13,12 +13,9 @@ import mrcfile
 import numpy as np
 import plotly.express as px
 from gemmi import cif
+from olefile import OleFileIO
 from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
-from txrm2tiff.inspector import Inspector
 from txrm2tiff.main import convert_and_save
-from txrm2tiff.txrm import open_txrm
-from txrm2tiff.txrm_functions.general import read_stream
-from txrm2tiff.xradia_properties.enums import XrmDataTypes
 from workflows.recipe import wrap_subscribe
 
 from cryoemservices.services.common_service import CommonService
@@ -859,23 +856,20 @@ class TomoAlign(CommonService):
 
     def convert_txrm_to_stack(self, txrm_file: str, stack_file: str) -> float:
         # Read the tilt angles and pixel size from the txrm
-        with open_txrm(
-            txrm_file, load_images=False, load_reference=False, strict=False
-        ) as txrm:
-            inspector = Inspector(txrm)
-            angles = read_stream(
-                inspector.txrm.ole,
-                "ImageInfo/Angles",
-                XrmDataTypes.XRM_FLOAT,
-                strict=True,
-            )
-            pixel_size_microns = read_stream(
-                inspector.txrm.ole,
-                "ImageInfo/PixelSize",
-                XrmDataTypes.XRM_FLOAT,
-                strict=True,
-            )
-        self.tilt_angles = dict(enumerate(angles))
+        pixel_size_angstroms = 100
+        with OleFileIO(txrm_file) as txrm_ole:
+            if txrm_ole.exists("ImageInfo/Angles"):
+                angles = np.frombuffer(
+                    txrm_ole.openstream("ImageInfo/Angles").getvalue(), np.float32
+                ).tolist()
+                self.tilt_angles = dict(enumerate(angles))
+
+            if txrm_ole.exists("ImageInfo/PixelSize"):
+                pixel_size_microns = np.frombuffer(
+                    txrm_ole.openstream("ImageInfo/PixelSize").getvalue(),
+                    np.float32,
+                ).tolist()
+                pixel_size_angstroms = pixel_size_microns[0] * 1e4
 
         # Convert the txrm to a tiff stack, then convert to mrc for aretomo
         tifftomo = Path(stack_file).with_suffix(".tiff")
@@ -883,9 +877,7 @@ class TomoAlign(CommonService):
         # Let this run, and check later if the output file exists
         subprocess.run(["tif2mrc", str(tifftomo), stack_file])
         tifftomo.unlink(missing_ok=True)
-        if pixel_size_microns:
-            return pixel_size_microns[0] * 1000
-        return 100
+        return pixel_size_angstroms
 
     def assemble_aretomo3_command(
         self,

--- a/tests/services/test_tomo_align.py
+++ b/tests/services/test_tomo_align.py
@@ -2277,7 +2277,7 @@ def test_tomo_align_service_txrm(
                     "tomogram_movie": "stack_Vol_movie.png",
                     "xy_shift_plot": "stack_xy_shift_plot.json",
                     "proj_xy": "stack_Vol_projXY.jpeg",
-                    "proj_xz": "stack_Vol_projXZ.jpeg",
+                    "proj_xz": "stack_Vol_projYZ.jpeg",
                     "alignment_quality": "0.5",
                 },
                 {

--- a/tests/services/test_tomo_align.py
+++ b/tests/services/test_tomo_align.py
@@ -9,7 +9,6 @@ from unittest import mock
 import mrcfile
 import numpy as np
 import pytest
-from txrm2tiff.xradia_properties.enums import XrmDataTypes
 from workflows.transport.offline_transport import OfflineTransport
 
 from cryoemservices.services import tomo_align
@@ -2084,17 +2083,13 @@ def test_tomo_align_service_fail_case(
 @mock.patch("cryoemservices.services.tomo_align.subprocess.run")
 @mock.patch("cryoemservices.services.tomo_align.mrcfile")
 @mock.patch("cryoemservices.services.tomo_align.convert_and_save")
-@mock.patch("cryoemservices.services.tomo_align.open_txrm")
-@mock.patch("cryoemservices.services.tomo_align.Inspector")
-@mock.patch("cryoemservices.services.tomo_align.read_stream")
+@mock.patch("cryoemservices.services.tomo_align.OleFileIO")
 @mock.patch("cryoemservices.services.tomo_align.resize_tomogram")
 @mock.patch("cryoemservices.services.tomo_align.rotate_tomogram")
 def test_tomo_align_service_txrm(
     mock_rotate,
     mock_resize,
-    mock_read_stream,
-    mock_inspector,
-    mock_open_txrm,
+    mock_ole_file,
     mock_convert_and_save,
     mock_mrcfile,
     mock_subprocess,
@@ -2105,7 +2100,10 @@ def test_tomo_align_service_txrm(
     Send a test message to TomoAlign (AreTomo3) for a txrm file
     """
     mock_mrcfile.open().__enter__().header = MrcFileHeader(nx=4000, ny=3000, nz=600)
-    mock_read_stream.return_value = [0.1, 0.3, 0.5]
+    mock_ole_file().__enter__().exists.return_value = True
+    mock_ole_file().__enter__().openstream().getvalue.return_value = np.array(
+        [0.01, 0.3, 0.5], dtype=np.float32
+    ).tobytes()
 
     header = {
         "message-id": mock.sentinel,
@@ -2199,26 +2197,15 @@ def test_tomo_align_service_txrm(
     ]
 
     # Check txrm file reading
-    mock_open_txrm.assert_called_once_with(
-        tomo_align_test_message["txrm_file"],
-        load_images=False,
-        load_reference=False,
-        strict=False,
-    )
-    mock_open_txrm().__enter__.assert_called_once()
-    mock_inspector.assert_called_once()
-    mock_read_stream.assert_any_call(
-        mock.ANY,
+    mock_ole_file.assert_any_call(tomo_align_test_message["txrm_file"])
+    assert mock_ole_file().__enter__().exists.call_count == 2
+    assert mock_ole_file().__enter__().openstream.call_count == 3  # 2 + 1 above
+    for field_name in [
         "ImageInfo/Angles",
-        XrmDataTypes.XRM_FLOAT,
-        strict=True,
-    )
-    mock_read_stream.assert_any_call(
-        mock.ANY,
         "ImageInfo/PixelSize",
-        XrmDataTypes.XRM_FLOAT,
-        strict=True,
-    )
+    ]:
+        mock_ole_file().__enter__().exists.assert_any_call(field_name)
+        mock_ole_file().__enter__().openstream.assert_any_call(field_name)
     mock_convert_and_save.assert_called_once_with(
         tomo_align_test_message["txrm_file"],
         f"{tmp_path}/Tomograms/stack.tiff",
@@ -2247,7 +2234,7 @@ def test_tomo_align_service_txrm(
     assert (tmp_path / "Tomograms/stack_TLT.txt").is_file()
     with open(tmp_path / "Tomograms/stack_TLT.txt", "r") as angfile:
         angles_data = angfile.read()
-    assert angles_data == "0.10  0\n0.30  1\n0.50  2\n"
+    assert angles_data == "0.01  0\n0.30  1\n0.50  2\n"
 
     # Check the shift plot
     with open(tmp_path / "Tomograms/stack_xy_shift_plot.json") as shift_plot:


### PR DESCRIPTION
Fixes a few display issues with the images for b24 tomograms:
- Tomo align should display YZ not XZ
- The text on the alignment image assumed the image was bigger than it is for b24, so a scaling is now applied
- Uses olefile directly where possible rather than txrm2tiff
- Two parameters in the recipe should not be hard-coded

This is not the full set of fixes needed, but does make the displays work. Also needed will be to make the alignment image tilt on the opposite axis, and display the motion in different units TBC.