### PR TITLE
Changes to make imod patch work in v5

### DIFF
--- a/src/cryoemservices/services/tomo_align_imod.py
+++ b/src/cryoemservices/services/tomo_align_imod.py
@@ -29,6 +29,7 @@ class ImodTomoParameters(BaseModel):
     patch: int = 1
     patch_size: int = 200
     patch_overlap: float = 0.5
+    local_alignment: int = 0
     flip_vol: int = 1
     manual_tilt_offset: Optional[float] = None
     cpus: int = 4
@@ -140,7 +141,7 @@ class ImodTomoAlign(CommonService):
         adoc_file = write_batch_directive_file(tomo_params)
         imod_output_path = (
             Path(tomo_params.stack_file).parent
-            / f"{Path(tomo_params.stack_file).stem}.rec"
+            / f"{Path(tomo_params.stack_file).stem}_rec.mrc"
         )
         imod_result = subprocess.run(
             [
@@ -301,6 +302,7 @@ def write_batch_directive_file(tomo_params: ImodTomoParameters):
         # Commands for copytomocoms
         adoc.write(f"setupset.datasetDirectory={adoc_file.parent}\n")
         adoc.write(f"setupset.copyarg.name={Path(tomo_params.stack_file).stem}\n")
+        adoc.write("setupset.copyarg.stackext=mrc\n")
         adoc.write("setupset.copyarg.userawtlt=1\n")
         adoc.write("setupset.copyarg.dual=0\n")
         adoc.write(f"setupset.copyarg.pixel={tomo_params.pixel_size / 10}\n")
@@ -350,11 +352,14 @@ def write_batch_directive_file(tomo_params: ImodTomoParameters):
 
         # Alignment
         adoc.write("comparam.align.tiltalign.SurfacesToAnalyze=1\n")
-        adoc.write("comparam.align.tiltalign.LocalAlignments=1\n")
+        adoc.write(
+            f"comparam.align.tiltalign.LocalAlignments={tomo_params.local_alignment}\n"
+        )
         adoc.write("comparam.align.tiltalign.MagOption=3\n")
         adoc.write("comparam.align.tiltalign.TiltOption=5\n")
         adoc.write("comparam.align.tiltalign.RotOption=3\n")
         adoc.write("comparam.align.tiltalign.RobustFitting=1\n")
+        adoc.write("comparam.restrictalign.restrictalign.UseCrossValidation=0\n")
 
         # Aligned Stack Parameters
         adoc.write("runtime.AlignedStack.any.linearInterpolation=1\n")

--- a/tests/services/test_tomo_align_imod.py
+++ b/tests/services/test_tomo_align_imod.py
@@ -69,7 +69,7 @@ def test_tomo_align_imod(
     (tmp_path / "test.txrm").touch()
     (tmp_path / "recipe/Tomograms").mkdir(parents=True)
     (tmp_path / "recipe/Tomograms/test_stack.mrc").touch()
-    (tmp_path / "recipe/Tomograms/test_stack.rec").touch()
+    (tmp_path / "recipe/Tomograms/test_stack_rec.mrc").touch()
 
     # Set up the mock service
     service = tomo_align_imod.ImodTomoAlign(
@@ -115,7 +115,7 @@ def test_tomo_align_imod(
 
     """# Check the shift plot
     with open(
-        tmp_path / "recipe/Tomograms/test_stack.rec/test_stack_xy_shift_plot.json"
+        tmp_path / "recipe/Tomograms/test_stack_rec.mrc/test_stack_xy_shift_plot.json"
     ) as shift_plot:
         shift_data = json.load(shift_plot)
     assert shift_data["data"][0]["x"] == [1.2]
@@ -152,21 +152,21 @@ def test_tomo_align_imod(
         "images",
         {
             "image_command": "mrc_central_slice",
-            "file": f"{tmp_path}/recipe/Tomograms/test_stack.rec",
+            "file": f"{tmp_path}/recipe/Tomograms/test_stack_rec.mrc",
         },
     )
     offline_transport.send.assert_any_call(
         "images",
         {
             "image_command": "mrc_to_apng",
-            "file": f"{tmp_path}/recipe/Tomograms/test_stack.rec",
+            "file": f"{tmp_path}/recipe/Tomograms/test_stack_rec.mrc",
         },
     )
     offline_transport.send.assert_any_call(
         "images",
         {
             "image_command": "mrc_projection",
-            "file": f"{tmp_path}/recipe/Tomograms/test_stack.rec",
+            "file": f"{tmp_path}/recipe/Tomograms/test_stack_rec.mrc",
             "projection": "XY",
             "pixel_spacing": 106,
         },
@@ -175,7 +175,7 @@ def test_tomo_align_imod(
         "images",
         {
             "image_command": "mrc_projection",
-            "file": f"{tmp_path}/recipe/Tomograms/test_stack.rec",
+            "file": f"{tmp_path}/recipe/Tomograms/test_stack_rec.mrc",
             "projection": "YZ",
             "pixel_spacing": 106,
             "thickness_ang": 500 * 106,
@@ -184,7 +184,7 @@ def test_tomo_align_imod(
     offline_transport.send.assert_any_call(
         "denoise",
         {
-            "volume": f"{tmp_path}/recipe/Tomograms/test_stack.rec",
+            "volume": f"{tmp_path}/recipe/Tomograms/test_stack_rec.mrc",
             "output_dir": f"{tmp_path}/recipe/Denoise",
             "relion_options": {},
         },
@@ -196,7 +196,7 @@ def test_tomo_align_imod(
             "ispyb_command_list": [
                 {
                     "ispyb_command": "insert_tomogram",
-                    "volume_file": "test_stack.rec",
+                    "volume_file": "test_stack_rec.mrc",
                     "stack_file": tomo_align_test_message["stack_file"],
                     "size_x": 4000,
                     "size_y": 3000,
@@ -204,11 +204,11 @@ def test_tomo_align_imod(
                     "pixel_spacing": 106.0,
                     "z_shift": 0,
                     "file_directory": f"{tmp_path}/recipe/Tomograms",
-                    "central_slice_image": "test_stack_thumbnail.jpeg",
-                    "tomogram_movie": "test_stack_movie.png",
-                    "xy_shift_plot": "test_stack_xy_shift_plot.json",
-                    "proj_xy": "test_stack_projXY.jpeg",
-                    "proj_xz": "test_stack_projYZ.jpeg",
+                    "central_slice_image": "test_stack_rec_thumbnail.jpeg",
+                    "tomogram_movie": "test_stack_rec_movie.png",
+                    "xy_shift_plot": "test_stack_rec_xy_shift_plot.json",
+                    "proj_xy": "test_stack_rec_projXY.jpeg",
+                    "proj_xz": "test_stack_rec_projYZ.jpeg",
                 },
                 {
                     "ispyb_command": "insert_processed_tomogram",
@@ -217,7 +217,7 @@ def test_tomo_align_imod(
                 },
                 {
                     "ispyb_command": "insert_processed_tomogram",
-                    "file_path": f"{tmp_path}/recipe/Tomograms/test_stack_alignment.jpeg",
+                    "file_path": f"{tmp_path}/recipe/Tomograms/test_stack_rec_alignment.jpeg",
                     "processing_type": "Alignment",
                 },
             ],


### PR DESCRIPTION
Imod v5 saves the output files as _rec.mrc

To make the patch tracking version work we need to turn off local alignment and cross validation.

The versions referred to as WBP and SIRT at b24 are still to do