### PR TITLE
IMOD processing bypass and file copying

### DIFF
--- a/Dockerfiles/tomo_align
+++ b/Dockerfiles/tomo_align
@@ -34,15 +34,16 @@ ENV PATH=/install/venv/bin:${PATH}
 ENV LD_LIBRARY_PATH=/install/venv/lib:${LD_LIBRARY_PATH}
 
 # Install IMOD
+RUN yum groupinstall "Development Tools" -y
+RUN yum install mesa-libGL -y
 RUN mkdir imod_install && \
     curl https://bio3d.colorado.edu/imod/AMD64-RHEL5/imod_5.1.9_RHEL8-64_CUDA12.0.sh > imod_5.1.9_RHEL8-64_CUDA12.0.sh && \
     chmod +x imod_5.1.9_RHEL8-64_CUDA12.0.sh && \
-    ln -s /install/venv/bin/python /usr/bin/python3 && \
     ./imod_5.1.9_RHEL8-64_CUDA12.0.sh -dir imod_install -skip -y
 ENV PATH=/imod_install/IMOD/bin:${PATH}
 ENV IMOD_DIR=/imod_install/IMOD
 
 # Install AreTomo
-COPY --chown="${userid}":"${groupid}" packages/AreTomo2 /AreTomo2
-ENV PATH=/AreTomo2:${PATH}
-RUN chmod +x /AreTomo2
+COPY --chown="${userid}":"${groupid}" packages/AreTomo3 /AreTomo3
+ENV PATH=/AreTomo3:${PATH}
+RUN chmod +x /AreTomo3

--- a/Dockerfiles/tomo_align
+++ b/Dockerfiles/tomo_align
@@ -1,4 +1,4 @@
-# This Dockerfile is used for GPU AreTomo2 processing
+# This Dockerfile is used for GPU AreTomo3 or IMOD processing
 FROM rockylinux:8 AS conda-build
 
 # Set up conda environment

--- a/recipes/ispyb/sxt-aretomo.json
+++ b/recipes/ispyb/sxt-aretomo.json
@@ -22,6 +22,7 @@
       "success": 7
     },
     "parameters": {
+      "copy_output": true,
       "dark_tol": 0,
       "manual_tilt_offset": "{manual_tilt_offset}",
       "out_bin": 1,

--- a/recipes/ispyb/sxt-imod-beads-wbp.json
+++ b/recipes/ispyb/sxt-imod-beads-wbp.json
@@ -31,7 +31,8 @@
       "stack_file": "{stack_file}",
       "tilt_axis": 0,
       "txrm_file": "{txrm_file}",
-      "wbp": 1
+      "wbp": 1,
+      "xrm_reference": "{xrm_reference}"
     },
     "queue": "tomo_align_imod",
     "service": "ImodTomoAlign"

--- a/recipes/ispyb/sxt-imod-beads-wbp.json
+++ b/recipes/ispyb/sxt-imod-beads-wbp.json
@@ -22,6 +22,7 @@
       "success": 7
     },
     "parameters": {
+      "copy_output": true,
       "manual_tilt_offset": "{manual_tilt_offset}",
       "out_bin": 1,
       "patch": 0,

--- a/recipes/ispyb/sxt-imod-patch-wbp.json
+++ b/recipes/ispyb/sxt-imod-patch-wbp.json
@@ -22,6 +22,7 @@
       "success": 7
     },
     "parameters": {
+      "copy_output": true,
       "manual_tilt_offset": "{manual_tilt_offset}",
       "out_bin": 1,
       "patch": 1,

--- a/recipes/ispyb/sxt-imod-patch-wbp.json
+++ b/recipes/ispyb/sxt-imod-patch-wbp.json
@@ -31,7 +31,8 @@
       "stack_file": "{stack_file}",
       "tilt_axis": 0,
       "txrm_file": "{txrm_file}",
-      "wbp": 1
+      "wbp": 1,
+      "xrm_reference": "{xrm_reference}"
     },
     "queue": "tomo_align_imod",
     "service": "ImodTomoAlign"

--- a/src/cryoemservices/services/denoise.py
+++ b/src/cryoemservices/services/denoise.py
@@ -6,6 +6,7 @@ import subprocess
 from pathlib import Path
 from typing import List, Optional
 
+import numpy as np
 from pydantic import BaseModel, Field, ValidationError, field_validator
 from workflows.recipe import wrap_subscribe
 
