### PR TITLE
Run 3D classification using multiple initial models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ murfey_db = [
 torch = [
     "membrain-seg",
     "topaz-em",
+    "torch==2.11.0",
 ]
 [project.urls]
     Bug-Tracker = "https://github.com/DiamondLightSource/cryoem-services/issues"

--- a/src/cryoemservices/wrappers/class3d_wrapper.py
+++ b/src/cryoemservices/wrappers/class3d_wrapper.py
@@ -156,12 +156,20 @@ def run_initial_model(
         initial_model_command, cwd=str(project_dir), capture_output=True
     )
 
+    if initial_model_params.multiple_initial_models:
+        ini_model_file = (
+            job_dir
+            / f"run_it{initial_model_params.initial_model_iterations:03}_model.star"
+        )
+    else:
+        ini_model_file = job_dir / "initial_model.mrc"
+
     # Register the initial model job with the node creator
     logger.info("Sending relion.initialmodel (model) to node creator")
     node_creator_parameters_refine: dict = {
         "job_type": "relion.initialmodel",
         "input_file": f"{project_dir}/{particles_file}",
-        "output_file": f"{job_dir}/initial_model.mrc",
+        "output_file": str(ini_model_file),
         "relion_options": dict(initial_model_params.relion_options),
         "command": " ".join(initial_model_command),
         "stdout": result.stdout.decode("utf8", "replace"),
@@ -178,13 +186,7 @@ def run_initial_model(
         )
         return "", []
 
-    if initial_model_params.multiple_initial_models:
-        ini_model_file = (
-            job_dir
-            / f"run_it{initial_model_params.initial_model_iterations:03}_model.star"
-        )
-    else:
-        ini_model_file = job_dir / "initial_model.mrc"
+    if not initial_model_params.multiple_initial_models:
         align_symmetry_command = [
             "relion_align_symmetry",
             "--i",
@@ -510,7 +512,7 @@ def run_class3d(class3d_params: Class3DParameters, send_to_rabbitmq: Callable) -
             "class_distribution": classes_loop[class_id, 1],
             "rotation_accuracy": classes_loop[class_id, 2],
             "translation_accuracy": classes_loop[class_id, 3],
-            "angular_efficiency": class_efficiencies[class_id],
+            "angular_efficiency": float(class_efficiencies[class_id]),
             "suggested_tilt": 0 if class_efficiencies[class_id] > 0.65 else 30,
         }
         if job_is_rerun:

--- a/src/cryoemservices/wrappers/class3d_wrapper.py
+++ b/src/cryoemservices/wrappers/class3d_wrapper.py
@@ -56,6 +56,7 @@ class Class3DParameters(BaseModel):
     initial_model_offset_range: float = 6
     initial_model_offset_step: float = 2
     start_initial_model_C1: bool = True
+    multiple_initial_models: bool = True
     dont_combine_weights_via_disc: bool = True
     preread_images: bool = True
     scratch_dir: str | None = None
@@ -177,57 +178,63 @@ def run_initial_model(
         )
         return "", []
 
-    ini_model_file = job_dir / "initial_model.mrc"
-    align_symmetry_command = [
-        "relion_align_symmetry",
-        "--i",
-        str(
-            job_dir.relative_to(project_dir)
+    if initial_model_params.multiple_initial_models:
+        ini_model_file = (
+            job_dir
             / f"run_it{initial_model_params.initial_model_iterations:03}_model.star"
-        ),
-        "--o",
-        f"{ini_model_file.relative_to(project_dir)}",
-        "--sym",
-        initial_model_params.symmetry,
-        "--apply_sym",
-        "--select_largest_class",
-        "--pipeline_control",
-        f"{job_dir.relative_to(project_dir)}/",
-    ]
-
-    # Run symmetry alignment and confirm it ran successfully
-    logger.info("Running symmetry alignment")
-    result = subprocess.run(
-        align_symmetry_command, cwd=str(project_dir), capture_output=True
-    )
-
-    # Register the initial model job with the node creator
-    logger.info("Sending relion.initialmodel (alignment) to node creator")
-    node_creator_parameters_symmetry: dict = {
-        "job_type": "relion.initialmodel",
-        "input_file": f"{project_dir}/{particles_file}",
-        "output_file": f"{job_dir}/initial_model.mrc",
-        "relion_options": dict(initial_model_params.relion_options),
-        "command": " ".join(align_symmetry_command),
-        "stdout": result.stdout.decode("utf8", "replace"),
-        "stderr": result.stderr.decode("utf8", "replace"),
-        "success": (result.returncode == 0),
-    }
-    send_to_rabbitmq("node_creator", node_creator_parameters_symmetry)
-
-    # End here if the command failed
-    if result.returncode:
-        logger.error(
-            f"Relion initial model symmetry alignment "
-            f"failed with exitcode {result.returncode}:\n"
-            + result.stderr.decode("utf8", "replace")
         )
-        return "", []
+    else:
+        ini_model_file = job_dir / "initial_model.mrc"
+        align_symmetry_command = [
+            "relion_align_symmetry",
+            "--i",
+            str(
+                job_dir.relative_to(project_dir)
+                / f"run_it{initial_model_params.initial_model_iterations:03}_model.star"
+            ),
+            "--o",
+            f"{ini_model_file.relative_to(project_dir)}",
+            "--sym",
+            initial_model_params.symmetry,
+            "--apply_sym",
+            "--select_largest_class",
+            "--pipeline_control",
+            f"{job_dir.relative_to(project_dir)}/",
+        ]
+
+        # Run symmetry alignment and confirm it ran successfully
+        logger.info("Running symmetry alignment")
+        result = subprocess.run(
+            align_symmetry_command, cwd=str(project_dir), capture_output=True
+        )
+
+        # Register the initial model job with the node creator
+        logger.info("Sending relion.initialmodel (alignment) to node creator")
+        node_creator_parameters_symmetry: dict = {
+            "job_type": "relion.initialmodel",
+            "input_file": f"{project_dir}/{particles_file}",
+            "output_file": f"{job_dir}/initial_model.mrc",
+            "relion_options": dict(initial_model_params.relion_options),
+            "command": " ".join(align_symmetry_command),
+            "stdout": result.stdout.decode("utf8", "replace"),
+            "stderr": result.stderr.decode("utf8", "replace"),
+            "success": (result.returncode == 0),
+        }
+        send_to_rabbitmq("node_creator", node_creator_parameters_symmetry)
+
+        # End here if the command failed
+        if result.returncode:
+            logger.error(
+                f"Relion initial model symmetry alignment "
+                f"failed with exitcode {result.returncode}:\n"
+                + result.stderr.decode("utf8", "replace")
+            )
+            return "", []
 
     # Send Murfey the location of the initial model
     murfey_params = {
         "register": "save_initial_model",
-        "initial_model": f"{job_dir}/initial_model.mrc",
+        "initial_model": str(ini_model_file),
     }
     send_to_rabbitmq("murfey_feedback", murfey_params)
 
@@ -248,20 +255,9 @@ def run_initial_model(
         "Will send best initial model to ispyb with "
         f"resolution {resolution} and {number_of_particles} particles"
     )
-    ini_ispyb_parameters = [
-        {
-            "ispyb_command": "buffer",
-            "buffer_lookup": {
-                "particle_classification_id": class_uuids_dict[class_uuids_keys[0]]
-            },
-            "buffer_command": {"ispyb_command": "insert_cryoem_initial_model"},
-            "number_of_particles": number_of_particles,
-            "resolution": resolution,
-            "store_result": "ispyb_initial_model_id",
-        }
-    ]
-    for i in range(1, initial_model_params.class3d_nr_classes):
-        # Insert initial model for every class, sending model id each time
+    ini_ispyb_parameters: list[dict] = []
+    for i in range(initial_model_params.class3d_nr_classes):
+        # Insert initial model for every class,
         ini_ispyb_parameters.append(
             {
                 "ispyb_command": "buffer",
@@ -269,17 +265,31 @@ def run_initial_model(
                     "particle_classification_id": class_uuids_dict[class_uuids_keys[i]]
                 },
                 "buffer_command": {"ispyb_command": "insert_cryoem_initial_model"},
-                "number_of_particles": number_of_particles,
-                "resolution": resolution,
-                "cryoem_initial_model_id": "$ispyb_initial_model_id",
             }
         )
     for i in range(initial_model_params.class3d_nr_classes):
         # Add resolution to every model if it is finite
-        if np.isfinite(float(resolution)):
-            ini_ispyb_parameters[i]["resolution"] = resolution
+        if initial_model_params.multiple_initial_models:
+            ini_ispyb_parameters[i]["resolution"] = (
+                model_resolutions[i]
+                if np.isfinite(float(model_resolutions[i]))
+                else 0.0
+            )
+            ini_ispyb_parameters[i]["number_of_particles"] = (
+                float(model_scores[i]) * initial_model_params.batch_size
+            )
         else:
-            ini_ispyb_parameters[i]["resolution"] = 0.0
+            ini_ispyb_parameters[i]["resolution"] = (
+                resolution if np.isfinite(float(resolution)) else 0.0
+            )
+            ini_ispyb_parameters[i]["number_of_particles"] = number_of_particles
+            # Set model id for the first class, sending model id each time afterwards
+            if i == 0:
+                ini_ispyb_parameters[i]["store_result"] = "ispyb_initial_model_id"
+            else:
+                ini_ispyb_parameters[i]["cryoem_initial_model_id"] = (
+                    "$ispyb_initial_model_id"
+                )
 
     logger.info("Running 3D classification using new initial model")
     return f"{ini_model_file}", ini_ispyb_parameters

--- a/src/cryoemservices/wrappers/class3d_wrapper.py
+++ b/src/cryoemservices/wrappers/class3d_wrapper.py
@@ -212,7 +212,7 @@ def run_initial_model(
                 align_symmetry_command, cwd=str(project_dir), capture_output=True
             )
 
-    else:
+    elif not initial_model_params.multiple_initial_models:
         align_symmetry_command = [
             "relion_align_symmetry",
             "--i",

--- a/src/cryoemservices/wrappers/class3d_wrapper.py
+++ b/src/cryoemservices/wrappers/class3d_wrapper.py
@@ -186,7 +186,33 @@ def run_initial_model(
         )
         return "", []
 
-    if not initial_model_params.multiple_initial_models:
+    if (
+        initial_model_params.multiple_initial_models
+        and initial_model_params.symmetry != "C1"
+    ):
+        for model in ini_model_file.parent.glob(
+            f"{ini_model_file.stem.replace('_model', '')}_class*.mrc"
+        ):
+            align_symmetry_command = [
+                "relion_align_symmetry",
+                "--i",
+                str(model.relative_to(project_dir)),
+                "--o",
+                str(model.relative_to(project_dir)),
+                "--sym",
+                initial_model_params.symmetry,
+                "--apply_sym",
+                "--pipeline_control",
+                f"{job_dir.relative_to(project_dir)}/",
+            ]
+
+            # Run symmetry alignment and confirm it ran successfully
+            logger.info(f"Running symmetry alignment for {model.name}")
+            result = subprocess.run(
+                align_symmetry_command, cwd=str(project_dir), capture_output=True
+            )
+
+    else:
         align_symmetry_command = [
             "relion_align_symmetry",
             "--i",

--- a/src/cryoemservices/wrappers/class3d_wrapper.py
+++ b/src/cryoemservices/wrappers/class3d_wrapper.py
@@ -211,6 +211,12 @@ def run_initial_model(
             result = subprocess.run(
                 align_symmetry_command, cwd=str(project_dir), capture_output=True
             )
+            if result.returncode:
+                logger.error(
+                    f"Relion initial model symmetry alignment "
+                    f"failed with exitcode {result.returncode}:\n"
+                    + result.stderr.decode("utf8", "replace")
+                )
 
     elif not initial_model_params.multiple_initial_models:
         align_symmetry_command = [

--- a/tests/wrappers/test_class3d_wrapper.py
+++ b/tests/wrappers/test_class3d_wrapper.py
@@ -69,6 +69,7 @@ def test_class3d_wrapper_do_initial_model(
                     "initial_model_iterations": 10,
                     "initial_model_offset_range": 6,
                     "initial_model_offset_step": 2,
+                    "multiple_initial_models": False,
                     "mask_diameter": "190.0",
                     "mpi_run_command": "srun -n 9",
                     "nr_pool": 5,
@@ -388,6 +389,329 @@ def test_class3d_wrapper_do_initial_model(
                     "ispyb_command": "buffer",
                     "number_of_particles": 20000.0,
                     "resolution": "30.3",
+                },
+            ],
+        },
+    )
+    mock_recwrap_send.assert_any_call(
+        "murfey_feedback",
+        {
+            "register": "done_3d_batch",
+            "refine_dir": f"{tmp_path}/Refine3D/job",
+            "class3d_dir": f"{tmp_path}/Class3D/job015",
+            "best_class": 0,
+            "do_refinement": False,
+        },
+    )
+
+    assert mock_efficiency.call_count == 2
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="does not run on windows")
+@mock.patch("cryoemservices.wrappers.class3d_wrapper.find_efficiency")
+@mock.patch("cryoemservices.wrappers.class3d_wrapper.subprocess.run")
+@mock.patch("workflows.recipe.wrapper.RecipeWrapper.send_to")
+def test_class3d_wrapper_initial_model_star_file(
+    mock_recwrap_send, mock_subprocess, mock_efficiency, offline_transport, tmp_path
+):
+    """
+    Send a test message to the Class3D wrapper for a first round of 50000 particles,
+    without a provided initial model. Uses star file for multiple models
+    The initial model and 3D classification commands should be run,
+    then both cause ispyb, node_creator and murfey messages.
+    """
+    mock_subprocess().returncode = 0
+    mock_subprocess().stdout = "stdout".encode("utf8")
+    mock_subprocess().stderr = "stderr".encode("utf8")
+    mock_efficiency.return_value = 0.7
+
+    # Example recipe wrapper message to run the service with a few parameters varied
+    class3d_test_message = {
+        "recipe": {
+            "start": [[1, []]],
+            "1": {
+                "job_parameters": {
+                    "batch_size": "50000",
+                    "class_uuids": "{'0': 10, '1': 11}",
+                    "class3d_dir": f"{tmp_path}/Class3D/job015",
+                    "class3d_grp_uuid": "5",
+                    "class3d_nr_classes": "2",
+                    "do_initial_model": True,
+                    "multiple_initial_models": True,
+                    "particle_diameter": "180",
+                    "particles_file": f"{tmp_path}/Select/job013/particles_50000.star",
+                    "relion_options": {},
+                },
+                "parameters": {
+                    "cluster": {
+                        "gpus": 4,
+                        "tasks": 9,
+                    },
+                    "recipewrapper": f"{tmp_path}/Class3D/job015/.recipewrap",
+                    "workingdir": f"{tmp_path}/Class3D/job015/",
+                },
+                "queue": "cluster.submission",
+                "service": "Class3DWrapper",
+                "wrapper": {"task_information": "Class3D"},
+            },
+        },
+        "recipe-pointer": 1,
+        "environment": {"ID": "envID"},
+        "recipe-path": [],
+        "payload": [],
+    }
+    output_relion_options = RelionServiceOptions()
+    output_relion_options.particle_diameter = 180
+    output_relion_options.class3d_nr_classes = 2
+    output_relion_options.class3d_nr_iter = 20
+    output_relion_options.batch_size = 50000
+    output_relion_options = dict(output_relion_options)
+
+    # Create the expected output files
+    (tmp_path / "InitialModel/job014").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "InitialModel/job014/initial_model.mrc").touch()
+    with open(tmp_path / "InitialModel/job014/run_it200_model.star", "w") as ini_star:
+        ini_star.write(
+            "data_model_classes\nloop_\n"
+            "_rlnReferenceImage\n_rlnClassDistribution\n_rlnEstimatedResolution\n"
+            "1@InitialModel/job014/run_it010_classes.mrcs 0.4 30.3\n"
+            "2@InitialModel/job014/run_it010_classes.mrcs 0.6 20.4\n"
+        )
+
+    (tmp_path / "Class3D/job015").mkdir(parents=True, exist_ok=True)
+    with open(tmp_path / "Class3D/job015/run_it020_data.star", "w") as data_star:
+        data_star.write(
+            "data_optics\nloop_\n_rlnImagePixelSize\n2.5\n\n"
+            "data_particles\nloop_\n_rlnAngleRot\n_rlnAngleTilt\n_rlnClassNumber\n"
+            "0.5 1.0 1\n1.5 2.0 1\n2.5 3.0 2\n3.5 4.0 2\n"
+        )
+    with open(tmp_path / "Class3D/job015/run_it020_model.star", "w") as model_star:
+        model_star.write(
+            "data_model_classes\nloop_\n"
+            "_rlnReferenceImage\n_Fraction\n_Rotation\n_Translation\n"
+            "_Resolution\n_Completeness\n_OffsetX\n_OffsetY\n"
+            "1@Class3D/job015/run_it020_classes.mrcs 0.4 30.3 33.3 12.2 1.0 0.6 0.01\n"
+            "2@Class3D/job015/run_it020_classes.mrcs 0.6 20.2 22.2 10.0 0.9 -0.5 -0.02"
+        )
+
+    # Create a recipe wrapper with the test message
+    recipe_wrapper = RecipeWrapper(
+        message=class3d_test_message, transport=offline_transport
+    )
+
+    # Set up and run the mock service
+    service_wrapper = class3d_wrapper.Class3DWrapper(recipe_wrapper)
+    service_wrapper.run()
+
+    # Check the initial model command
+    assert mock_subprocess.call_count == 5
+    initial_model_command = [
+        "relion_refine",
+        "--grad",
+        "--denovo_3dref",
+        "--i",
+        "Select/job013/particles_50000.star",
+        "--o",
+        "InitialModel/job014/run",
+        "--particle_diameter",
+        str(output_relion_options["mask_diameter"]),
+        "--gpu",
+        "0,1,2,3",
+        "--sym",
+        "C1",
+        "--iter",
+        "200",
+        "--offset_range",
+        "6",
+        "--offset_step",
+        "2",
+        "--dont_combine_weights_via_disc",
+        "--preread_images",
+        "--pool",
+        "10",
+        "--pad",
+        "2",
+        "--ctf",
+        "--K",
+        "2",
+        "--flatten_solvent",
+        "--zero_mask",
+        "--oversampling",
+        "1",
+        "--healpix_order",
+        "2",
+        "--j",
+        "4",
+        "--pipeline_control",
+        "InitialModel/job014/",
+    ]
+    mock_subprocess.assert_any_call(
+        initial_model_command, capture_output=True, cwd=str(tmp_path)
+    )
+    # Check the node creator and murfey sends for the initial model
+    mock_recwrap_send.assert_any_call(
+        "node_creator",
+        {
+            "job_type": "relion.initialmodel",
+            "input_file": f"{tmp_path}/Select/job013/particles_50000.star",
+            "output_file": f"{tmp_path}/InitialModel/job014/run_it200_model.star",
+            "relion_options": output_relion_options,
+            "command": " ".join(initial_model_command),
+            "stdout": "stdout",
+            "stderr": "stderr",
+            "success": True,
+        },
+    )
+    mock_recwrap_send.assert_any_call(
+        "murfey_feedback",
+        {
+            "register": "save_initial_model",
+            "initial_model": f"{tmp_path}/InitialModel/job014/run_it200_model.star",
+        },
+    )
+
+    # Check the expected 3D classifcation command was run
+    class3d_command = [
+        "mpirun",
+        "-n",
+        "9",
+        "relion_refine_mpi",
+        "--i",
+        "Select/job013/particles_50000.star",
+        "--o",
+        "Class3D/job015/run",
+        "--ref",
+        f"{tmp_path}/InitialModel/job014/run_it200_model.star",
+        "--particle_diameter",
+        str(output_relion_options["mask_diameter"]),
+        "--dont_combine_weights_via_disc",
+        "--preread_images",
+        "--pool",
+        "10",
+        "--pad",
+        "2",
+        "--firstiter_cc",
+        "--ini_high",
+        "40.0",
+        "--ctf",
+        "--iter",
+        "20",
+        "--tau2_fudge",
+        "4",
+        "--K",
+        "2",
+        "--flatten_solvent",
+        "--zero_mask",
+        "--oversampling",
+        "1",
+        "--healpix_order",
+        "2",
+        "--offset_range",
+        "5",
+        "--offset_step",
+        "4",
+        "--sym",
+        str(output_relion_options["symmetry"]),
+        "--norm",
+        "--scale",
+        "--j",
+        "4",
+        "--gpu",
+        "0:1:2:3",
+        "--pipeline_control",
+        "Class3D/job015/",
+    ]
+    mock_subprocess.assert_any_call(
+        class3d_command, capture_output=True, cwd=str(tmp_path)
+    )
+
+    # Check the expected message sends to other processes
+    assert mock_recwrap_send.call_count == 5
+    mock_recwrap_send.assert_any_call(
+        "node_creator",
+        {
+            "job_type": "relion.class3d",
+            "input_file": f"{tmp_path}/Select/job013/particles_50000.star:{tmp_path}/InitialModel/job014/run_it200_model.star",
+            "output_file": f"{tmp_path}/Class3D/job015",
+            "relion_options": output_relion_options,
+            "command": " ".join(class3d_command),
+            "stdout": "stdout",
+            "stderr": "stderr",
+            "success": True,
+        },
+    )
+    mock_recwrap_send.assert_any_call(
+        "ispyb_connector",
+        {
+            "ispyb_command": "multipart_message",
+            "ispyb_command_list": [
+                {
+                    "batch_number": "1",
+                    "binned_pixel_size": "2.5",
+                    "buffer_command": {
+                        "ispyb_command": "insert_particle_classification_group"
+                    },
+                    "buffer_store": 5,
+                    "ispyb_command": "buffer",
+                    "number_of_classes_per_batch": 2,
+                    "number_of_particles_per_batch": 50000,
+                    "particle_picker_id": None,
+                    "symmetry": str(output_relion_options["symmetry"]),
+                    "type": "3D",
+                },
+                {
+                    "buffer_command": {
+                        "ispyb_command": "insert_particle_classification"
+                    },
+                    "buffer_lookup": {"particle_classification_group_id": 5},
+                    "buffer_store": 10,
+                    "class_distribution": "0.4",
+                    "class_image_full_path": (
+                        f"{tmp_path}/Class3D/job015/run_it020_class001.mrc"
+                    ),
+                    "class_number": 1,
+                    "estimated_resolution": 12.2,
+                    "ispyb_command": "buffer",
+                    "overall_fourier_completeness": 1.0,
+                    "particles_per_class": 20000.0,
+                    "rotation_accuracy": "30.3",
+                    "translation_accuracy": "33.3",
+                    "angular_efficiency": 0.7,
+                    "suggested_tilt": 0,
+                },
+                {
+                    "buffer_command": {
+                        "ispyb_command": "insert_particle_classification"
+                    },
+                    "buffer_lookup": {"particle_classification_group_id": 5},
+                    "buffer_store": 11,
+                    "class_distribution": "0.6",
+                    "class_image_full_path": (
+                        f"{tmp_path}/Class3D/job015/run_it020_class002.mrc"
+                    ),
+                    "class_number": 2,
+                    "estimated_resolution": 10.0,
+                    "ispyb_command": "buffer",
+                    "overall_fourier_completeness": 0.9,
+                    "particles_per_class": 30000.0,
+                    "rotation_accuracy": "20.2",
+                    "translation_accuracy": "22.2",
+                    "angular_efficiency": 0.7,
+                    "suggested_tilt": 0,
+                },
+                {
+                    "buffer_command": {"ispyb_command": "insert_cryoem_initial_model"},
+                    "buffer_lookup": {"particle_classification_id": 10},
+                    "ispyb_command": "buffer",
+                    "number_of_particles": 20000.0,
+                    "resolution": "30.3",
+                },
+                {
+                    "buffer_command": {"ispyb_command": "insert_cryoem_initial_model"},
+                    "buffer_lookup": {"particle_classification_id": 11},
+                    "ispyb_command": "buffer",
+                    "number_of_particles": 30000.0,
+                    "resolution": "20.4",
                 },
             ],
         },


### PR DESCRIPTION
Optionally send relion class3d the initial model star file instead of a single model.
Expected behaviour:
 - If no model supplied the default is to use the star file (`multiple_initial_models` is true)
 - Send star file to murfey instead of model mrc
 - If model is user-supplied use that instead