### PR TITLE
Switch rabbitmq message nacks for rejections

### DIFF
--- a/src/cryoemservices/services/bfactor_setup.py
+++ b/src/cryoemservices/services/bfactor_setup.py
@@ -54,7 +54,7 @@ class BFactor(CommonService):
             self.log.info("Received a simple message")
             if not isinstance(message, dict):
                 self.log.error("Rejected invalid simple message")
-                self._transport.nack(header)
+                self._reject_message(header, requeue=False)
                 return
 
             # Create a wrapper-like object that can be passed to functions
@@ -77,7 +77,7 @@ class BFactor(CommonService):
                 f"and recipe parameters: {rw.recipe_step.get('parameters', {})} "
                 f"with exception: {e}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
 
         self.log.info(

--- a/src/cryoemservices/services/class2d.py
+++ b/src/cryoemservices/services/class2d.py
@@ -33,7 +33,7 @@ class Class2D(CommonService):
             self.log.info("Received a simple message")
             if not isinstance(message, dict):
                 self.log.error("Rejected invalid simple message")
-                self._transport.nack(header)
+                self._reject_message(header, requeue=False)
                 return
 
             # Create a wrapper-like object that can be passed to functions
@@ -57,14 +57,14 @@ class Class2D(CommonService):
                 f"and recipe parameters: {rw.recipe_step.get('parameters', {})} "
                 f"with exception: {e}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
 
-        # In this setup we cannot nack messages on failure, so instead check here
+        # In this setup we cannot reject messages on failure, so instead check here
         if message.get("requeue", 0) >= 5:
-            self.log.warning(f"Nacking requeued file {class2d_params.particles_file}")
-            rw.transport.nack(header)
-            return False
+            self.log.warning(f"Rejecting requeued file {class2d_params.particles_file}")
+            self._reject_message(header, transport=rw.transport, requeue=False)
+            return
 
         # Acknowledge the message and disconnect from rabbitmq
         self.log.info(

--- a/src/cryoemservices/services/class3d.py
+++ b/src/cryoemservices/services/class3d.py
@@ -32,8 +32,8 @@ class Class3D(CommonService):
         if not rw:
             self.log.info("Received a simple message")
             if not isinstance(message, dict):
-                self.log.error("Rejected invalid simple message")
-                self._transport.nack(header)
+                self.log.error("Rejected invaid simple message")
+                self._reject_message(header, requeue=False)
                 return
 
             # Create a wrapper-like object that can be passed to functions
@@ -57,14 +57,14 @@ class Class3D(CommonService):
                 f"and recipe parameters: {rw.recipe_step.get('parameters', {})} "
                 f"with exception: {e}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
 
-        # In this setup we cannot nack messages on failure, so instead check here
+        # In this setup we cannot reject messages on failure, so instead check here
         if message.get("requeue", 0) >= 5:
-            self.log.warning(f"Nacking requeued file {class3d_params.particles_file}")
-            rw.transport.nack(header)
-            return False
+            self.log.warning(f"Rejecting requeued file {class3d_params.particles_file}")
+            self._reject_message(header, transport=rw.transport, requeue=False)
+            return
 
         # Acknowledge the message and disconnect from rabbitmq
         self.log.info(

--- a/src/cryoemservices/services/clem_align_and_merge.py
+++ b/src/cryoemservices/services/clem_align_and_merge.py
@@ -38,7 +38,7 @@ class AlignAndMergeService(CommonService):
             self.log.info("Received a simple message")
             if not isinstance(message, dict):
                 self.log.error("Rejected invalid simple message")
-                self._transport.nack(header)
+                self._reject_message(header, requeue=False)
                 return
 
             # Create a wrapper-like object that can be passed to functions
@@ -61,7 +61,7 @@ class AlignAndMergeService(CommonService):
                 f"and recipe parameters: {rw.recipe_step.get('parameters', {})} "
                 f"with exception: {e}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
 
         # Process files and collect output
@@ -75,20 +75,20 @@ class AlignAndMergeService(CommonService):
                 align_across=params.align_across,
                 num_procs=params.num_procs,
             )
-        # Log error and nack message if the command fails to execute
+        # Log error and reject message if the command fails to execute
         except Exception:
             self.log.error(
                 f"Exception encountered while aligning and merging images for {params.series_name!r}: \n",
                 exc_info=True,
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
         if not result:
             self.log.error(
                 "Failed to complete the aligning and merging process for "
                 f"{params.series_name!r}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         # Request for PNG image to be created

--- a/src/cryoemservices/services/clem_process_raw_lifs.py
+++ b/src/cryoemservices/services/clem_process_raw_lifs.py
@@ -38,7 +38,7 @@ class ProcessRawLIFsService(CommonService):
             self.log.info("Received a simple message")
             if not isinstance(message, dict):
                 self.log.error("Rejected invalid simple message")
-                self._transport.nack(header)
+                self._reject_message(header, requeue=False)
                 return
 
             # Create a wrapper-like object that can be passed to functions
@@ -61,7 +61,7 @@ class ProcessRawLIFsService(CommonService):
                 f"and recipe parameters: {rw.recipe_step.get('parameters', {})} "
                 f"with exception: {e}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
 
         # Process files and collect output
@@ -71,19 +71,19 @@ class ProcessRawLIFsService(CommonService):
                 root_folder=params.root_folder,
                 number_of_processes=params.num_procs,
             )
-        # Log error and nack message if the command fails to execute
+        # Log error and reject message if the command fails to execute
         except Exception:
             self.log.error(
-                f"Exception encontered while processing LIF file {str(params.lif_file)!r}: \n",
+                f"Exception encountered while processing LIF file {str(params.lif_file)!r}: \n",
                 exc_info=True,
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
         if not results:
             self.log.error(
                 f"Failed to extract image stacks from {str(params.lif_file)!r}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         # Send each subset of output files to Murfey for registration

--- a/src/cryoemservices/services/clem_process_raw_tiffs.py
+++ b/src/cryoemservices/services/clem_process_raw_tiffs.py
@@ -38,7 +38,7 @@ class ProcessRawTIFFsService(CommonService):
             self.log.info("Received a simple message")
             if not isinstance(message, dict):
                 self.log.error("Rejected invalid simple message")
-                self._transport.nack(header)
+                self._reject_message(header, requeue=False)
                 return
 
             # Create a wrapper-like object that can be passed to functions
@@ -61,7 +61,7 @@ class ProcessRawTIFFsService(CommonService):
                 f"and recipe parameters: {rw.recipe_step.get('parameters', {})} "
                 f"with exception: {e}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
 
         # Reconstruct series name using reference file from list
@@ -74,7 +74,7 @@ class ProcessRawTIFFsService(CommonService):
                 f"Subpath {params.root_folder!r} was not found in file path "
                 f"{str(ref_file.parent / ref_file.stem.split('--')[0])!r}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
         series_name = "--".join(
             [p.replace(" ", "_") if " " in p else p for p in path_parts][
@@ -90,19 +90,19 @@ class ProcessRawTIFFsService(CommonService):
                 metadata_file=params.metadata,
                 number_of_processes=params.num_procs,
             )
-        # Log error and nack message if the command fails to execute
+        # Log error and reject message if the command fails to execute
         except Exception:
             self.log.error(
                 f"Exception encountered while processing TIFF files for series {series_name}: \n",
                 exc_info=True,
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
         if not result:
             self.log.error(
                 f"No processing results were returned for TIFF series {series_name!r}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         # Request for PNG images to be created

--- a/src/cryoemservices/services/cluster_submission.py
+++ b/src/cryoemservices/services/cluster_submission.py
@@ -46,7 +46,7 @@ class ClusterSubmission(CommonService):
                 Path(wrapper).parent.mkdir(parents=True, exist_ok=True)
             except OSError:
                 self.log.error(f"Cannot make directory for {wrapper}")
-                self._transport.nack(header)
+                self._reject_message(header, transport=rw.transport)
                 return
             self.log.info(f"Storing serialized recipe wrapper in {wrapper}")
             cluster_params.commands = cluster_params.commands.replace(
@@ -72,7 +72,7 @@ class ClusterSubmission(CommonService):
             self.log.error(
                 "No absolute working directory specified. Will not run cluster job"
             )
-            self._transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
         working_directory = Path(parameters["workingdir"])
         try:
@@ -81,7 +81,7 @@ class ClusterSubmission(CommonService):
             self.log.error(
                 "Could not create working directory: %s", str(e), exc_info=True
             )
-            self._transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         if parameters.get("standard_output"):
@@ -105,7 +105,7 @@ class ClusterSubmission(CommonService):
         )
         if not jobnumber:
             self.log.error("Job was not submitted")
-            self._transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         # Conditionally acknowledge receipt of the message

--- a/src/cryoemservices/services/common_service.py
+++ b/src/cryoemservices/services/common_service.py
@@ -96,4 +96,4 @@ class CommonService:
             self.log.warning(
                 f"Message {message_id} in {subscription_id} is not valid for rabbitmq"
             )
-            transport.nack(header)
+            transport.nack(header, requeue=requeue)

--- a/src/cryoemservices/services/common_service.py
+++ b/src/cryoemservices/services/common_service.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import logging
 import queue
+from functools import partial
 
 from workflows.transport.common_transport import CommonTransport
+from workflows.transport.pika_transport import PikaTransport
 
 
 class CommonService:
@@ -66,3 +68,28 @@ class CommonService:
             self._transport.disconnect()
         except Exception as e:
             self.log.error(f"Could not disconnect transport: {e}", exc_info=True)
+
+    def _reject_message(
+        self,
+        header: dict,
+        transport: CommonTransport | None = None,
+        requeue: bool = True,
+    ):
+        message_id = header.get("message-id")
+        subscription_id = header.get("subscription")
+        if transport is None:
+            transport = self._transport
+        if (
+            isinstance(transport, PikaTransport)
+            and message_id is not None
+            and subscription_id is not None
+        ):
+            pika_thread = transport._pika_thread
+            channel = pika_thread._pika_channels[subscription_id]
+            pika_thread._connection.add_callback_threadsafe(
+                partial(channel.basic_reject, delivery_tag=message_id, requeue=requeue)
+            )
+        else:
+            self.log.warning(
+                f"Message {message_id} in {subscription_id} is not valid for rabbitmq"
+            )

--- a/src/cryoemservices/services/common_service.py
+++ b/src/cryoemservices/services/common_service.py
@@ -75,6 +75,7 @@ class CommonService:
         transport: CommonTransport | None = None,
         requeue: bool = True,
     ):
+        """Reject failed messages back to rabbitmq"""
         message_id = header.get("message-id")
         subscription_id = header.get("subscription")
         if transport is None:
@@ -90,6 +91,9 @@ class CommonService:
                 partial(channel.basic_reject, delivery_tag=message_id, requeue=requeue)
             )
         else:
+            # Resort back to nacking if this isn't pika or the header is invalid
+            # Mostly just for tests compatibility
             self.log.warning(
                 f"Message {message_id} in {subscription_id} is not valid for rabbitmq"
             )
+            transport.nack(header)

--- a/src/cryoemservices/services/cryolo.py
+++ b/src/cryoemservices/services/cryolo.py
@@ -112,7 +112,7 @@ class CrYOLO(CommonService):
             self.log.info("Received a simple message")
             if not isinstance(message, dict):
                 self.log.error("Rejected invalid simple message")
-                self._transport.nack(header)
+                self._reject_message(header, requeue=False)
                 return
 
             # Create a wrapper-like object that can be passed to functions
@@ -138,7 +138,7 @@ class CrYOLO(CommonService):
                 f"and recipe parameters: {rw.recipe_step.get('parameters', {})} "
                 f"with exception: {e}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
 
         # Check if this file has been run before
@@ -160,7 +160,7 @@ class CrYOLO(CommonService):
             job_number = int(job_num_search[0][4:7])
         else:
             self.log.warning(f"Invalid job directory in {cryolo_params.output_path}")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
 
         # Check job alias
@@ -169,7 +169,7 @@ class CrYOLO(CommonService):
             job_alias.symlink_to(job_dir)
         elif not (job_alias.is_symlink() and job_alias.resolve() == job_dir.resolve()):
             self.log.error(f"Symlink {job_alias} already exists")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         Path(cryolo_params.output_path).unlink(missing_ok=True)
@@ -302,7 +302,7 @@ class CrYOLO(CommonService):
                 f"crYOLO failed with exitcode {result.returncode}:\n"
                 + result.stderr.decode("utf8", "replace")
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         # If this is tomo then make an image and stop here

--- a/src/cryoemservices/services/ctffind.py
+++ b/src/cryoemservices/services/ctffind.py
@@ -117,7 +117,7 @@ class CTFFind(CommonService):
             self.log.info("Received a simple message")
             if not isinstance(message, dict):
                 self.log.error("Rejected invalid simple message")
-                self._transport.nack(header)
+                self._reject_message(header, requeue=False)
                 return
 
             # Create a wrapper-like object that can be passed to functions
@@ -138,12 +138,12 @@ class CTFFind(CommonService):
                 f"and recipe parameters: {rw.recipe_step.get('parameters', {})} "
                 f"with exception: {e}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
 
         if ctf_params.ctffind_version not in [4, 5]:
             self.log.error(f"Cannot use CTFFind version {ctf_params.ctffind_version}")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
         self.log.info(f"Using CTFFind version {ctf_params.ctffind_version}")
 
@@ -168,7 +168,7 @@ class CTFFind(CommonService):
             self.log.warning(
                 f"Could not determine job number in {ctf_params.output_image}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
         job_alias = Path(
             re.sub(
@@ -185,7 +185,7 @@ class CTFFind(CommonService):
             == (job_alias.parent / f"job{ctf_job_number:03}").resolve()
         ):
             self.log.error(f"Symlink {job_alias} already exists")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         parameters_list = [
@@ -271,7 +271,7 @@ class CTFFind(CommonService):
                 f"CTFFind failed with exitcode {result.returncode}:\n"
                 + result.stderr.decode("utf8", "replace")
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         # Write stdout to logfile

--- a/src/cryoemservices/services/denoise.py
+++ b/src/cryoemservices/services/denoise.py
@@ -142,7 +142,7 @@ class Denoise(CommonService):
             self.log.info("Received a simple message")
             if not isinstance(message, dict):
                 self.log.error("Rejected invalid simple message")
-                self._transport.nack(header)
+                self._reject_message(header, requeue=False)
                 return
 
             # Create a wrapper-like object that can be passed to functions
@@ -165,10 +165,11 @@ class Denoise(CommonService):
                 f"and recipe parameters: {rw.recipe_step.get('parameters', {})} "
                 f"with exception: {e}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
 
         if not self.check_visit(denoise_params):
+            # This one should infinitely nack
             self.log.warning(f"Visit rejected for {denoise_params.volume}")
             rw.transport.nack(header, requeue=True)
             return
@@ -255,7 +256,7 @@ class Denoise(CommonService):
         # Stop here if the job failed
         if result.returncode:
             self.log.error("Denoising failed to run")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         # Clean up the slurm files

--- a/src/cryoemservices/services/easymode.py
+++ b/src/cryoemservices/services/easymode.py
@@ -65,7 +65,7 @@ class Easymode(CommonService):
             self.log.info("Received a simple message")
             if not isinstance(message, dict):
                 self.log.error("Rejected invalid simple message")
-                self._transport.nack(header)
+                self._reject_message(header, requeue=False)
                 return
 
             # Create a wrapper-like object that can be passed to functions
@@ -88,7 +88,7 @@ class Easymode(CommonService):
                 f"and recipe parameters: {rw.recipe_step.get('parameters', {})} "
                 f"with exception: {e}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
 
         try:
@@ -96,7 +96,7 @@ class Easymode(CommonService):
                 tomogram_header = mrc.header
         except (FileNotFoundError, ValueError):
             self.log.error(f"Input tomogram {easymode_params.tomogram} cannot be read")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         output_tomograms: dict[str, Path] = {}

--- a/src/cryoemservices/services/extract.py
+++ b/src/cryoemservices/services/extract.py
@@ -69,7 +69,7 @@ class Extract(CommonService):
             self.log.info("Received a simple message")
             if not isinstance(message, dict):
                 self.log.error("Rejected invalid simple message")
-                self._transport.nack(header)
+                self._reject_message(header, requeue=False)
                 return
 
             # Create a wrapper-like object that can be passed to functions
@@ -92,7 +92,7 @@ class Extract(CommonService):
                 f"and recipe parameters: {rw.recipe_step.get('parameters', {})} "
                 f"with exception: {e}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
 
         self.log.info(
@@ -113,7 +113,7 @@ class Extract(CommonService):
             job_dir = Path(job_dir_search[0])
         else:
             self.log.warning(f"Invalid job directory in {extract_params.output_file}")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
         project_dir = job_dir.parent.parent
         if not Path(extract_params.output_file).parent.exists():
@@ -129,7 +129,7 @@ class Extract(CommonService):
             job_alias.symlink_to(job_dir)
         elif not (job_alias.is_symlink() and job_alias.resolve() == job_dir.resolve()):
             self.log.error(f"Symlink {job_alias} already exists")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         # If no background radius set diameter as 75% of box

--- a/src/cryoemservices/services/extract_class.py
+++ b/src/cryoemservices/services/extract_class.py
@@ -62,7 +62,7 @@ class ExtractClass(CommonService):
             self.log.info("Received a simple message")
             if not isinstance(message, dict):
                 self.log.error("Rejected invalid simple message")
-                self._transport.nack(header)
+                self._reject_message(header, requeue=False)
                 return
 
             # Create a wrapper-like object that can be passed to functions
@@ -85,7 +85,7 @@ class ExtractClass(CommonService):
                 f"and recipe parameters: {rw.recipe_step.get('parameters', {})} "
                 f"with exception: {e}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
 
         self.log.info(
@@ -104,7 +104,7 @@ class ExtractClass(CommonService):
             job_num_refine = int(job_num_search[0][4:7])
         else:
             self.log.warning(f"Invalid job number in {extract_params.refine_job_dir}")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
         original_dir = Path(extract_params.class3d_dir).parent.parent
         ctf_micrographs_file = "CtfFind/Live_ctffind/micrographs_ctf.star"
@@ -125,7 +125,7 @@ class ExtractClass(CommonService):
                     break
         if not downscaled_pixel_size:
             self.log.warning("No class3d pixel size found")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         with open(
@@ -139,7 +139,7 @@ class ExtractClass(CommonService):
                     break
         if not mask_diameter:
             self.log.warning("No mask diameter found")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         # Boxsize conversion as in particle extraction, enlarged by 25%
@@ -291,7 +291,7 @@ class ExtractClass(CommonService):
             self.log.warning(
                 f"Reextraction failed: {result.stderr.decode('utf8', 'replace')}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         # Create a reference for the refinement

--- a/src/cryoemservices/services/icebreaker.py
+++ b/src/cryoemservices/services/icebreaker.py
@@ -64,7 +64,7 @@ class IceBreaker(CommonService):
             self.log.info("Received a simple message")
             if not isinstance(message, dict):
                 self.log.error("Rejected invalid simple message")
-                self._transport.nack(header)
+                self._reject_message(header, requeue=False)
                 return
 
             # Create a wrapper-like object that can be passed to functions
@@ -87,7 +87,7 @@ class IceBreaker(CommonService):
                 f"and recipe parameters: {rw.recipe_step.get('parameters', {})} "
                 f"with exception: {e}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
 
         # IceBreaker requires running in the job directory
@@ -219,7 +219,7 @@ class IceBreaker(CommonService):
                     )
                 except FileNotFoundError as e:
                     self.log.warning(f"IceBreaker failed to find file: {e}")
-                    rw.transport.nack(header)
+                    self._reject_message(header, transport=rw.transport)
                     return
 
                 # Create a star file with the input data
@@ -257,7 +257,7 @@ class IceBreaker(CommonService):
             self.log.warning(
                 f"Unknown IceBreaker job type {icebreaker_params.icebreaker_type}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         # Register the icebreaker job with the node creator
@@ -293,7 +293,7 @@ class IceBreaker(CommonService):
         # End here if the command failed
         if not icebreaker_success:
             self.log.error("IceBreaker failed")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         # Forward results to next IceBreaker job

--- a/src/cryoemservices/services/images.py
+++ b/src/cryoemservices/services/images.py
@@ -51,7 +51,7 @@ class Images(CommonService):
             self.log.info("Received a simple message")
             if not isinstance(message, dict):
                 self.log.error("Rejected invalid simple message")
-                self._transport.nack(header)
+                self._reject_message(header, requeue=False)
                 return
 
             # Create a wrapper-like object that can be passed to functions
@@ -67,14 +67,14 @@ class Images(CommonService):
         command = parameters("image_command")
         if command not in self.image_functions:
             self.log.error(f"Unknown command: {command!r}")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         try:
             result = self.image_functions[command](parameters)
         except (PermissionError, FileNotFoundError) as e:
             self.log.error(f"Command {command!r} raised {e}", exc_info=True)
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         if result:
@@ -82,4 +82,4 @@ class Images(CommonService):
             rw.transport.ack(header)
         else:
             self.log.error(f"Command {command!r} returned {result!r}")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)

--- a/src/cryoemservices/services/ispyb_connector.py
+++ b/src/cryoemservices/services/ispyb_connector.py
@@ -52,7 +52,7 @@ class EMISPyB(CommonService):
             self.log.info("Received a simple message")
             if not isinstance(message, dict):
                 self.log.error("Rejected invalid simple message")
-                self._transport.nack(header)
+                self._reject_message(header, requeue=False)
                 return
 
             if message.get("parameters"):
@@ -101,12 +101,12 @@ class EMISPyB(CommonService):
         command = parameters("ispyb_command")
         if not command:
             self.log.error("Received message is not a valid ISPyB command")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
         command_function = self.get_command(command)
         if not command_function:
             self.log.error("Received unknown ISPyB command (%s)", command)
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         # Set an expiry time for this message, for delays on database synchronisation
@@ -127,7 +127,7 @@ class EMISPyB(CommonService):
                 "quarantining message and shutting down instance.",
                 exc_info=True,
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         # Store results if they are requested in the parameters or in the command
@@ -154,7 +154,7 @@ class EMISPyB(CommonService):
             rw.transport.ack(header)
         elif message["expiry_time"] > time.time():
             self.log.warning(f"Failed call {command} due to timeout")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
         else:
             self.log.error(f"ISPyB request for {command} failed")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)

--- a/src/cryoemservices/services/membrain_seg.py
+++ b/src/cryoemservices/services/membrain_seg.py
@@ -67,7 +67,7 @@ class MembrainSeg(CommonService):
             self.log.info("Received a simple message")
             if not isinstance(message, dict):
                 self.log.error("Rejected invalid simple message")
-                self._transport.nack(header)
+                self._reject_message(header, requeue=False)
                 return
 
             # Create a wrapper-like object that can be passed to functions
@@ -90,7 +90,7 @@ class MembrainSeg(CommonService):
                 f"and recipe parameters: {rw.recipe_step.get('parameters', {})} "
                 f"with exception: {e}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
 
         # Assemble the membrain-seg command
@@ -213,7 +213,7 @@ class MembrainSeg(CommonService):
             self.log.error(
                 f"membrain-seg failed to run: {result.stderr.decode('utf8', 'replace')}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         # Rename the output file

--- a/src/cryoemservices/services/motioncorr.py
+++ b/src/cryoemservices/services/motioncorr.py
@@ -251,7 +251,7 @@ class MotionCorr(CommonService):
             self.log.info("Received a simple message")
             if not isinstance(message, dict):
                 self.log.error("Rejected invalid simple message")
-                self._transport.nack(header)
+                self._reject_message(header, requeue=False)
                 return
 
             # Create a wrapper-like object that can be passed to functions
@@ -274,13 +274,13 @@ class MotionCorr(CommonService):
                 f"and recipe parameters: {rw.recipe_step.get('parameters', {})} "
                 f"with exception: {e}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
 
         # Catch any cases where the movie does not exist
         if not Path(mc_params.movie).is_file():
             self.log.warning(f"Movie {mc_params.movie} does not exist")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         # Find the job number
@@ -289,7 +289,7 @@ class MotionCorr(CommonService):
             job_number = int(job_number_search[0][4:7])
         else:
             self.log.warning(f"Could not determine job number in {mc_params.mrc_out}")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
 
         # Check if the gain file exists:
@@ -328,7 +328,7 @@ class MotionCorr(CommonService):
             == (job_alias.parent / f"job{job_number:03}").resolve()
         ):
             self.log.error(f"Symlink {job_alias} already exists")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         # Get the eer grouping out of the fractionation file
@@ -389,7 +389,7 @@ class MotionCorr(CommonService):
             input_flag = "-InEer"
         else:
             self.log.error(f"No input flag found for movie {mc_params.movie}")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         # Run motion correction
@@ -530,7 +530,7 @@ class MotionCorr(CommonService):
                 "alias": "Live_motioncorr",
             }
             rw.send_to("node_creator", node_creator_parameters)
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         # Extract results for ispyb
@@ -666,7 +666,7 @@ class MotionCorr(CommonService):
                 project_dir = Path(project_dir_search[0]).parent.parent
             else:
                 self.log.error(f"Cannot find project dir for {mc_params.mrc_out}")
-                rw.transport.nack(header)
+                self._reject_message(header, transport=rw.transport)
                 return
             import_movie = (
                 project_dir

--- a/src/cryoemservices/services/node_creator.py
+++ b/src/cryoemservices/services/node_creator.py
@@ -231,7 +231,7 @@ class NodeCreator(CommonService):
             self.log.info("Received a simple message")
             if not isinstance(message, dict):
                 self.log.error("Rejected invalid simple message")
-                self._transport.nack(header)
+                self._reject_message(header, requeue=False)
                 return
 
             # Create a wrapper-like object that can be passed to functions
@@ -255,7 +255,7 @@ class NodeCreator(CommonService):
                 f"and recipe parameters: {rw.recipe_step.get('parameters', {})} "
                 f"with exception: {e}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
 
         self.log.info(
@@ -271,7 +271,7 @@ class NodeCreator(CommonService):
             job_number = int(job_num_search[0][4:])
         else:
             self.log.warning(f"Cannot determine job dir for {job_info.output_file}")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
         project_dir = job_dir.parent.parent
         os.chdir(project_dir)
@@ -296,7 +296,7 @@ class NodeCreator(CommonService):
                 f"Unknown node creator job type {job_info.job_type} "
                 f"in {job_info.experiment_type} collection"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         # Get the options for this job out of the RelionServiceOptions
@@ -306,7 +306,7 @@ class NodeCreator(CommonService):
         )
         if not pipeline_options:
             self.log.error(f"Cannot generate pipeline options for {job_info.job_type}")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         # Work out the name of the input star file and add this to the job.star
@@ -381,7 +381,7 @@ class NodeCreator(CommonService):
                 )
         except (IndexError, ValueError) as e:
             self.log.error(f"Pipeliner failed for {job_info.job_type}, error {e}")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         # Copy the job.star file
@@ -461,7 +461,7 @@ class NodeCreator(CommonService):
                     )
             except FileNotFoundError as e:
                 self.log.error(f"Cannot find expected file: {e}", exc_info=True)
-                rw.transport.nack(header)
+                self._reject_message(header, transport=rw.transport)
                 return
             if extra_output_nodes:
                 # Add any extra nodes if they are not already present

--- a/src/cryoemservices/services/postprocess.py
+++ b/src/cryoemservices/services/postprocess.py
@@ -69,7 +69,7 @@ class PostProcess(CommonService):
             self.log.info("Received a simple message")
             if not isinstance(message, dict):
                 self.log.error("Rejected invalid simple message")
-                self._transport.nack(header)
+                self._reject_message(header, requeue=False)
                 return
 
             # Create a wrapper-like object that can be passed to functions
@@ -92,7 +92,7 @@ class PostProcess(CommonService):
                 f"and recipe parameters: {rw.recipe_step.get('parameters', {})} "
                 f"with exception: {e}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
 
         # Run in the project directory
@@ -108,7 +108,7 @@ class PostProcess(CommonService):
             self.log.error(
                 f"Can't determine job number from {postprocess_params.job_dir}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
 
         # Update the relion options
@@ -195,7 +195,7 @@ class PostProcess(CommonService):
                 f"{postprocess_result.returncode}:\n"
                 + postprocess_result.stderr.decode("utf8", "replace")
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         # Copy the angular distribution from Refinement
@@ -229,7 +229,7 @@ class PostProcess(CommonService):
             self.log.error(
                 f"Unable to read bfactor and resolution in {postprocess_params.job_dir}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         # Send refinement job information to ispyb
@@ -272,7 +272,7 @@ class PostProcess(CommonService):
                     f"{Path(postprocess_params.half_map).parent}/run_model.star "
                     f"does not exist"
                 )
-                rw.transport.nack(header)
+                self._reject_message(header, transport=rw.transport)
                 return
 
             data = cif.read_file(

--- a/src/cryoemservices/services/process_recipe.py
+++ b/src/cryoemservices/services/process_recipe.py
@@ -80,7 +80,7 @@ class ProcessRecipe(CommonService):
         parameters = message.get("parameters", {})
         if not isinstance(parameters, dict):
             self.log.error("Rejected parameters not given as dictionary")
-            self._transport.nack(header)
+            self._reject_message(header, requeue=False)
             return
 
         # Unless 'guid' is already defined then generate a unique recipe ID
@@ -100,7 +100,7 @@ class ProcessRecipe(CommonService):
                 )
             except Exception as e:
                 self.log.info(f"Rejected message due to filter {name} error: {e}")
-                self._transport.nack(header)
+                self._reject_message(header, transport=rw.transport)
                 return
 
         self.log.info(f"Filtered processing request: {str(message)}")

--- a/src/cryoemservices/services/refine3d.py
+++ b/src/cryoemservices/services/refine3d.py
@@ -33,7 +33,7 @@ class Refine3D(CommonService):
             self.log.info("Received a simple message")
             if not isinstance(message, dict):
                 self.log.error("Rejected invalid simple message")
-                self._transport.nack(header)
+                self._reject_message(header, requeue=False)
                 return
 
             # Create a wrapper-like object that can be passed to functions
@@ -57,14 +57,14 @@ class Refine3D(CommonService):
                 f"and recipe parameters: {rw.recipe_step.get('parameters', {})} "
                 f"with exception: {e}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
 
-        # In this setup we cannot nack messages on failure, so instead check here
+        # In this setup we cannot reject messages on failure, so instead check here
         if message.get("requeue", 0) >= 5:
-            self.log.warning(f"Nacking requeued file {refine_params.particles_file}")
-            rw.transport.nack(header)
-            return False
+            self.log.warning(f"Rejecting requeued file {refine_params.particles_file}")
+            self._reject_message(header, transport=rw.transport, requeue=False)
+            return
 
         # Acknowledge the message and disconnect from rabbitmq
         self.log.info(

--- a/src/cryoemservices/services/select_classes.py
+++ b/src/cryoemservices/services/select_classes.py
@@ -93,7 +93,7 @@ class SelectClasses(CommonService):
             self.log.info("Received a simple message")
             if not isinstance(message, dict):
                 self.log.error("Rejected invalid simple message")
-                self._transport.nack(header)
+                self._reject_message(header, requeue=False)
                 return
 
             # Create a wrapper-like object that can be passed to functions
@@ -116,7 +116,7 @@ class SelectClasses(CommonService):
                 f"and recipe parameters: {rw.recipe_step.get('parameters', {})} "
                 f"with exception: {e}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
 
         # Update the relion options
@@ -138,7 +138,7 @@ class SelectClasses(CommonService):
             select_job_num = int(job_num_search[0][4:]) + 2
         else:
             self.log.warning(f"Invalid job directory in {autoselect_params.input_file}")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
         project_dir = class2d_job_dir.parent.parent
         select_dir = project_dir / f"Select/job{select_job_num:03}"
@@ -288,7 +288,7 @@ class SelectClasses(CommonService):
                 f"2D autoselection failed with exitcode {autoselect_result.returncode}:\n"
                 + autoselect_result.stderr.decode("utf8", "replace")
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         # Find which classes were picked
@@ -348,7 +348,7 @@ class SelectClasses(CommonService):
             job_alias.is_symlink() and job_alias.resolve() == combine_star_dir.resolve()
         ):
             self.log.error(f"Symlink {job_alias} already exists")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         if not (
@@ -390,7 +390,7 @@ class SelectClasses(CommonService):
             # End here if the command failed
             if not combine_node_creator_params["success"]:
                 self.log.error("Star file combination failed")
-                rw.transport.nack(header)
+                self._reject_message(header, transport=rw.transport)
                 return
         else:
             # If combination isn't run the number of particles needs to be found
@@ -503,7 +503,7 @@ class SelectClasses(CommonService):
         # End here if the command failed
         if not split_node_creator_params["success"]:
             self.log.error("Star file splitting failed")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         # Request selected particles image from images service

--- a/src/cryoemservices/services/select_particles.py
+++ b/src/cryoemservices/services/select_particles.py
@@ -49,7 +49,7 @@ class SelectParticles(CommonService):
             self.log.info("Received a simple message")
             if not isinstance(message, dict):
                 self.log.error("Rejected invalid simple message")
-                self._transport.nack(header)
+                self._reject_message(header, requeue=False)
                 return
 
             # Create a wrapper-like object that can be passed to functions
@@ -72,7 +72,7 @@ class SelectParticles(CommonService):
                 f"and recipe parameters: {rw.recipe_step.get('parameters', {})} "
                 f"with exception: {e}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
 
         self.log.info(f"Inputs: {select_params.input_file}")
@@ -85,7 +85,7 @@ class SelectParticles(CommonService):
             select_job_num = int(job_num_search[0][4:7]) + 1
         else:
             self.log.warning(f"Invalid job directory in {select_params.input_file}")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
         project_dir = extract_job_dir.parent.parent
         select_dir = project_dir / f"Select/job{select_job_num:03}"
@@ -99,7 +99,7 @@ class SelectParticles(CommonService):
             job_alias.is_symlink() and job_alias.resolve() == select_dir.resolve()
         ):
             self.log.error(f"Symlink {job_alias} already exists")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         extracted_parts_file = cif.read_file(select_params.input_file)

--- a/src/cryoemservices/services/tomo_align.py
+++ b/src/cryoemservices/services/tomo_align.py
@@ -276,7 +276,7 @@ class TomoAlign(CommonService):
             self.log.info("Received a simple message")
             if not isinstance(message, dict):
                 self.log.error("Rejected invalid simple message")
-                self._transport.nack(header)
+                self._reject_message(header, requeue=False)
                 return
 
             # Create a wrapper-like object that can be passed to functions
@@ -297,13 +297,14 @@ class TomoAlign(CommonService):
                 f"and recipe parameters: {rw.recipe_step.get('parameters', {})} "
                 f"with exception: {e}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
 
         def _tilt(file_list_for_tilts):
             return float(file_list_for_tilts[1])
 
         if not self.check_visit(tomo_params):
+            # This one should infinitely nack
             self.log.warning(f"Visit rejected for {tomo_params.stack_file}")
             rw.transport.nack(header, requeue=True)
             return
@@ -343,11 +344,11 @@ class TomoAlign(CommonService):
             # Check we now have the expected stack file
             if not Path(tomo_params.stack_file).is_file():
                 self.log.warning("Stack file generation failed")
-                rw.transport.nack(header)
+                self._reject_message(header, transport=rw.transport)
                 return
         else:
             self.log.warning(f"Invalid input or {tomo_params.txrm_file} is not a file")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         self.log.info(
@@ -368,7 +369,7 @@ class TomoAlign(CommonService):
         for tilt in self.input_file_list_of_lists:
             if not Path(tilt[0]).is_file():
                 self.log.warning(f"File not found {tilt[0]}")
-                rw.transport.nack(header)
+                self._reject_message(header, transport=rw.transport)
                 return
             if tilt[1] not in tilt_dict:
                 tilt_dict[tilt[1]] = []
@@ -446,7 +447,7 @@ class TomoAlign(CommonService):
             job_number = 0
         else:
             self.log.warning(f"Invalid project directory in {tomo_params.stack_file}")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         if self.input_file_list_of_lists:
@@ -457,7 +458,7 @@ class TomoAlign(CommonService):
                 )
             except (FileNotFoundError, ValueError) as e:
                 self.log.error(f"Creating stack file failed: {e}")
-                rw.transport.nack(header)
+                self._reject_message(header, transport=rw.transport)
                 return
 
         # Set up the angle file needed for dose weighting
@@ -497,7 +498,7 @@ class TomoAlign(CommonService):
         aln_file = self.extract_from_aln(tomo_params, alignment_output_dir, plot_path)
         if not aretomo_result.returncode and not aln_file:
             self.log.error("Failed to read alignment file")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
         rot_centre_z = None
         if tomo_params.tilt_cor:
@@ -546,7 +547,7 @@ class TomoAlign(CommonService):
             )
             # Update failure processing status
             rw.send_to("failure", {})
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         # Change permissions of imod directory
@@ -738,7 +739,7 @@ class TomoAlign(CommonService):
                     self.log.error(
                         f"{e} - Dark images haven't been accounted for properly"
                     )
-                    rw.transport.nack(header)
+                    self._reject_message(header, transport=rw.transport)
                     return
 
         if job_number:

--- a/src/cryoemservices/services/topaz_pick.py
+++ b/src/cryoemservices/services/topaz_pick.py
@@ -62,7 +62,7 @@ class TopazPick(CommonService):
             self.log.info("Received a simple message")
             if not isinstance(message, dict):
                 self.log.error("Rejected invalid simple message")
-                self._transport.nack(header)
+                self._reject_message(header, requeue=False)
                 return
 
             # Create a wrapper-like object that can be passed to functions
@@ -85,7 +85,7 @@ class TopazPick(CommonService):
                 f"and recipe parameters: {rw.recipe_step.get('parameters', {})} "
                 f"with exception: {e}"
             )
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
 
         # Check if this file has been run before
@@ -106,7 +106,7 @@ class TopazPick(CommonService):
             job_number = int(job_num_search[0][4:7])
         else:
             self.log.warning(f"Invalid job directory in {topaz_params.output_path}")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport, requeue=False)
             return
 
         # Check job alias
@@ -125,7 +125,7 @@ class TopazPick(CommonService):
             == (job_alias.parent / f"job{job_number:03}").resolve()
         ):
             self.log.error(f"Symlink {job_alias} already exists")
-            rw.transport.nack(header)
+            self._reject_message(header, transport=rw.transport)
             return
 
         # Construct a command to run topaz with the given parameters

--- a/tests/services/test_clem_align_and_merge_service.py
+++ b/tests/services/test_clem_align_and_merge_service.py
@@ -219,7 +219,7 @@ def test_align_and_merge_bad_messsage(
     )
 
     # Check that message was nacked with the expected parameters
-    offline_transport.nack.assert_called_once_with(header)
+    offline_transport.nack.assert_called_once_with(header, requeue=False)
 
     # Check that the message wasn't erronerously sent
     offline_transport.send.assert_not_called()
@@ -295,7 +295,7 @@ def test_align_and_merge_service_validation_failed(
     )
 
     # Check that the message was nacked
-    offline_transport.nack.assert_called_once_with(header)
+    offline_transport.nack.assert_called_once_with(header, requeue=False)
 
     # Check that the message wasn't erronerously sent
     offline_transport.send.assert_not_called()
@@ -346,7 +346,7 @@ def test_align_and_merge_service_process_failed(
     )
 
     # Check that the message was nacked with the expected parameters
-    offline_transport.nack.assert_called_once_with(header)
+    offline_transport.nack.assert_called_once_with(header, requeue=True)
 
     # Check that the message wasn't erronerously sent
     offline_transport.send.assert_not_called()

--- a/tests/services/test_clem_process_raw_lifs_service.py
+++ b/tests/services/test_clem_process_raw_lifs_service.py
@@ -180,7 +180,7 @@ def test_lif_to_stack_bad_messsage(
     )
 
     # Check that message was nacked with the expected parameters
-    offline_transport.nack.assert_called_once_with(header)
+    offline_transport.nack.assert_called_once_with(header, requeue=False)
 
     # Check that the message wasn't erronerously sent
     offline_transport.send.assert_not_called()
@@ -241,7 +241,7 @@ def test_lif_to_stack_service_validation_failed(
     )
 
     # Check that the message was nacked with the expected parameters
-    offline_transport.nack.assert_called_once_with(header)
+    offline_transport.nack.assert_called_once_with(header, requeue=False)
 
     # Check that the message wasn't erronerously sent
     offline_transport.send.assert_not_called()
@@ -285,7 +285,7 @@ def test_lif_to_stack_service_processing_failed(
     )
 
     # Check that message was nacked with expected parameters
-    offline_transport.nack.assert_called_once_with(header)
+    offline_transport.nack.assert_called_once_with(header, requeue=True)
 
     # Check that the message wasn't erronerously sent
     offline_transport.send.assert_not_called()

--- a/tests/services/test_clem_process_raw_tiffs_service.py
+++ b/tests/services/test_clem_process_raw_tiffs_service.py
@@ -196,7 +196,7 @@ def test_process_raw_tiffs_bad_messsage(
     )
 
     # Check that message was nacked with the expected parameters
-    offline_transport.nack.assert_called_once_with(header)
+    offline_transport.nack.assert_called_once_with(header, requeue=False)
 
     # Check that the message wasn't erronerously sent
     offline_transport.send.assert_not_called()
@@ -258,7 +258,7 @@ def test_process_raw_tiffs_service_validation_failed(
     )
 
     # Check that the message was nacked with the expected parameters
-    offline_transport.nack.assert_called_once_with(header)
+    offline_transport.nack.assert_called_once_with(header, requeue=False)
 
     # Check that the message wasn't erronerously sent
     offline_transport.send.assert_not_called()
@@ -305,7 +305,7 @@ def test_process_raw_tiffs_service_processing_failed(
     )
 
     # Check that the message was nacked with the expected parameters
-    offline_transport.nack.assert_called_once_with(header)
+    offline_transport.nack.assert_called_once_with(header, requeue=True)
 
     # Check that the message wasn't erronerously sent
     offline_transport.send.assert_not_called()

--- a/tests/services/test_cluster_submission.py
+++ b/tests/services/test_cluster_submission.py
@@ -322,6 +322,7 @@ def test_cluster_submission_failed_submission(
             },
         }
     }
+    mock_rw.transport = offline_transport
 
     # Set up the mock service
     service = cluster_submission.ClusterSubmission(
@@ -382,6 +383,7 @@ def test_cluster_submission_directory_failures(mock_rw, offline_transport, tmp_p
             },
         }
     }
+    mock_rw.transport = offline_transport
     service.run_submit_job(mock_rw, header=header, message={})
 
     # Cases of invalid working dirs

--- a/tests/services/test_common_service.py
+++ b/tests/services/test_common_service.py
@@ -4,6 +4,7 @@ import sys
 from unittest import mock
 
 import pytest
+from workflows.transport.pika_transport import PikaTransport
 
 from cryoemservices.services import common_service
 
@@ -41,3 +42,34 @@ def test_common_service(mock_queue, tmp_path):
     mock_queue.PriorityQueue().get.assert_called_with(True, 2)
 
     mock_service.assert_called_with("test_header", "test_message")
+
+
+@mock.patch("cryoemservices.services.common_service.partial")
+def test_reject_message(mock_partial):
+    """
+    Check message rejection works
+    """
+    # Set up mock transports for both offline and pika
+    mock_transport = mock.Mock()
+    mock_pika = mock.Mock(spec=PikaTransport)
+    mock_thread = mock.Mock()
+    mock_channel = mock.Mock()
+    mock_thread._pika_channels = {2: mock_channel}
+    mock_pika._pika_thread = mock_thread
+
+    # Set up the mock service and send the message to it
+    service = common_service.CommonService(
+        environment={"queue": ""}, transport=mock_transport
+    )
+    header = {"message-id": 1, "subscription": 2}
+
+    # Reject using the basic transport
+    service._reject_message(header)
+    mock_transport.nack.assert_called_once_with(header, requeue=True)
+
+    # Reject using a pika instance
+    service._reject_message(header, transport=mock_pika, requeue=False)
+    mock_thread._connection.add_callback_threadsafe.assert_called_once()
+    mock_partial.assert_called_once_with(
+        mock_channel.basic_reject, delivery_tag=1, requeue=False
+    )

--- a/tests/services/test_tomo_align_slurm.py
+++ b/tests/services/test_tomo_align_slurm.py
@@ -519,12 +519,8 @@ def test_tomo_align_slurm_service_reject_visits(
 
     # Send a message to the service
     service.tomo_align(None, header=header, message=tomo_align_test_message)
-    if valid_visit:
-        # These fail due to file not found
-        offline_transport.nack.assert_called_once_with(header)
-    else:
-        # Invalid visits should be requeued for non-slurm service
-        offline_transport.nack.assert_called_once_with(header, requeue=True)
+    # Invalid visits or file not found should be requeued for non-slurm service
+    offline_transport.nack.assert_called_once_with(header, requeue=True)
 
 
 @mock.patch("cryoemservices.services.tomo_align_slurm.get_iris_state")


### PR DESCRIPTION
A way to resolve the rabbitmq infinite loops we have been seeing. This creates a new functions based on `python-workflows` methods to reject messages rather than nack them. Then replaces (almost) all instances of nack with reject.

I'm not certain I've got every requeue choice right but the general policy is:
- `requeue=False` if the input message is wrong (e.g. missing parameter, malformed directory)
- `requeue=True` if the failure is external (e.g. failed subprocess call, missing file)

There is a resort back to nacking if not using pika transport, mostly to avoid having to rewrite all the tests