@@ -330,10 +331,16 @@ class Denoise(CommonService):
 
         # Optionally copy output file
         if denoise_params.copy_output:
+            # Take file name for Relion-type projects, or folder name for SXT-style
+            tomo_name = (
+                denoised_full_path.name
+                if np.array(
+                    [re.match("job[0-9]+", p) for p in denoised_full_path.parts]
+                ).any()
+                else f"{denoised_full_path.parent.parent}_denoised.mrc"
+            )
             shutil.copy(
-                denoised_full_path,
-                denoised_full_path.parent.parent.parent
-                / f"{denoised_full_path.parent.parent}_denoised.mrc",
+                denoised_full_path, denoised_full_path.parent.parent.parent / tomo_name
             )
 
         self.log.info(f"Done denoising for {denoise_params.volume}")

--- a/src/cryoemservices/services/denoise.py
+++ b/src/cryoemservices/services/denoise.py
@@ -6,7 +6,6 @@ import subprocess
 from pathlib import Path
 from typing import List, Optional
 
-import numpy as np
 from pydantic import BaseModel, Field, ValidationError, field_validator
 from workflows.recipe import wrap_subscribe
 
@@ -334,9 +333,7 @@ class Denoise(CommonService):
             # Take file name for Relion-type projects, or folder name for SXT-style
             tomo_name = (
                 denoised_full_path.name
-                if np.array(
-                    [re.match("job[0-9]+", p) for p in denoised_full_path.parts]
-                ).any()
+                if re.match("/job[0-9]+/", str(denoised_full_path))
                 else f"{denoised_full_path.parent.parent}_denoised.mrc"
             )
             shutil.copy(

--- a/src/cryoemservices/services/denoise.py
+++ b/src/cryoemservices/services/denoise.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import shutil
 import subprocess
 from pathlib import Path
 from typing import List, Optional
@@ -48,6 +49,7 @@ class DenoiseParameters(BaseModel):
     patch_padding: Optional[int] = None  # 48
     device: Optional[int] = None  # -2
     cleanup_output: bool = True
+    copy_output: bool = False
     visits_for_slurm: Optional[list] = ["bi", "cm", "nr", "nt"]
     relion_options: RelionServiceOptions
 
@@ -305,6 +307,7 @@ class Denoise(CommonService):
             "tomogram": str(denoised_full_path),
             "output_dir": str(segmentation_dir),
             "pixel_size": str(denoise_params.relion_options.pixel_size_downscaled),
+            "copy_output": denoise_params.copy_output,
             "relion_options": dict(denoise_params.relion_options),
         }
         cryolo_parameters = {
@@ -324,6 +327,14 @@ class Denoise(CommonService):
             "processing_type": "Denoised",
         }
         rw.send_to("ispyb_connector", ispyb_parameters)
+
+        # Optionally copy output file
+        if denoise_params.copy_output:
+            shutil.copy(
+                denoised_full_path,
+                denoised_full_path.parent.parent.parent
+                / f"{denoised_full_path.parent.parent}_denoised.mrc",
+            )
 
         self.log.info(f"Done denoising for {denoise_params.volume}")
         rw.transport.ack(header)

--- a/src/cryoemservices/services/denoise.py
+++ b/src/cryoemservices/services/denoise.py
@@ -333,7 +333,7 @@ class Denoise(CommonService):
             # Take file name for Relion-type projects, or folder name for SXT-style
             tomo_name = (
                 denoised_full_path.name
-                if re.match("/job[0-9]+/", str(denoised_full_path))
+                if re.match(".*/job[0-9]+/.*", str(denoised_full_path))
                 else f"{denoised_full_path.parent.parent}_denoised.mrc"
             )
             shutil.copy(

--- a/src/cryoemservices/services/membrain_seg.py
+++ b/src/cryoemservices/services/membrain_seg.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 from pathlib import Path
 from typing import Optional
 
+import numpy as np
 from pydantic import BaseModel, Field, ValidationError
 from workflows.recipe import wrap_subscribe
 
@@ -270,11 +272,15 @@ class MembrainSeg(CommonService):
 
         # Optionally copy output file
         if membrain_seg_params.copy_output:
-            shutil.copy(
-                segmented_path,
-                segmented_path.parent.parent.parent
-                / f"{segmented_path.parent.parent}_segmented.mrc",
+            # Take file name for Relion-type projects, or folder name for SXT-style
+            tomo_name = (
+                segmented_path.name
+                if np.array(
+                    [re.match("job[0-9]+", p) for p in segmented_path.parts]
+                ).any()
+                else f"{segmented_path.parent.parent}_segmented.mrc"
             )
+            shutil.copy(segmented_path, segmented_path.parent.parent.parent / tomo_name)
 
         self.log.info(f"Done segmentation for {membrain_seg_params.tomogram}")
         rw.transport.ack(header)

--- a/src/cryoemservices/services/membrain_seg.py
+++ b/src/cryoemservices/services/membrain_seg.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shutil
 import subprocess
 from pathlib import Path
 from typing import Optional
@@ -36,6 +37,7 @@ class MembrainSegParameters(BaseModel):
     segmentation_threshold: float = 0.0
     cleanup_output: bool = True
     submit_to_slurm: bool = False
+    copy_output: bool = False
     relion_options: RelionServiceOptions
 
 
@@ -265,6 +267,14 @@ class MembrainSeg(CommonService):
                 "relion_options": dict(membrain_seg_params.relion_options),
             },
         )
