### PR TITLE
Improve CLEM composites

### DIFF
--- a/recipes/ispyb/clem-align-and-merge-wrapper.json
+++ b/recipes/ispyb/clem-align-and-merge-wrapper.json
@@ -4,11 +4,10 @@
       "series_name": "{series_name}",
       "images": "{images}",
       "metadata": "{metadata}",
-      "crop_to_n_frames": "{crop_to_n_frames}",
-      "align_self": "{align_self}",
-      "flatten": "{flatten}",
-      "align_across": "{align_across}",
-      "num_procs": "{num_procs}"
+      "crop_to_n_frames": null,
+      "align_self": false,
+      "flatten": true,
+      "align_across": false
     },
     "output": {
       "murfey_feedback": 2,

--- a/recipes/ispyb/clem-align-and-merge-wrapper.json
+++ b/recipes/ispyb/clem-align-and-merge-wrapper.json
@@ -7,7 +7,8 @@
       "crop_to_n_frames": null,
       "align_self": false,
       "flatten": true,
-      "align_across": false
+      "align_across": false,
+      "num_procs": 1
     },
     "output": {
       "murfey_feedback": 2,

--- a/recipes/ispyb/clem-align-and-merge.json
+++ b/recipes/ispyb/clem-align-and-merge.json
@@ -4,11 +4,10 @@
       "series_name": "{series_name}",
       "images": "{images}",
       "metadata": "{metadata}",
-      "crop_to_n_frames": "{crop_to_n_frames}",
-      "align_self": "{align_self}",
-      "flatten": "{flatten}",
-      "align_across": "{align_across}",
-      "num_procs": "{num_procs}"
+      "crop_to_n_frames": null,
+      "align_self": false,
+      "flatten": true,
+      "align_across": false
     },
     "output": {
       "murfey_feedback": 2,

--- a/recipes/ispyb/clem-align-and-merge.json
+++ b/recipes/ispyb/clem-align-and-merge.json
@@ -7,7 +7,8 @@
       "crop_to_n_frames": null,
       "align_self": false,
       "flatten": true,
-      "align_across": false
+      "align_across": false,
+      "num_procs": 1
     },
     "output": {
       "murfey_feedback": 2,

--- a/recipes/ispyb/clem-lif-to-stack-wrapper.json
+++ b/recipes/ispyb/clem-lif-to-stack-wrapper.json
@@ -2,8 +2,7 @@
   "1": {
     "job_parameters": {
       "lif_file": "{lif_file}",
-      "root_folder": "{root_folder}",
-      "num_procs": "{num_procs}"
+      "root_folder": "{root_folder}"
     },
     "output": {
       "murfey_feedback": 2,

--- a/recipes/ispyb/clem-lif-to-stack-wrapper.json
+++ b/recipes/ispyb/clem-lif-to-stack-wrapper.json
@@ -2,7 +2,8 @@
   "1": {
     "job_parameters": {
       "lif_file": "{lif_file}",
-      "root_folder": "{root_folder}"
+      "root_folder": "{root_folder}",
+      "num_procs": 1
     },
     "output": {
       "murfey_feedback": 2,

--- a/recipes/ispyb/clem-lif-to-stack.json
+++ b/recipes/ispyb/clem-lif-to-stack.json
@@ -2,8 +2,7 @@
   "1": {
     "parameters": {
       "lif_file": "{lif_file}",
-      "root_folder": "{root_folder}",
-      "num_procs": "{num_procs}"
+      "root_folder": "{root_folder}"
     },
     "output": {
       "murfey_feedback": 2,

--- a/recipes/ispyb/clem-lif-to-stack.json
+++ b/recipes/ispyb/clem-lif-to-stack.json
@@ -2,7 +2,8 @@
   "1": {
     "parameters": {
       "lif_file": "{lif_file}",
-      "root_folder": "{root_folder}"
+      "root_folder": "{root_folder}",
+      "num_procs": 1
     },
     "output": {
       "murfey_feedback": 2,

--- a/recipes/ispyb/clem-tiff-to-stack-wrapper.json
+++ b/recipes/ispyb/clem-tiff-to-stack-wrapper.json
@@ -4,7 +4,8 @@
       "tiff_list": "{tiff_list}",
       "tiff_file": "{tiff_file}",
       "root_folder": "{root_folder}",
-      "metadata": "{metadata}"
+      "metadata": "{metadata}",
+      "num_procs": 1
     },
     "output": {
       "murfey_feedback": 2,

--- a/recipes/ispyb/clem-tiff-to-stack-wrapper.json
+++ b/recipes/ispyb/clem-tiff-to-stack-wrapper.json
@@ -4,8 +4,7 @@
       "tiff_list": "{tiff_list}",
       "tiff_file": "{tiff_file}",
       "root_folder": "{root_folder}",
-      "metadata": "{metadata}",
-      "num_procs": "{num_procs}"
+      "metadata": "{metadata}"
     },
     "output": {
       "murfey_feedback": 2,

--- a/recipes/ispyb/clem-tiff-to-stack.json
+++ b/recipes/ispyb/clem-tiff-to-stack.json
@@ -4,7 +4,8 @@
       "tiff_list": "{tiff_list}",
       "tiff_file": "{tiff_file}",
       "root_folder": "{root_folder}",
-      "metadata": "{metadata}"
+      "metadata": "{metadata}",
+      "num_procs": 1
     },
     "output": {
       "murfey_feedback": 2,

--- a/recipes/ispyb/clem-tiff-to-stack.json
+++ b/recipes/ispyb/clem-tiff-to-stack.json
@@ -4,8 +4,7 @@
       "tiff_list": "{tiff_list}",
       "tiff_file": "{tiff_file}",
       "root_folder": "{root_folder}",
-      "metadata": "{metadata}",
-      "num_procs": "{num_procs}"
+      "metadata": "{metadata}"
     },
     "output": {
       "murfey_feedback": 2,

--- a/src/cryoemservices/cli/clem_align_and_merge.py
+++ b/src/cryoemservices/cli/clem_align_and_merge.py
@@ -83,35 +83,23 @@ def run():
     # Align image stacks before flattening
     parser.add_argument(
         "--align-self",
-        default="",
-        type=str,
-        help=(
-            "Choose whether to align the image stacks individually before flattening. \n"
-            "VALUES:    'enabled', '' \n"
-            "DEFAULT:   ''"
-        ),
+        action="store_true",
+        default=False,
+        help=("If set, aligns the image stacks individually before flattening."),
     )
     # Determine how the image is flattened
     parser.add_argument(
         "--flatten",
-        default="mean",
-        type=str,
-        help=(
-            "Choose whether to flatten the image stacks. \n"
-            "VALUES:    'mean', 'min', 'max', '' \n"
-            "DEFAULT:   'mean'"
-        ),
+        action="store_true",
+        default=False,
+        help=("If set, flattens the image stacks."),
     )
     # Determine what image registration protocol to implement
     parser.add_argument(
         "--align-across",
-        default="",
-        type=str,
-        help=(
-            "Choose whether to align the image stacks to one another before merging. \n"
-            "VALUES:    'enabled', '' \n"
-            "DEFAULT:   ''"
-        ),
+        action="store_true",
+        default=False,
+        help=("If set, aligns the image stacks to one another before merging. \n"),
     )
     # Determine number of processes to use
     parser.add_argument(

--- a/src/cryoemservices/wrappers/clem_align_and_merge.py
+++ b/src/cryoemservices/wrappers/clem_align_and_merge.py
@@ -69,7 +69,19 @@ def align_and_merge_stacks(
 
     # Validate inputs before proceeding further
     if crop_to_n_frames is not None and not isinstance(crop_to_n_frames, int):
-        message = "Incorrect value provided for 'crop_to_n_frames' parameter"
+        message = f"Invalid value provided for 'crop_to_n_frames' parameter: {crop_to_n_frames}"
+        logger.error(message)
+        raise ValueError(message)
+    if not isinstance(align_self, bool):
+        message = f"Invalid value provided for 'align_self' parameter: {align_self}"
+        logger.error(message)
+        raise ValueError(message)
+    if not isinstance(flatten, bool):
+        message = f"Invalid value provided for 'flatten' parameter: {flatten}"
+        logger.error(message)
+        raise ValueError(message)
+    if not isinstance(align_across, bool):
+        message = f"Invalid value provided for 'align_across' parameter: {align_across}"
         logger.error(message)
         raise ValueError(message)
 

--- a/src/cryoemservices/wrappers/clem_align_and_merge.py
+++ b/src/cryoemservices/wrappers/clem_align_and_merge.py
@@ -72,18 +72,6 @@ def align_and_merge_stacks(
         message = f"Invalid value provided for 'crop_to_n_frames' parameter: {crop_to_n_frames}"
         logger.error(message)
         raise ValueError(message)
-    if not isinstance(align_self, bool):
-        message = f"Invalid value provided for 'align_self' parameter: {align_self}"
-        logger.error(message)
-        raise ValueError(message)
-    if not isinstance(flatten, bool):
-        message = f"Invalid value provided for 'flatten' parameter: {flatten}"
-        logger.error(message)
-        raise ValueError(message)
-    if not isinstance(align_across, bool):
-        message = f"Invalid value provided for 'align_across' parameter: {align_across}"
-        logger.error(message)
-        raise ValueError(message)
 
     # Standardise into a list of Paths
     files = [images] if isinstance(images, (Path, str)) else images

--- a/src/cryoemservices/wrappers/clem_align_and_merge.py
+++ b/src/cryoemservices/wrappers/clem_align_and_merge.py
@@ -17,7 +17,7 @@ import time
 from ast import literal_eval
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import Any, Literal, Optional
+from typing import Any, Optional
 
 import numpy as np
 from defusedxml.ElementTree import parse
@@ -43,9 +43,9 @@ def align_and_merge_stacks(
     images: Path | list[Path],
     metadata: Optional[Path] = None,
     crop_to_n_frames: Optional[int] = None,
-    align_self: Literal["enabled", ""] = "",
-    flatten: Optional[Literal["min", "max", "mean", ""]] = "mean",
-    align_across: Literal["enabled", ""] = "",
+    align_self: bool = False,
+    flatten: bool = True,
+    align_across: bool = False,
     num_procs: int = 4,
 ) -> dict[str, Any]:
     """
@@ -70,21 +70,6 @@ def align_and_merge_stacks(
     # Validate inputs before proceeding further
     if crop_to_n_frames is not None and not isinstance(crop_to_n_frames, int):
         message = "Incorrect value provided for 'crop_to_n_frames' parameter"
-        logger.error(message)
-        raise ValueError(message)
-
-    if align_self not in ("enabled", ""):
-        message = "Incorrect value provided for 'align_self' parameter"
-        logger.error(message)
-        raise ValueError(message)
-
-    if flatten not in ("mean", "min", "max", ""):
-        message = "Incorrect value provided for 'flatten' parameter"
-        logger.error(message)
-        raise ValueError(message)
-
-    if align_across not in ("enabled", ""):
-        message = "Incorrect value provided for 'align_across' parameter"
         logger.error(message)
         raise ValueError(message)
 
@@ -298,7 +283,10 @@ def align_and_merge_stacks(
                 arrays = list(
                     pool.map(
                         lambda p: flatten_image(*p),
-                        [(arr, flatten) for arr in arrays],
+                        [
+                            (arr, "mean" if color == "gray" else "max")
+                            for arr, color in zip(arrays, colors_to_process)
+                        ],
                     )
                 )
             if len({arr.shape for arr in arrays}) > 1:
@@ -504,9 +492,9 @@ class AlignAndMergeParameters(BaseModel):
     images: Path | list[Path]
     metadata: Optional[Path] = Field(default=None)
     crop_to_n_frames: Optional[int] = Field(default=None)
-    align_self: Literal["enabled", ""] = Field(default="")
-    flatten: Literal["mean", "min", "max", ""] = Field(default="mean")
-    align_across: Literal["enabled", ""] = Field(default="")
+    align_self: bool = Field(default=False)
+    flatten: bool = Field(default=True)
+    align_across: bool = Field(default=False)
     num_procs: int = Field(default=4)
 
     @field_validator("images", mode="before")

--- a/src/cryoemservices/wrappers/clem_align_and_merge.py
+++ b/src/cryoemservices/wrappers/clem_align_and_merge.py
@@ -72,6 +72,18 @@ def align_and_merge_stacks(
         message = f"Invalid value provided for 'crop_to_n_frames' parameter: {crop_to_n_frames}"
         logger.error(message)
         raise ValueError(message)
+    if not isinstance(align_self, bool):
+        message = f"Invalid value provided for 'align_self' parameter: {align_self}"
+        logger.error(message)
+        raise ValueError(message)
+    if not isinstance(flatten, bool):
+        message = f"Invalid value provided for 'flatten' parameter: {flatten}"
+        logger.error(message)
+        raise ValueError(message)
+    if not isinstance(align_across, bool):
+        message = f"Invalid value provided for 'align_across' parameter: {align_across}"
+        logger.error(message)
+        raise ValueError(message)
 
     # Standardise into a list of Paths
     files = [images] if isinstance(images, (Path, str)) else images

--- a/tests/cli/test_clem_align_and_merge_cli.py
+++ b/tests/cli/test_clem_align_and_merge_cli.py
@@ -30,11 +30,8 @@ def test_align_and_merge_with_optional_args(mocker: MockerFixture, tmp_path: Pat
         "--crop-to-n-frames",
         "5",
         "--align-self",
-        "enabled",
         "--flatten",
-        "min",
         "--align-across",
-        "enabled",
         "--num-procs",
         "4",
         "--debug",
@@ -46,9 +43,9 @@ def test_align_and_merge_with_optional_args(mocker: MockerFixture, tmp_path: Pat
         images=[tmp_path / "file1", tmp_path / "file2"],
         metadata=Path("metadata.xml"),
         crop_to_n_frames=5,
-        align_self="enabled",
-        flatten="min",
-        align_across="enabled",
+        align_self=True,
+        flatten=True,
+        align_across=True,
         num_procs=4,
     )
 
@@ -75,9 +72,9 @@ def test_align_and_merge_with_default_args(mocker: MockerFixture, tmp_path: Path
         images=[tmp_path / "file1"],
         metadata=None,
         crop_to_n_frames=None,
-        align_self="",
-        flatten="mean",
-        align_across="",
+        align_self=False,
+        flatten=False,
+        align_across=False,
         num_procs=1,
     )
 
@@ -103,9 +100,9 @@ def test_align_and_merge_string_list(mocker: MockerFixture, tmp_path):
         images=[tmp_path / "file1", tmp_path / "file2"],
         metadata=None,
         crop_to_n_frames=None,
-        align_self="",
-        flatten="mean",
-        align_across="",
+        align_self=False,
+        flatten=False,
+        align_across=False,
         num_procs=1,
     )
 
@@ -128,7 +125,7 @@ def test_align_and_merge_exists():
     )
     assert cleaned_help_line == (
         "usage:clem.align_and_merge[-h][--metadataMETADATA]"
-        "[--crop-to-n-framesCROP_TO_N_FRAMES][--align-selfALIGN_SELF]"
-        "[--flattenFLATTEN][--align-acrossALIGN_ACROSS]"
+        "[--crop-to-n-framesCROP_TO_N_FRAMES][--align-self]"
+        "[--flatten][--align-across]"
         "[--num-procsNUM_PROCS][--debug]images[images...]"
     )

--- a/tests/services/test_clem_align_and_merge_service.py
+++ b/tests/services/test_clem_align_and_merge_service.py
@@ -71,22 +71,20 @@ def offline_transport(mocker):
     return transport
 
 
-align_and_merge_params_matrix = (
-    # Use Recipe Wrapper | Crop to N frames | Align to self | Flatten | Align across
-    (True, 20, "enabled", "mean", "enabled"),
-    (True, 20, "enabled", "min", "enabled"),
-    (True, 20, "enabled", "max", "enabled"),
-    (False, 20, "enabled", "mean", ""),
-    (False, 20, "", "min", "enabled"),
-    (False, 20, "", "max", ""),
+@pytest.mark.parametrize(
+    "test_params",
+    (
+        # Use Recipe Wrapper | Crop to N frames | Align to self | Flatten | Align across
+        (True, 20, True, True, True),
+        (False, 20, True, True, False),
+        (False, 20, False, True, True),
+        (False, 20, False, True, False),
+    ),
 )
-
-
-@pytest.mark.parametrize("test_params", align_and_merge_params_matrix)
 @mock.patch("cryoemservices.services.clem_align_and_merge.align_and_merge_stacks")
 def test_align_and_merge_service(
     mock_align,
-    test_params: tuple[bool, int, str, str, str],
+    test_params: tuple[bool, int, bool, bool, bool],
     image_stacks: list[Path],
     metadata: Path,
     series_name: str,
@@ -225,22 +223,21 @@ def test_align_and_merge_bad_messsage(
     offline_transport.send.assert_not_called()
 
 
-# Introduce invalid parameters field-by-field
-align_and_merge_params_bad_validation_matrix = (
-    # Series name | Images | Metadata | Crop to N frames | Align to self | Flatten | Align across
-    (False, True, True, 20, "enabled", "mean", "enabled"),
-    (True, False, True, 20, "enabled", "mean", "enabled"),
-    (True, True, False, 20, "enabled", "mean", "enabled"),
-    (True, True, True, "Not a number", "enabled", "mean", "enabled"),
-    (True, True, True, 20, "off", "mean", "enabled"),
-    (True, True, True, 20, "enabled", "off", "enabled"),
-    (True, True, True, 20, "enabled", "mean", "off"),
+@pytest.mark.parametrize(
+    "test_params",
+    (  # Introduce invalid parameters field-by-field
+        # Series name | Images | Metadata | Crop to N frames | Align to self | Flatten | Align across
+        (False, True, True, 20, True, True, True),
+        (True, False, True, 20, True, True, True),
+        (True, True, False, 20, True, True, True),
+        (True, True, True, "Not a number", True, True, True),
+        (True, True, True, 20, "off", True, True),
+        (True, True, True, 20, True, "off", True),
+        (True, True, True, 20, True, True, "off"),
+    ),
 )
-
-
-@pytest.mark.parametrize("test_params", align_and_merge_params_bad_validation_matrix)
 def test_align_and_merge_service_validation_failed(
-    test_params: tuple[bool, bool, bool, Any, str, str, str],
+    test_params: tuple[bool, bool, bool, Any, Any, Any, Any],
     image_stacks: list[Path],
     metadata: Path,
     series_name: str,
@@ -295,7 +292,21 @@ def test_align_and_merge_service_validation_failed(
     )
 
     # Check that the message was nacked
-    offline_transport.nack.assert_called_once_with(header, requeue=False)
+    offline_transport.nack.assert_called_once_with(
+        header,
+        requeue=(
+            True
+            if any(
+                isinstance(item, str)
+                for item in (
+                    align_self,
+                    flatten,
+                    align_across,
+                )
+            )
+            else False
+        ),
+    )
 
     # Check that the message wasn't erronerously sent
     offline_transport.send.assert_not_called()
@@ -325,9 +336,9 @@ def test_align_and_merge_service_process_failed(
         "images": [str(f) for f in image_stacks],
         "metadata": str(metadata),
         "crop_to_n_frames": 50,
-        "align_self": "enabled",
-        "flatten": "mean",
-        "align_across": "enabled",
+        "align_self": True,
+        "flatten": True,
+        "align_across": True,
     }
 
     # Set up expected return values if the process fails

--- a/tests/wrappers/test_clem_align_and_merge_wrapper.py
+++ b/tests/wrappers/test_clem_align_and_merge_wrapper.py
@@ -179,19 +179,20 @@ def test_align_and_merge_stacks(
     (
         # Colors | Crop frames | Align self | Flatten | Align across
         # Wrong 'crop_frames' value
-        ("5", "enabled", "max", "enabled"),
-        (5.0, "enabled", "mean", "enabled"),
+        ("5", True, True, True),
+        (5.0, True, True, True),
         # Wrong 'align_self' value
-        (5, None, "min", ""),
-        (None, 1, "mean", "enabled"),
+        (5, None, True, True),
+        (None, 1, True, True),
+        (5, "enabled", True, True),
         # Wrong 'flatten' value
-        (5, "enabled", None, ""),
-        (5, "enabled", 1, "enabled"),
-        (10, "enabled", True, "enabled"),
+        (5, True, None, False),
+        (5, True, 1, True),
+        (10, True, "enabled", True),
         # Wrong 'align_across' value
-        (5, "", "min", None),
-        (None, "enabled", "mean", True),
-        (5, "enabled", "", 1),
+        (5, False, True, None),
+        (None, True, True, 1),
+        (5, True, False, "enabled"),
     ),
 )
 def test_align_and_merge_stacks_wrong_params(

--- a/tests/wrappers/test_clem_align_and_merge_wrapper.py
+++ b/tests/wrappers/test_clem_align_and_merge_wrapper.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -109,29 +109,23 @@ def image_list(processed_dir: Path):
     "test_params",
     (
         # Colors | Crop frames | Align self | Flatten | Align across
-        (("gray", "green", "red"), 5, "enabled", "max", "enabled"),
-        (("gray", "green", "red", "blue"), 5, "enabled", "max", "enabled"),
-        (("gray", "green", "red"), 10, "enabled", "mean", "enabled"),
-        (("gray", "green", "red"), 5, "", "min", ""),
-        (("gray", "green", "red"), None, "enabled", "mean", "enabled"),
-        (("gray", "green", "red"), 5, "enabled", "", ""),
-        (("green", "red"), 5, "enabled", "max", "enabled"),
-        (("green", "red", "blue"), 5, "enabled", "max", "enabled"),
-        (("green", "red"), 10, "enabled", "mean", "enabled"),
-        (("green", "red"), 5, "", "min", ""),
-        (("green", "red"), None, "enabled", "mean", "enabled"),
-        (("green", "red"), 5, "enabled", "", ""),
+        (("gray", "green", "red"), 5, True, True, True),
+        (("gray", "green", "red", "blue"), 5, True, True, True),
+        (("gray", "green", "red"), 10, True, True, True),
+        (("gray", "green", "red"), 5, False, True, False),
+        (("gray", "green", "red"), None, True, True, True),
+        (("gray", "green", "red"), 5, True, False, False),
+        (("green", "red"), 5, True, True, True),
+        (("green", "red", "blue"), 5, True, True, True),
+        (("green", "red"), 10, True, True, True),
+        (("green", "red"), 5, False, True, False),
+        (("green", "red"), None, True, True, True),
+        (("green", "red"), 5, True, False, False),
     ),
 )
 def test_align_and_merge_stacks(
     mocker: MockerFixture,
-    test_params: tuple[
-        tuple[str, ...],
-        int | None,
-        Literal["enabled", ""],
-        Literal["min", "max", "mean", ""],
-        Literal["enabled", ""],
-    ],
+    test_params: tuple[tuple[str, ...], int | None, bool, bool, bool],
     metadata_file: Path,
     image_list: list[Path],
 ):
@@ -238,14 +232,14 @@ def test_align_and_merge_stacks_wrong_params(
     "test_params",
     (
         # Number of images | Stringify list | Frames to crop | Align self | Flatten | Align across
-        (3, False, 5, "enabled", "max", "enabled"),
-        (3, True, 5, "", "mean", "enabled"),
-        (3, False, None, "enabled", "min", ""),
-        (3, False, "None", "enabled", "min", ""),
-        (1, False, 5, "", "", "enabled"),
-        (1, True, 5, "enabled", "max", "enabled"),
-        (1, False, None, "", "mean", ""),
-        (1, False, "None", "", "mean", ""),
+        (3, False, 5, "true", "true", "true"),
+        (3, True, 5, "false", "true", "true"),
+        (3, False, None, "true", "true", "false"),
+        (3, False, "None", "true", "true", "false"),
+        (1, False, 5, "false", "false", "true"),
+        (1, True, 5, "true", "true", "true"),
+        (1, False, None, "false", "true", "false"),
+        (1, False, "None", "false", "true", "false"),
     ),
 )
 def test_align_and_merge_parameters(
@@ -295,9 +289,9 @@ def test_align_and_merge_parameters(
         isinstance(validated_params.crop_to_n_frames, int)
         or validated_params.crop_to_n_frames is None
     )
-    assert validated_params.align_self in ("enabled", "")
-    assert validated_params.flatten in ("mean", "min", "max", "")
-    assert validated_params.align_across in ("enabled", "")
+    assert validated_params.align_self in (True, False)
+    assert validated_params.flatten in (True, False)
+    assert validated_params.align_across in (True, False)
 
 
 # Set up a mock transport object
@@ -325,9 +319,9 @@ def test_align_and_merge_wrapper(
 
     # Construct a dictionary to pass to the wrapper
     crop_to_n_frames = 30
-    align_self = "enabled"
-    flatten = "max"
-    align_across = "enabled"
+    align_self = True
+    flatten = True
+    align_across = True
     num_procs = 4
 
     message = {


### PR DESCRIPTION
Feedback on the automated CLEM composites generated has been that the fluorescent images are too dim, with the actual features of interest being barely visible compared to the presence of other contaminants in the image.

This PR changes the logic of the `align_and_merge_stacks` function so that it handles bright field (BF) and fluorescent (FL) images differently: For BF images, it will proceed as normal and use the averaged intensity projection along the z-axis. For FL images, it will now take the maximum intensity projection instead.

Additionally, the nature of the parameters passed to the `align_and_merge_stacks` have been updated. `align_self`, `flatten`, and `align_across` have been changed to accept booleans instead of string literals. The CLI has been changed to reflect this, and the recipes will need to be updated separately.