### PR TITLE
Add ISPyB querying logic to image correlation service

### DIFF
--- a/src/cryoemservices/services/correlative_align_images.py
+++ b/src/cryoemservices/services/correlative_align_images.py
@@ -1,10 +1,15 @@
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
+import ispyb.sqlalchemy
+import sqlalchemy.orm
+from ispyb.sqlalchemy import _auto_db_schema as ISPyBDB
 from pydantic import BaseModel, ValidationError
+from sqlalchemy import select
 from workflows.recipe import RecipeWrapper, wrap_subscribe
 
 from cryoemservices.services.common_service import CommonService
+from cryoemservices.util.config import config_from_file
 from cryoemservices.util.models import MockRW
 
 
@@ -17,6 +22,34 @@ class AlignImagesParameters(BaseModel):
     pixel_size_mov: float
 
 
+def _get_atlas_dcg_experiment_type(session: sqlalchemy.orm.Session, atlas_id: int):
+    """
+    Runs an ISPyB query to get the Atlas and its corresponding DataCollectionGroup
+    and ExperimentType rows.
+    """
+
+    statement = (
+        select(ISPyBDB.Atlas, ISPyBDB.DataCollectionGroup, ISPyBDB.ExperimentType)
+        .join(
+            ISPyBDB.DataCollectionGroup,
+            ISPyBDB.Atlas.dataCollectionGroupId
+            == ISPyBDB.DataCollectionGroup.dataCollectionGroupId,
+        )
+        .join(
+            ISPyBDB.ExperimentType,
+            ISPyBDB.DataCollectionGroup.experimentTypeId
+            == ISPyBDB.ExperimentType.experimentTypeId,
+        )
+        .where(ISPyBDB.Atlas.atlasId == atlas_id)
+    )
+    result = session.execute(statement).one()  # Will error if no match is found
+    return (
+        cast(ISPyBDB.Atlas, result.Atlas),
+        cast(ISPyBDB.DataCollectionGroup, result.DataCollectionGroup),
+        cast(ISPyBDB.ExperimentType, result.ExperimentType),
+    )
+
+
 class AlignImagesService(CommonService):
     """
     A CryoEM service to align to images to one another
@@ -26,7 +59,14 @@ class AlignImagesService(CommonService):
 
     def initializing(self):
         """Subscribe to a queue. Received messages must be acknowledged."""
-        self.log.info("Correlative image alignment service starting")
+        # Set up ISPyB session maker
+        service_config = config_from_file(self._environment["config"])
+        self._database_session_maker = sqlalchemy.orm.sessionmaker(
+            bind=sqlalchemy.create_engine(
+                ispyb.sqlalchemy.url(credentials=service_config.ispyb_credentials),
+                connect_args={"use_pure": True},
+            )
+        )
         # Subscribe service to RMQ queue
         wrap_subscribe(
             self._transport,
@@ -35,6 +75,7 @@ class AlignImagesService(CommonService):
             acknowledgement=True,
             allow_non_recipe_messages=True,
         )
+        self.log.info("CorrelativeAlignImages service ready")
 
     def call_align_images(
         self,
@@ -81,6 +122,37 @@ class AlignImagesService(CommonService):
         ###############################################################################
         # Image alignment logic goes here
         ###############################################################################
+
+        # Load the ISPyB Atlas entries using the provided IDs
+        try:
+            with self._database_session_maker() as session:
+                atlas_ref, dcg_ref, experiment_type_ref = (
+                    _get_atlas_dcg_experiment_type(
+                        session=session, atlas_id=params.id_ref
+                    )
+                )
+                atlas_mov, dcg_mov, experiment_type_mov = (
+                    _get_atlas_dcg_experiment_type(
+                        session=session, atlas_id=params.id_mov
+                    )
+                )
+        except Exception:
+            self.log.error(
+                "Uncaught exception {e!r} while querying ISPyB, "
+                "quarantining message and shutting down instance.",
+                exc_info=True,
+            )
+            self._reject_message(header, transport=rw.transport)
+            return
+
+        # Align images differently depending on which data types are being compared
+        match (experiment_type_ref.name, experiment_type_mov.name):
+            case ("Tomography", "FIB"):
+                self.log.info("Aligning FIB atlas to tomography one")
+            case _:
+                self.log.info(
+                    "No image alignment algorithm implemented for this case yet"
+                )
 
         # Ack message after completion
         rw.transport.ack(header)

--- a/tests/services/test_correlative_align_images_service.py
+++ b/tests/services/test_correlative_align_images_service.py
@@ -9,8 +9,32 @@ from workflows.transport.offline_transport import OfflineTransport
 from cryoemservices.services.correlative_align_images import (
     AlignImagesParameters,
     AlignImagesService,
+    _get_atlas_dcg_experiment_type,
 )
 from cryoemservices.util.models import MockRW
+
+
+def test_get_atlas_dcg_experiment_type(mocker: MockerFixture):
+    # Create mock return results
+    mock_atlas = MagicMock()
+    mock_dcg = MagicMock()
+    mock_experiment = MagicMock()
+
+    mock_result = MagicMock()
+    mock_result.Atlas = mock_atlas
+    mock_result.DataCollectionGroup = mock_dcg
+    mock_result.ExperimentType = mock_experiment
+
+    # Create the mock SQLAlchemy session
+    mock_session = MagicMock()
+    mock_session.execute.return_value.one.return_value = mock_result
+
+    # Run the function
+    assert _get_atlas_dcg_experiment_type(mock_session, 1) == (
+        mock_atlas,
+        mock_dcg,
+        mock_experiment,
+    )
 
 
 @pytest.fixture

--- a/tests/services/test_correlative_align_images_service.py
+++ b/tests/services/test_correlative_align_images_service.py
@@ -17,22 +17,44 @@ from cryoemservices.util.models import MockRW
 def offline_transport(mocker: MockerFixture):
     transport = OfflineTransport()
     mocker.spy(transport, "send")
+    mocker.spy(transport, "nack")
     return transport
 
 
+@pytest.fixture
+def mock_config_file(tmp_path: Path):
+    config_file = tmp_path / "config.yaml"
+    lines = [
+        "rabbitmq_credentials: rmq_creds",
+        f"recipe_directory: {tmp_path}/recipes",
+        f"ispyb_credentials: {tmp_path}/ispyb.cfg",
+    ]
+    with open(config_file, "w") as file:
+        for line in lines:
+            file.write(line + "\n")
+    return config_file
+
+
 @pytest.mark.parametrize(
-    "use_recwrap",
-    (
-        True,
-        False,
+    "test_params",
+    (  # Use recwrap | Ref type | Mov type
+        (True, "Tomography", "FIB"),
+        (False, "Tomography", "FIB"),
+        (True, "Tomography", "Single Particle"),
+        (False, "Tomography", "Single Particle"),
+        (True, "Tomography", "CLEM"),
+        (False, "Tomography", "CLEM"),
     ),
 )
 def test_align_images_service(
+    mocker: MockerFixture,
     tmp_path: Path,
+    mock_config_file: Path,
     offline_transport: OfflineTransport,
-    use_recwrap: bool,
+    test_params: tuple[bool, str, str],
 ):
     # Set up the message parameters
+    use_recwrap, ref_type, mov_type = test_params
     header = {
         "message-id": mock.sentinel,
         "subscription": mock.sentinel,
@@ -41,14 +63,44 @@ def test_align_images_service(
         "id_ref": 1,
         "image_ref": str(tmp_path / "ref.png"),
         "pixel_size_ref": 1e-6,
-        "id_mov": 1,
+        "id_mov": 2,
         "image_mov": str(tmp_path / "mov.png"),
         "pixel_size_mov": 1e-6,
     }
     params = AlignImagesParameters(**align_images_test_message)
 
+    # Mock the ISPyB session creation logic
+    mock_sqlalchemy = mocker.patch(
+        "cryoemservices.services.correlative_align_images.sqlalchemy"
+    )
+    mocker.patch("cryoemservices.services.correlative_align_images.ispyb.sqlalchemy")
+    mock_ispyb_session = MagicMock()
+    mock_sqlalchemy.orm.sessionmaker()().__enter__.return_value = mock_ispyb_session
+
+    # Mock the query function and its returns
+    mock_atlas_ref = MagicMock()
+    mock_dcg_ref = MagicMock()
+    mock_experiment_ref = MagicMock()
+    mock_experiment_ref.name = ref_type
+
+    mock_atlas_mov = MagicMock()
+    mock_dcg_mov = MagicMock()
+    mock_experiment_mov = MagicMock()
+    mock_experiment_mov.name = mov_type
+
+    mock_get = mocker.patch(
+        "cryoemservices.services.correlative_align_images._get_atlas_dcg_experiment_type",
+        side_effect=[
+            (mock_atlas_ref, mock_dcg_ref, mock_experiment_ref),
+            (mock_atlas_mov, mock_dcg_mov, mock_experiment_mov),
+        ],
+    )
+
     # Set up and run the service
-    service = AlignImagesService(environment={"queue": ""}, transport=offline_transport)
+    service = AlignImagesService(
+        environment={"config": str(mock_config_file), "queue": ""},
+        transport=offline_transport,
+    )
     service.log = MagicMock()  # Mock the logger to evaluate calls
     service.initializing()
     if use_recwrap:
@@ -66,8 +118,20 @@ def test_align_images_service(
             message=align_images_test_message,
         )
 
-    # Check that the main block in the function was run
-    service.log.info.assert_called_with(
-        "Running image alignment with the following parameters:\n"
-        f"{params.model_dump(mode='json')}"
+    # Queries for the Atlas, DCG, and ExperimentType were made
+    mock_get.assert_any_call(
+        session=mock_ispyb_session,
+        atlas_id=params.id_ref,
     )
+    mock_get.assert_any_call(
+        session=mock_ispyb_session,
+        atlas_id=params.id_mov,
+    )
+    # It goes into the correct case block
+    match (ref_type, mov_type):
+        case ("Tomography", "FIB"):
+            service.log.info.assert_called_with("Aligning FIB atlas to tomography one")
+        case _:
+            service.log.info.assert_called_with(
+                "No image alignment algorithm implemented for this case yet"
+            )


### PR DESCRIPTION
Extends the logic of the new image correlation service by adding logic for it to query ISPyB for the Atlas and its matching DataCollectionGroup and ExperimentType rows using the atlas IDs of both the reference and target atlases. With these rows returned, it will then be possible to identify which experiment types the reference and target images are associated with, and thus to choose the appropriate workflow to handle them.