+
+        # Optionally copy output file
+        if membrain_seg_params.copy_output:
+            shutil.copy(
+                segmented_path,
+                segmented_path.parent.parent.parent
+                / f"{segmented_path.parent.parent}_segmented.mrc",
+            )
 
         self.log.info(f"Done segmentation for {membrain_seg_params.tomogram}")
         rw.transport.ack(header)

--- a/src/cryoemservices/services/membrain_seg.py
+++ b/src/cryoemservices/services/membrain_seg.py
@@ -6,7 +6,6 @@ import subprocess
 from pathlib import Path
 from typing import Optional
 
-import numpy as np
 from pydantic import BaseModel, Field, ValidationError
 from workflows.recipe import wrap_subscribe
 
@@ -275,9 +274,7 @@ class MembrainSeg(CommonService):
             # Take file name for Relion-type projects, or folder name for SXT-style
             tomo_name = (
                 segmented_path.name
-                if np.array(
-                    [re.match("job[0-9]+", p) for p in segmented_path.parts]
-                ).any()
+                if re.match("/job[0-9]+/", str(segmented_path))
                 else f"{segmented_path.parent.parent}_segmented.mrc"
             )
             shutil.copy(segmented_path, segmented_path.parent.parent.parent / tomo_name)

--- a/src/cryoemservices/services/membrain_seg.py
+++ b/src/cryoemservices/services/membrain_seg.py
@@ -274,7 +274,7 @@ class MembrainSeg(CommonService):
             # Take file name for Relion-type projects, or folder name for SXT-style
             tomo_name = (
                 segmented_path.name
-                if re.match("/job[0-9]+/", str(segmented_path))
+                if re.match(".*/job[0-9]+/.*", str(segmented_path))
                 else f"{segmented_path.parent.parent}_segmented.mrc"
             )
             shutil.copy(segmented_path, segmented_path.parent.parent.parent / tomo_name)

--- a/src/cryoemservices/services/tomo_align_aretomo.py
+++ b/src/cryoemservices/services/tomo_align_aretomo.py
@@ -860,19 +860,12 @@ class AreTomoAlign(CommonService):
             # Take file name for Relion-type projects, or folder name for SXT-style
             stack_name = (
                 Path(tomo_params.stack_file).name
-                if np.array(
-                    [
-                        re.match("job[0-9]+", p)
-                        for p in Path(tomo_params.stack_file).parts
-                    ]
-                ).any()
+                if re.match("job[0-9]+", tomo_params.stack_file)
                 else f"{Path(tomo_params.stack_file).parent.parent}_stack.mrc"
             )
             tomo_name = (
                 aretomo_output_path.name
-                if np.array(
-                    [re.match("job[0-9]+", p) for p in aretomo_output_path.parts]
-                ).any()
+                if re.match("job[0-9]+", str(aretomo_output_path))
                 else f"{aretomo_output_path.parent.parent}_volume.mrc"
             )
             shutil.copy(Path(tomo_params.stack_file), project_dir.parent / stack_name)

--- a/src/cryoemservices/services/tomo_align_aretomo.py
+++ b/src/cryoemservices/services/tomo_align_aretomo.py
@@ -857,15 +857,26 @@ class AreTomoAlign(CommonService):
 
         # Optionally copy output file
         if tomo_params.copy_output:
-            shutil.copy(
-                Path(tomo_params.stack_file),
-                project_dir.parent
-                / f"{Path(tomo_params.stack_file).parent.parent}_stack.mrc",
+            # Take file name for Relion-type projects, or folder name for SXT-style
+            stack_name = (
+                Path(tomo_params.stack_file).name
+                if np.array(
+                    [
+                        re.match("job[0-9]+", p)
+                        for p in Path(tomo_params.stack_file).parts
+                    ]
+                ).any()
+                else f"{Path(tomo_params.stack_file).parent.parent}_stack.mrc"
             )
-            shutil.copy(
-                aretomo_output_path,
-                project_dir.parent / f"{aretomo_output_path.parent.parent}_volume.mrc",
+            tomo_name = (
+                aretomo_output_path.name
+                if np.array(
+                    [re.match("job[0-9]+", p) for p in aretomo_output_path.parts]
+                ).any()
+                else f"{aretomo_output_path.parent.parent}_volume.mrc"
             )
+            shutil.copy(Path(tomo_params.stack_file), project_dir.parent / stack_name)
+            shutil.copy(aretomo_output_path, project_dir.parent / tomo_name)
 
         # Update success processing status
         rw.send_to("success", {})

--- a/src/cryoemservices/services/tomo_align_aretomo.py
+++ b/src/cryoemservices/services/tomo_align_aretomo.py
@@ -860,12 +860,12 @@ class AreTomoAlign(CommonService):
             # Take file name for Relion-type projects, or folder name for SXT-style
             stack_name = (
                 Path(tomo_params.stack_file).name
-                if re.match("job[0-9]+", tomo_params.stack_file)
+                if re.match(".*/job[0-9]+/.*", tomo_params.stack_file)
                 else f"{Path(tomo_params.stack_file).parent.parent}_stack.mrc"
             )
             tomo_name = (
                 aretomo_output_path.name
-                if re.match("job[0-9]+", str(aretomo_output_path))
+                if re.match(".*/job[0-9]+/.*", str(aretomo_output_path))
                 else f"{aretomo_output_path.parent.parent}_volume.mrc"
             )
             shutil.copy(Path(tomo_params.stack_file), project_dir.parent / stack_name)

--- a/src/cryoemservices/services/tomo_align_aretomo.py
+++ b/src/cryoemservices/services/tomo_align_aretomo.py
@@ -4,6 +4,7 @@ import ast
 import json
 import os.path
 import re
+import shutil
 import subprocess
 import time
 from pathlib import Path
@@ -135,6 +136,7 @@ class AreTomoParameters(BaseModel):
     interpolation_correction: int | None = None
     dark_tol: float | None = None
     manual_tilt_offset: float | None = None
+    copy_output: bool = False
     visits_for_slurm: list | None = ["bi", "cm", "nr", "nt"]
     relion_options: RelionServiceOptions
 
@@ -835,6 +837,7 @@ class AreTomoAlign(CommonService):
                 "volume": str(aretomo_output_path),
                 "output_dir": str(denoise_dir),
                 "relion_options": dict(tomo_params.relion_options),
+                "copy_output": tomo_params.copy_output,
             },
         )
 
@@ -851,6 +854,18 @@ class AreTomoAlign(CommonService):
             f"{Path(tomo_params.stack_file).stem}*~"
         ):
             tmp_file.unlink()
+
+        # Optionally copy output file
+        if tomo_params.copy_output:
+            shutil.copy(
+                Path(tomo_params.stack_file),
+                project_dir.parent
+                / f"{Path(tomo_params.stack_file).parent.parent}_stack.mrc",
+            )
+            shutil.copy(
+                aretomo_output_path,
+                project_dir.parent / f"{aretomo_output_path.parent.parent}_volume.mrc",
+            )
 
         # Update success processing status
         rw.send_to("success", {})

--- a/src/cryoemservices/services/tomo_align_imod.py
+++ b/src/cryoemservices/services/tomo_align_imod.py
@@ -1,3 +1,4 @@
+import shutil
 import subprocess
 from pathlib import Path
 from typing import Optional
@@ -32,6 +33,7 @@ class ImodTomoParameters(BaseModel):
     local_alignment: int = 0
     flip_vol: int = 1
     manual_tilt_offset: Optional[float] = None
+    copy_output: bool = False
     cpus: int = 4
 
 
@@ -150,6 +152,7 @@ class ImodTomoAlign(CommonService):
                 str(adoc_file),
                 "-cpus",
                 str(tomo_params.cpus),
+                "-bypass",
             ],
             capture_output=True,
         )
@@ -272,6 +275,7 @@ class ImodTomoAlign(CommonService):
             {
                 "volume": str(imod_output_path),
                 "output_dir": str(imod_output_path.parent.parent / "Denoise"),
+                "copy_output": tomo_params.copy_output,
                 "relion_options": {},
             },
         )
@@ -289,6 +293,14 @@ class ImodTomoAlign(CommonService):
             f"{Path(tomo_params.stack_file).stem}*~"
         ):
             tmp_file.unlink()
+
+        # Optionally copy output file
+        if tomo_params.copy_output:
+            shutil.copy(
+                imod_output_path,
+                imod_output_path.parent.parent.parent
+                / f"{imod_output_path.parent.parent}_volume.mrc",
+            )
 
         # Update success processing status
         rw.send_to("success", {})

--- a/tests/services/test_denoise.py
+++ b/tests/services/test_denoise.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import subprocess
 from unittest import mock
 
 import pytest
@@ -188,6 +189,7 @@ def test_denoise_local_topaz_service(
             "tomogram": f"{tmp_path}/Denoise/job007/denoised/test_stack_aretomo.denoised.mrc",
             "output_dir": f"{tmp_path}/Segmentation/job008/tomograms",
             "pixel_size": "1.0",
+            "copy_output": False,
             "relion_options": output_relion_options,
         },
     )
@@ -216,9 +218,18 @@ def test_denoise_local_subprocess_service(
     This should call the mock subprocess then send messages on to
     the membrain-seg and images services.
     """
-    mock_subprocess().returncode = 0
-    mock_subprocess().stdout = "stdout".encode("ascii")
-    mock_subprocess().stderr = "stderr".encode("ascii")
+
+    def touch_denoise_output(*args, **kwargs):
+        (tmp_path / "Denoise/job007/denoised").mkdir(parents=True, exist_ok=True)
+        (tmp_path / "Denoise/job007/denoised/test_stack_aretomo.denoised.mrc").touch()
+        return subprocess.CompletedProcess(
+            "",
+            returncode=0,
+            stdout="stdout".encode("ascii"),
+            stderr="stderr".encode("ascii"),
+        )
+
+    mock_subprocess.side_effect = touch_denoise_output
 
     header = {
         "message-id": mock.sentinel,
@@ -250,6 +261,7 @@ def test_denoise_local_subprocess_service(
         "patch_size": 96,
         "patch_padding": 48,
         "device": "-2",
+        "copy_output": True,
         "relion_options": {"pixel_size_downscaled": 1},
     }
     output_relion_options = dict(RelionServiceOptions())
@@ -310,7 +322,10 @@ def test_denoise_local_subprocess_service(
         "-d",
         "-2",
     ]
-    mock_subprocess.assert_any_call(denoise_command, capture_output=True)
+    mock_subprocess.assert_called_once_with(denoise_command, capture_output=True)
+
+    # Check output copy
+    assert (tmp_path / "Denoise/test_stack_aretomo.denoised.mrc").is_file()
 
     # Check the images service request
     assert offline_transport.send.call_count == 6
@@ -356,6 +371,7 @@ def test_denoise_local_subprocess_service(
             "tomogram": f"{tmp_path}/Denoise/job007/denoised/test_stack_aretomo.denoised.mrc",
             "output_dir": f"{tmp_path}/Segmentation/job008/tomograms",
             "pixel_size": "1.0",
+            "copy_output": True,
             "relion_options": output_relion_options,
         },
     )
@@ -568,6 +584,7 @@ def test_denoise_slurm_service(
             "tomogram": f"{tmp_path}/cm12345-6/Denoise/job007/denoised/test_stack_aretomo.denoised.mrc",
             "output_dir": f"{tmp_path}/cm12345-6/Segmentation/job008/tomograms",
             "pixel_size": "1.0",
+            "copy_output": False,
             "relion_options": output_relion_options,
         },
     )
@@ -654,6 +671,7 @@ def test_denoise_local_topaz_service_rerun(
             "tomogram": f"{tmp_path}/Denoise/job007/denoised/test_stack_aretomo.denoised.mrc",
             "output_dir": f"{tmp_path}/Segmentation/job008/tomograms",
             "pixel_size": "1.0",
+            "copy_output": False,
             "relion_options": output_relion_options,
         },
     )

--- a/tests/services/test_membrain_seg.py
+++ b/tests/services/test_membrain_seg.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 from unittest import mock
 
 import pytest
@@ -159,9 +160,20 @@ def test_membrain_seg_service_local_subprocess(
     Send a test message to membrain-seg for the local version
     This should call the mock subprocess then send messages to the images service.
     """
-    mock_subprocess().returncode = 0
-    mock_subprocess().stdout = "stdout".encode("ascii")
-    mock_subprocess().stderr = "stderr".encode("ascii")
+
+    def touch_membrain_output(*args, **kwargs):
+        (
+            tmp_path
+            / "Segmentation/job008/tomograms/test_stack_aretomo.denoised_segmented.mrc"
+        ).touch()
+        return subprocess.CompletedProcess(
+            "",
+            returncode=0,
+            stdout="stdout".encode("ascii"),
+            stderr="stderr".encode("ascii"),
+        )
+
+    mock_subprocess.side_effect = touch_membrain_output
 
     header = {
         "message-id": mock.sentinel,
@@ -179,6 +191,7 @@ def test_membrain_seg_service_local_subprocess(
         "window_size": 100,
         "connected_component_threshold": 2,
         "segmentation_threshold": 4,
+        "copy_output": True,
         "relion_options": {},
     }
     output_relion_options = dict(RelionServiceOptions())
@@ -213,8 +226,12 @@ def test_membrain_seg_service_local_subprocess(
         "--store-probabilities",
         "--store-connected-components",
     ]
-    assert mock_subprocess.call_count == 4
-    mock_subprocess.assert_any_call(membrain_command, capture_output=True)
+    mock_subprocess.assert_called_once_with(membrain_command, capture_output=True)
+
+    # Check output copy
+    assert (
+        tmp_path / "Segmentation/test_stack_aretomo.denoised_segmented.mrc"
+    ).is_file()
 
     # Check the images service request
     assert offline_transport.send.call_count == 5

--- a/tests/services/test_tomo_align_aretomo.py
+++ b/tests/services/test_tomo_align_aretomo.py
@@ -367,6 +367,7 @@ def test_tomo_align_service_file_list_aretomo3(
             "volume": f"{tmp_path}/Tomograms/job006/tomograms/test_stack_Vol.mrc",
             "output_dir": f"{tmp_path}/Denoise/job007/tomograms",
             "relion_options": output_relion_options,
+            "copy_output": False,
         },
     )
     offline_transport.send.assert_any_call("success", {})
@@ -688,6 +689,7 @@ def test_tomo_align_service_file_list_aretomo2(
             "volume": f"{tmp_path}/Tomograms/job006/tomograms/test_stack_Vol.mrc",
             "output_dir": f"{tmp_path}/Denoise/job007/tomograms",
             "relion_options": output_relion_options,
+            "copy_output": False,
         },
     )
     offline_transport.send.assert_any_call("success", {})
@@ -1339,6 +1341,7 @@ def test_tomo_align_service_file_list_rerun(
             "volume": f"{tmp_path}/Tomograms/job006/tomograms/test_stack_Vol.mrc",
             "output_dir": f"{tmp_path}/Denoise/job007/tomograms",
             "relion_options": output_relion_options,
+            "copy_output": False,
         },
     )
     offline_transport.send.assert_any_call("success", {})
@@ -2110,7 +2113,7 @@ def test_tomo_align_service_txrm(
         "subscription": mock.sentinel,
     }
     tomo_align_test_message = {
-        "stack_file": f"{tmp_path}/Tomograms/stack.mrc",
+        "stack_file": f"{tmp_path}/recipe/Tomograms/stack.mrc",
         "txrm_file": f"{tmp_path}/tilt_stack.txrm",
         "pixel_size": 100,
         "relion_options": {},
@@ -2119,6 +2122,7 @@ def test_tomo_align_service_txrm(
         "out_bin": 1,
         "tilt_axis": 0,
         "wbp": 1,
+        "copy_output": True,
     }
     output_relion_options = dict(RelionServiceOptions())
     output_relion_options["pixel_size"] = 100
@@ -2138,14 +2142,14 @@ def test_tomo_align_service_txrm(
 
     def write_aretomo_outputs(command, capture_output: bool = False):
         if command[0] != "AreTomo3":
-            (tmp_path / "Tomograms/stack.mrc").touch(exist_ok=True)
+            (tmp_path / "recipe/Tomograms/stack.mrc").touch(exist_ok=True)
             return CompletedProcess("", returncode=0)
         # Set up outputs: stack_Imod file like AreTomo3, no exclusions but with space
-        (tmp_path / "Tomograms/stack_Imod").mkdir(parents=True)
-        (tmp_path / "Tomograms/stack_Vol.mrc").touch()
-        with open(tmp_path / "Tomograms/stack_Imod/tilt.com", "w") as dark_file:
+        (tmp_path / "recipe/Tomograms/stack_Imod").mkdir(parents=True)
+        (tmp_path / "recipe/Tomograms/stack_Vol.mrc").touch()
+        with open(tmp_path / "recipe/Tomograms/stack_Imod/tilt.com", "w") as dark_file:
             dark_file.write("EXCLUDELIST ")
-        with open(tmp_path / "Tomograms/stack.aln", "w") as aln_file:
+        with open(tmp_path / "recipe/Tomograms/stack.aln", "w") as aln_file:
             aln_file.write("# Thickness = 130\ndummy 0.0 1000 1.2 2.3 5 6 7 8 4.5")
         return CompletedProcess(
             "",
@@ -2171,7 +2175,7 @@ def test_tomo_align_service_txrm(
         "-InPrefix",
         tomo_align_test_message["stack_file"],
         "-OutDir",
-        f"{tmp_path}/Tomograms",
+        f"{tmp_path}/recipe/Tomograms",
         "-TiltCor",
         "1",
         "0.0",
@@ -2208,7 +2212,7 @@ def test_tomo_align_service_txrm(
         mock_ole_file().__enter__().openstream.assert_any_call(field_name)
     mock_convert_and_save.assert_called_once_with(
         tomo_align_test_message["txrm_file"],
-        f"{tmp_path}/Tomograms/stack.tiff",
+        f"{tmp_path}/recipe/Tomograms/stack.tiff",
         custom_reference=None,
     )
 
@@ -2217,8 +2221,8 @@ def test_tomo_align_service_txrm(
     mock_subprocess.assert_any_call(
         [
             "tif2mrc",
-            f"{tmp_path}/Tomograms/stack.tiff",
-            f"{tmp_path}/Tomograms/stack.mrc",
+            f"{tmp_path}/recipe/Tomograms/stack.tiff",
+            f"{tmp_path}/recipe/Tomograms/stack.mrc",
         ],
         capture_output=True,
     )
@@ -2228,17 +2232,23 @@ def test_tomo_align_service_txrm(
     )
 
     # Check resizing and rotating
-    mock_resize.assert_called_once_with(tmp_path / "Tomograms/stack_Vol.mrc", 600)
-    mock_rotate.assert_called_once_with(tmp_path / "Tomograms/stack_Vol.mrc", 0)
+    mock_resize.assert_called_once_with(
+        tmp_path / "recipe/Tomograms/stack_Vol.mrc", 600
+    )
+    mock_rotate.assert_called_once_with(tmp_path / "recipe/Tomograms/stack_Vol.mrc", 0)
+
+    # Check output copy
+    assert (tmp_path / "recipe_stack.mrc").is_file()
+    assert (tmp_path / "recipe_volume.mrc").is_file()
 
     # Check the angle file
-    assert (tmp_path / "Tomograms/stack_TLT.txt").is_file()
-    with open(tmp_path / "Tomograms/stack_TLT.txt", "r") as angfile:
+    assert (tmp_path / "recipe/Tomograms/stack_TLT.txt").is_file()
+    with open(tmp_path / "recipe/Tomograms/stack_TLT.txt", "r") as angfile:
         angles_data = angfile.read()
     assert angles_data == "0.01  0\n0.30  1\n0.50  2\n"
 
     # Check the shift plot
-    with open(tmp_path / "Tomograms/stack_xy_shift_plot.json") as shift_plot:
+    with open(tmp_path / "recipe/Tomograms/stack_xy_shift_plot.json") as shift_plot:
         shift_data = json.load(shift_plot)
     assert shift_data["data"][0]["x"] == [1.2]
     assert shift_data["data"][0]["y"] == [2.3]
@@ -2260,7 +2270,7 @@ def test_tomo_align_service_txrm(
                     "pixel_spacing": "100.0",
                     "tilt_angle_offset": "1.1",
                     "z_shift": "2.1",
-                    "file_directory": f"{tmp_path}/Tomograms",
+                    "file_directory": f"{tmp_path}/recipe/Tomograms",
                     "central_slice_image": "stack_Vol_thumbnail.jpeg",
                     "tomogram_movie": "stack_Vol_movie.png",
                     "xy_shift_plot": "stack_xy_shift_plot.json",
@@ -2270,12 +2280,12 @@ def test_tomo_align_service_txrm(
                 },
                 {
                     "ispyb_command": "insert_processed_tomogram",
-                    "file_path": f"{tmp_path}/Tomograms/stack.mrc",
+                    "file_path": f"{tmp_path}/recipe/Tomograms/stack.mrc",
                     "processing_type": "Stack",
                 },
                 {
                     "ispyb_command": "insert_processed_tomogram",
-                    "file_path": f"{tmp_path}/Tomograms/stack_alignment.jpeg",
+                    "file_path": f"{tmp_path}/recipe/Tomograms/stack_alignment.jpeg",
                     "processing_type": "Alignment",
                 },
             ],
@@ -2286,7 +2296,7 @@ def test_tomo_align_service_txrm(
         {
             "image_command": "tilt_series_alignment",
             "file": tomo_align_test_message["stack_file"],
-            "aln_file": f"{tmp_path}/Tomograms/stack.aln",
+            "aln_file": f"{tmp_path}/recipe/Tomograms/stack.aln",
             "pixel_size": tomo_align_test_message["pixel_size"],
         },
     )
@@ -2308,21 +2318,21 @@ def test_tomo_align_service_txrm(
         "images",
         {
             "image_command": "mrc_central_slice",
-            "file": f"{tmp_path}/Tomograms/stack_Vol.mrc",
+            "file": f"{tmp_path}/recipe/Tomograms/stack_Vol.mrc",
         },
     )
     offline_transport.send.assert_any_call(
         "images",
         {
             "image_command": "mrc_to_apng",
-            "file": f"{tmp_path}/Tomograms/stack_Vol.mrc",
+            "file": f"{tmp_path}/recipe/Tomograms/stack_Vol.mrc",
         },
     )
     offline_transport.send.assert_any_call(
         "images",
         {
             "image_command": "mrc_projection",
-            "file": f"{tmp_path}/Tomograms/stack_Vol.mrc",
+            "file": f"{tmp_path}/recipe/Tomograms/stack_Vol.mrc",
             "projection": "XY",
             "pixel_spacing": 100.0,
         },
@@ -2331,7 +2341,7 @@ def test_tomo_align_service_txrm(
         "images",
         {
             "image_command": "mrc_projection",
-            "file": f"{tmp_path}/Tomograms/stack_Vol.mrc",
+            "file": f"{tmp_path}/recipe/Tomograms/stack_Vol.mrc",
             "projection": "YZ",
             "pixel_spacing": 100.0,
             "thickness_ang": 13000.0,
@@ -2343,9 +2353,10 @@ def test_tomo_align_service_txrm(
     offline_transport.send.assert_any_call(
         "denoise",
         {
-            "volume": f"{tmp_path}/Tomograms/stack_Vol.mrc",
-            "output_dir": f"{tmp_path}/Denoise",
+            "volume": f"{tmp_path}/recipe/Tomograms/stack_Vol.mrc",
+            "output_dir": f"{tmp_path}/recipe/Denoise",
             "relion_options": output_relion_options,
+            "copy_output": True,
         },
     )
     offline_transport.send.assert_any_call("success", {})

--- a/tests/services/test_tomo_align_imod.py
+++ b/tests/services/test_tomo_align_imod.py
@@ -63,6 +63,7 @@ def test_tomo_align_imod(
         "vol_z": 500,
         "out_bin": 1,
         "cpus": 2,
+        "copy_output": True,
     }
 
     # Touch the expected input/output and stack files
@@ -109,9 +110,13 @@ def test_tomo_align_imod(
             f"{tmp_path}/recipe/Tomograms/test_stack.adoc",
             "-cpus",
             "2",
+            "-bypass",
         ],
         capture_output=True,
     )
+
+    # Check output copy
+    assert (tmp_path / "recipe_volume.mrc").is_file()
 
     """# Check the shift plot
     with open(
@@ -187,6 +192,7 @@ def test_tomo_align_imod(
             "volume": f"{tmp_path}/recipe/Tomograms/test_stack_rec.mrc",
             "output_dir": f"{tmp_path}/recipe/Denoise",
             "relion_options": {},
+            "copy_output": True,
         },
     )
     offline_transport.send.assert_any_call(


### PR DESCRIPTION
Updates imod dockerfile to include some missing libraries, then runs using `-bypass` to avoid the java dependency.

Also sets up a mechanism to copy the output files to a higher level. This was requested by b24 as the output folders can be messy and they want an easy way to access the tomograms.