### PR TITLE
Align FIB and tomography images

### DIFF
--- a/src/cryoemservices/services/correlative_align_images.py
+++ b/src/cryoemservices/services/correlative_align_images.py
@@ -172,13 +172,9 @@ class AlignImagesService(CommonService):
         # Align images differently depending on which data types are being compared
         try:
             match sorted((experiment_type_ref.name, experiment_type_mov.name)):
-                case (
-                    ["FIB", "Tomography"]
-                    | ["FIB", "Lamella Tomography"]
-                    | ["FIB", "Single Particle"]
-                ):
-                    self.log.info("Aligning FIB atlas to TEM one")
-                    result = self._handle_fib_tem_case(
+                case ["FIB", "Tomography"] | ["FIB", "Lamella Tomography"]:
+                    self.log.info("Aligning FIB atlas to tomography atlas")
+                    result = self._handle_fib_tomo_case(
                         params,
                         atlas_ref,
                         visit_ref,
@@ -186,7 +182,9 @@ class AlignImagesService(CommonService):
                         visit_mov,
                     )
                     if result["transform"] is not None:
-                        self.log.info("Successfully aligned FIB atlas to TEM atlas")
+                        self.log.info(
+                            "Successfully aligned FIB atlas to tomography atlas"
+                        )
                 case _:
                     self.log.info(
                         "No image alignment algorithm implemented for this case yet"
@@ -201,7 +199,7 @@ class AlignImagesService(CommonService):
         rw.transport.ack(header)
         return
 
-    def _handle_fib_tem_case(
+    def _handle_fib_tomo_case(
         self,
         params: AlignImagesParameters,
         atlas_ref: ISPyBDB.Atlas,

--- a/src/cryoemservices/services/correlative_align_images.py
+++ b/src/cryoemservices/services/correlative_align_images.py
@@ -24,15 +24,15 @@ class AlignImagesParameters(BaseModel):
     id_mov: int | None = None
     # Optional keys for manual testing
     # Reference image
-    image_ref: Path | None = None
-    pixel_size_ref: float | None = None
     visit_ref: str | None = None
     experiment_type_ref: str | None = None
+    image_ref: Path | None = None
+    pixel_size_ref: float | None = None
     # Moving image
-    image_mov: Path | None = None
-    pixel_size_mov: float | None = None
     visit_mov: str | None = None
     experiment_type_mov: str | None = None
+    image_mov: Path | None = None
+    pixel_size_mov: float | None = None
     save_dir: Path | None = None
 
 

--- a/src/cryoemservices/services/correlative_align_images.py
+++ b/src/cryoemservices/services/correlative_align_images.py
@@ -20,13 +20,19 @@ from cryoemservices.util.models import MockRW
 
 class AlignImagesParameters(BaseModel):
     # ISPyB Atlas atlasId values
-    id_ref: int
-    id_mov: int
+    id_ref: int | None = None
+    id_mov: int | None = None
     # Optional keys for manual testing
+    # Reference image
     image_ref: Path | None = None
     pixel_size_ref: float | None = None
+    visit_ref: str | None = None
+    experiment_type_ref: str | None = None
+    # Moving image
     image_mov: Path | None = None
     pixel_size_mov: float | None = None
+    visit_mov: str | None = None
+    experiment_type_mov: str | None = None
     save_dir: Path | None = None
 
 
@@ -145,41 +151,95 @@ class AlignImagesService(CommonService):
         ###############################################################################
 
         # Load the ISPyB Atlas entries using the provided IDs
-        try:
-            with self._database_session_maker() as session:
-                atlas_ref, proposal_ref, bl_session_ref, experiment_type_ref = (
-                    _get_atlas_proposal_session_experiment_type(
-                        session=session, atlas_id=params.id_ref
+        if params.id_ref and params.id_mov:
+            try:
+                with self._database_session_maker() as session:
+                    atlas_ref, proposal_ref, bl_session_ref, experiment_type_ref = (
+                        _get_atlas_proposal_session_experiment_type(
+                            session=session, atlas_id=params.id_ref
+                        )
                     )
-                )
-                atlas_mov, proposal_mov, bl_session_mov, experiment_type_mov = (
-                    _get_atlas_proposal_session_experiment_type(
-                        session=session, atlas_id=params.id_mov
+                    atlas_mov, proposal_mov, bl_session_mov, experiment_type_mov = (
+                        _get_atlas_proposal_session_experiment_type(
+                            session=session, atlas_id=params.id_mov
+                        )
                     )
-                )
-                # Construct visit names
-                visit_ref = f"{proposal_ref.proposalCode}{proposal_ref.proposalNumber}-{bl_session_ref.visit_number}"
-                visit_mov = f"{proposal_mov.proposalCode}{proposal_mov.proposalNumber}-{bl_session_mov.visit_number}"
-        except Exception:
-            self.log.error(
-                "Uncaught exception {e!r} while querying ISPyB, "
-                "quarantining message and shutting down instance.",
-                exc_info=True,
-            )
-            self._reject_message(header, transport=rw.transport)
-            return
+                    # Extract and construct needed values
+                    visit_ref = f"{proposal_ref.proposalCode}{proposal_ref.proposalNumber}-{bl_session_ref.visit_number}"
+                    experiment_name_ref = experiment_type_ref.name
+                    image_ref = Path(atlas_ref.atlasImage)
+                    pixel_size_ref = atlas_ref.pixelSize
 
-        # Align images differently depending on which data types are being compared
+                    visit_mov = f"{proposal_mov.proposalCode}{proposal_mov.proposalNumber}-{bl_session_mov.visit_number}"
+                    experiment_name_mov = experiment_type_mov.name
+                    image_mov = Path(atlas_mov.atlasImage)
+                    pixel_size_mov = atlas_mov.pixelSize
+
+            except Exception:
+                self.log.error(
+                    "Uncaught exception {e!r} while querying ISPyB, "
+                    "quarantining message and shutting down instance.",
+                    exc_info=True,
+                )
+                self._reject_message(header, transport=rw.transport)
+                return
+        # Use the directly provided values in the message
+        else:
+            if (
+                params.visit_ref is not None
+                and params.experiment_type_ref is not None
+                and params.image_ref is not None
+                and params.pixel_size_ref is not None
+                and params.visit_mov is not None
+                and params.experiment_type_mov is not None
+                and params.image_mov is not None
+                and params.pixel_size_mov is not None
+            ):
+                # Extract and construct needed values
+                visit_ref = params.visit_ref
+                experiment_name_ref = params.experiment_type_ref
+                image_ref = params.image_ref
+                pixel_size_ref = params.pixel_size_ref
+
+                visit_mov = params.visit_mov
+                experiment_name_mov = params.experiment_type_mov
+                image_mov = params.image_mov
+                pixel_size_mov = params.pixel_size_mov
+            else:
+                self.log.error(
+                    "Missing values needed to perform image correlation:\n"
+                    f"visit_ref: {params.visit_ref}\n"
+                    f"experiment_type_ref: {params.experiment_type_ref}\n"
+                    f"image_ref: {params.image_ref}\n"
+                    f"pixel_size_ref: {params.pixel_size_ref}\n"
+                    f"visit_mov: {params.visit_mov}\n"
+                    f"experiment_type_mov: {params.experiment_type_mov}\n"
+                    f"image_mov: {params.image_mov}\n"
+                    f"pixel_size_mov: {params.pixel_size_mov}\n"
+                )
+                self._reject_message(header, transport=rw.transport)
+                return
+
         try:
-            match sorted((experiment_type_ref.name, experiment_type_mov.name)):
+            # Construct the save directory for the outputs
+            visit_dir = image_ref.parents[-(image_ref.parts.index(visit_ref) + 1)]
+            save_dir = (
+                visit_dir / "processed" / "correlation" / visit_mov / image_mov.stem
+            )
+            if not save_dir.exists():
+                save_dir.mkdir(parents=True)
+                self.log.info(f"Created save directory at {save_dir}")
+
+            # Align images differently depending on which data types are being compared
+            match sorted((experiment_name_ref, experiment_name_mov)):
                 case ["FIB", "Tomography"] | ["FIB", "Lamella Tomography"]:
                     self.log.info("Aligning FIB atlas to tomography atlas")
                     result = self._handle_fib_tomo_case(
-                        params,
-                        atlas_ref,
-                        visit_ref,
-                        atlas_mov,
-                        visit_mov,
+                        image_ref,
+                        pixel_size_ref,
+                        image_mov,
+                        pixel_size_mov,
+                        save_dir,
                     )
                     if result["transform"] is not None:
                         self.log.info(
@@ -201,65 +261,16 @@ class AlignImagesService(CommonService):
 
     def _handle_fib_tomo_case(
         self,
-        params: AlignImagesParameters,
-        atlas_ref: ISPyBDB.Atlas,
-        visit_ref: str,
-        atlas_mov: ISPyBDB.Atlas,
-        visit_mov: str,
+        image_ref: Path,
+        pixel_size_ref: float,
+        image_mov: Path,
+        pixel_size_mov: float,
+        save_dir: Path,
     ):
-        # Ensure image path and pixel size are present as params or in the atlas tables
-        if not (
-            (
-                (atlas_ref.atlasImage and atlas_ref.pixelSize)
-                or (params.image_ref and params.pixel_size_ref)
-            )
-            and (
-                (atlas_mov.atlasImage and atlas_mov.pixelSize)
-                or (params.image_mov and params.pixel_size_mov)
-            )
-        ):
-            raise ValueError(
-                "Could not determine the file path or pixel size for "
-                "either the reference or moving image"
-            )
         # Load image files and pixel sizes
         # Load from params, then fall back to table (useful for testing)
-        file_ref = (
-            params.image_ref
-            if params.image_ref is not None
-            else Path(atlas_ref.atlasImage)
-        )
-        img_ref = cv2.imread(file_ref, flags=cv2.IMREAD_GRAYSCALE)
-        pixel_size_ref = (
-            params.pixel_size_ref
-            if params.pixel_size_ref is not None
-            else atlas_ref.pixelSize
-        )
-        file_mov = (
-            params.image_mov
-            if params.image_mov is not None
-            else Path(atlas_mov.atlasImage)
-        )
-        img_mov = cv2.imread(file_mov, flags=cv2.IMREAD_GRAYSCALE)
-        pixel_size_mov = (
-            params.pixel_size_mov
-            if params.pixel_size_mov is not None
-            else atlas_mov.pixelSize
-        )
-
-        # Get save directory from message
-        save_dir = params.save_dir
-        # Fall back to constructing a save directory using ISPyB-derived data
-        if save_dir is None:
-            visit_dir = file_ref.parents[-(file_ref.parts.index(visit_ref) + 1)]
-            save_dir = (
-                visit_dir / "processed" / "correlation" / visit_mov / file_mov.stem
-            )
-
-        # Store images under the visit name of the moving image
-        if not save_dir.exists():
-            save_dir.mkdir(parents=True)
-            self.log.info(f"Created save directory at {save_dir}")
+        img_ref = cv2.imread(image_ref, flags=cv2.IMREAD_GRAYSCALE)
+        img_mov = cv2.imread(image_mov, flags=cv2.IMREAD_GRAYSCALE)
 
         # Rescale images to same pixel size and crop to the same dimensions
         pixel_size_target = 4.0e-6

--- a/src/cryoemservices/services/correlative_align_images.py
+++ b/src/cryoemservices/services/correlative_align_images.py
@@ -226,9 +226,8 @@ class AlignImagesService(CommonService):
             save_dir = (
                 visit_dir / "processed" / "correlation" / visit_mov / image_mov.stem
             )
-            if not save_dir.exists():
-                save_dir.mkdir(parents=True)
-                self.log.info(f"Created save directory at {save_dir}")
+            save_dir.mkdir(parents=True, exist_ok=True)
+            self.log.info(f"Created save directory at {save_dir}")
 
             # Align images differently depending on which data types are being compared
             match sorted((experiment_name_ref, experiment_name_mov)):

--- a/src/cryoemservices/services/correlative_align_images.py
+++ b/src/cryoemservices/services/correlative_align_images.py
@@ -270,6 +270,10 @@ class AlignImagesService(CommonService):
                         self.log.info(
                             "Successfully aligned FIB atlas to tomography atlas"
                         )
+                    else:
+                        self.log.error("Could not align FIB atlas to tomography atlas")
+                        self._reject_message(header, transport=rw.transport)
+                        return
                 case _:
                     self.log.info(
                         "No image alignment algorithm implemented for this case yet"
@@ -279,6 +283,7 @@ class AlignImagesService(CommonService):
                 "Error while attempting to perform image alignment", exc_info=True
             )
             self._reject_message(header, transport=rw.transport)
+            return
 
         # Ack message after completion
         rw.transport.ack(header)

--- a/src/cryoemservices/services/correlative_align_images.py
+++ b/src/cryoemservices/services/correlative_align_images.py
@@ -15,11 +15,11 @@ from cryoemservices.util.models import MockRW
 
 class AlignImagesParameters(BaseModel):
     id_ref: int  # ISPyB Atlas atlasId
-    image_ref: Path
-    pixel_size_ref: float
+    image_ref: Path | None = None
+    pixel_size_ref: float | None = None
     id_mov: int  # ISPyB Atlas atlasId
-    image_mov: Path
-    pixel_size_mov: float
+    image_mov: Path | None = None
+    pixel_size_mov: float | None = None
 
 
 def _get_atlas_dcg_experiment_type(session: sqlalchemy.orm.Session, atlas_id: int):

--- a/src/cryoemservices/services/correlative_align_images.py
+++ b/src/cryoemservices/services/correlative_align_images.py
@@ -22,7 +22,9 @@ class AlignImagesParameters(BaseModel):
     # ISPyB Atlas atlasId values
     id_ref: int | None = None
     id_mov: int | None = None
+
     # Optional keys for manual testing
+    # --------------------------------
     # Reference image
     visit_ref: str | None = None
     experiment_type_ref: str | None = None
@@ -33,7 +35,30 @@ class AlignImagesParameters(BaseModel):
     experiment_type_mov: str | None = None
     image_mov: Path | None = None
     pixel_size_mov: float | None = None
+    # Save directory
     save_dir: Path | None = None
+    # Image alignment params
+    # These parameters have been empirically determined to work with a target pixel
+    # size of 4e-6
+    target_pixel_size: float = 4e-6
+    median_blur: int | None = None
+    gaussian_blur: float | None = 0.5
+    sobel_kernel: int | None = 3
+    use_hanning: bool = False
+    min_component_area: int | None = 20
+    threshold_percentile: float | None = 98.5
+    morph_close_kernel: int | None = 10
+    morph_open_kernel: int | None = 2
+    min_feature_area: int | None = 20
+    max_feature_area: int | None = 1000
+    min_solidity: float | None = 0.6
+    min_ellipse_fit: float | None = 0.4
+    max_aspect_ratio: float | None = 0.95
+    max_neighbor_distance: int | None = 200
+    min_score: float | None = 0.3
+    ransac_threshold: float = 5
+    save_images: bool = True
+    save_tables: bool = True
 
 
 def _get_atlas_proposal_session_experiment_type(
@@ -239,6 +264,7 @@ class AlignImagesService(CommonService):
                         image_mov,
                         pixel_size_mov,
                         save_dir,
+                        params,
                     )
                     if result["transform"] is not None:
                         self.log.info(
@@ -265,6 +291,7 @@ class AlignImagesService(CommonService):
         image_mov: Path,
         pixel_size_mov: float,
         save_dir: Path,
+        params: AlignImagesParameters,
     ):
         # Load image files and pixel sizes
         # Load from params, then fall back to table (useful for testing)
@@ -272,21 +299,20 @@ class AlignImagesService(CommonService):
         img_mov = cv2.imread(image_mov, flags=cv2.IMREAD_GRAYSCALE)
 
         # Rescale images to same pixel size and crop to the same dimensions
-        pixel_size_target = 4.0e-6
         resized_ref = cv2.resize(
             img_ref,
             dsize=None,
             dst=None,
-            fx=pixel_size_ref / pixel_size_target,
-            fy=pixel_size_ref / pixel_size_target,
+            fx=pixel_size_ref / params.target_pixel_size,
+            fy=pixel_size_ref / params.target_pixel_size,
             interpolation=cv2.INTER_AREA,
         )
         resized_mov = cv2.resize(
             img_mov,
             dsize=None,
             dst=None,
-            fx=pixel_size_mov / pixel_size_target,
-            fy=pixel_size_mov / pixel_size_target,
+            fx=pixel_size_mov / params.target_pixel_size,
+            fy=pixel_size_mov / params.target_pixel_size,
             interpolation=cv2.INTER_AREA,
         )
         height = min(resized_ref.shape[0], resized_mov.shape[0])
@@ -295,27 +321,26 @@ class AlignImagesService(CommonService):
         cropped_mov = crop_image(resized_mov, width=width, height=height)
 
         # Perform image alignment
-        # Parameters empirically determined to work for a pixel size of ~4.0e-6
         return align_images_using_neighbors(
             cropped_ref,
             cropped_mov,
-            median_blur=None,
-            gaussian_blur=0.5,
-            sobel_kernel=3,
-            use_hanning=False,
-            min_component_area=20,
-            threshold_percentile=98.5,
-            morph_close_kernel=10,
-            morph_open_kernel=2,
-            min_feature_area=20,
-            max_feature_area=1000,
-            min_solidity=0.6,
-            min_ellipse_fit=0.4,
-            max_aspect_ratio=0.95,
-            max_neighbor_distance=200,
-            min_score=0.3,
-            ransac_threshold=5,
-            save_images=True,
-            save_tables=True,
+            median_blur=params.median_blur,
+            gaussian_blur=params.gaussian_blur,
+            sobel_kernel=params.sobel_kernel,
+            use_hanning=params.use_hanning,
+            min_component_area=params.min_component_area,
+            threshold_percentile=params.threshold_percentile,
+            morph_close_kernel=params.morph_close_kernel,
+            morph_open_kernel=params.morph_open_kernel,
+            min_feature_area=params.min_feature_area,
+            max_feature_area=params.max_feature_area,
+            min_solidity=params.min_solidity,
+            min_ellipse_fit=params.min_ellipse_fit,
+            max_aspect_ratio=params.max_aspect_ratio,
+            max_neighbor_distance=params.max_neighbor_distance,
+            min_score=params.min_score,
+            ransac_threshold=params.ransac_threshold,
+            save_images=params.save_images,
+            save_tables=params.save_tables,
             save_dir=save_dir,
         )

--- a/src/cryoemservices/services/correlative_align_images.py
+++ b/src/cryoemservices/services/correlative_align_images.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Any, cast
 
+import cv2
 import ispyb.sqlalchemy
 import sqlalchemy.orm
 from ispyb.sqlalchemy import _auto_db_schema as ISPyBDB
@@ -10,26 +11,37 @@ from workflows.recipe import RecipeWrapper, wrap_subscribe
 
 from cryoemservices.services.common_service import CommonService
 from cryoemservices.util.config import config_from_file
+from cryoemservices.util.image_processing.align_images_using_neighbors import (
+    align_images_using_neighbors,
+)
+from cryoemservices.util.image_processing.shared import crop_image
 from cryoemservices.util.models import MockRW
 
 
 class AlignImagesParameters(BaseModel):
-    id_ref: int  # ISPyB Atlas atlasId
+    # ISPyB Atlas atlasId values
+    id_ref: int
+    id_mov: int
+    # Optional keys for manual testing
     image_ref: Path | None = None
     pixel_size_ref: float | None = None
-    id_mov: int  # ISPyB Atlas atlasId
     image_mov: Path | None = None
     pixel_size_mov: float | None = None
+    save_dir: Path | None = None
 
 
-def _get_atlas_dcg_experiment_type(session: sqlalchemy.orm.Session, atlas_id: int):
+def _get_atlas_proposal_session_experiment_type(
+    session: sqlalchemy.orm.Session, atlas_id: int
+):
     """
-    Runs an ISPyB query to get the Atlas and its corresponding DataCollectionGroup
+    Runs an ISPyB query to get the Atlas and its corresponding Proposal, BLSession,
     and ExperimentType rows.
     """
 
     statement = (
-        select(ISPyBDB.Atlas, ISPyBDB.DataCollectionGroup, ISPyBDB.ExperimentType)
+        select(
+            ISPyBDB.Atlas, ISPyBDB.Proposal, ISPyBDB.BLSession, ISPyBDB.ExperimentType
+        )
         .join(
             ISPyBDB.DataCollectionGroup,
             ISPyBDB.Atlas.dataCollectionGroupId
@@ -40,12 +52,21 @@ def _get_atlas_dcg_experiment_type(session: sqlalchemy.orm.Session, atlas_id: in
             ISPyBDB.DataCollectionGroup.experimentTypeId
             == ISPyBDB.ExperimentType.experimentTypeId,
         )
+        .join(
+            ISPyBDB.BLSession,
+            ISPyBDB.DataCollectionGroup.sessionId == ISPyBDB.BLSession.sessionId,
+        )
+        .join(
+            ISPyBDB.Proposal,
+            ISPyBDB.BLSession.proposalId == ISPyBDB.Proposal.proposalId,
+        )
         .where(ISPyBDB.Atlas.atlasId == atlas_id)
     )
     result = session.execute(statement).one()  # Will error if no match is found
     return (
         cast(ISPyBDB.Atlas, result.Atlas),
-        cast(ISPyBDB.DataCollectionGroup, result.DataCollectionGroup),
+        cast(ISPyBDB.Proposal, result.Proposal),
+        cast(ISPyBDB.BLSession, result.BLSession),
         cast(ISPyBDB.ExperimentType, result.ExperimentType),
     )
 
@@ -126,16 +147,19 @@ class AlignImagesService(CommonService):
         # Load the ISPyB Atlas entries using the provided IDs
         try:
             with self._database_session_maker() as session:
-                atlas_ref, dcg_ref, experiment_type_ref = (
-                    _get_atlas_dcg_experiment_type(
+                atlas_ref, proposal_ref, bl_session_ref, experiment_type_ref = (
+                    _get_atlas_proposal_session_experiment_type(
                         session=session, atlas_id=params.id_ref
                     )
                 )
-                atlas_mov, dcg_mov, experiment_type_mov = (
-                    _get_atlas_dcg_experiment_type(
+                atlas_mov, proposal_mov, bl_session_mov, experiment_type_mov = (
+                    _get_atlas_proposal_session_experiment_type(
                         session=session, atlas_id=params.id_mov
                     )
                 )
+                # Construct visit names
+                visit_ref = f"{proposal_ref.proposalCode}{proposal_ref.proposalNumber}-{bl_session_ref.visit_number}"
+                visit_mov = f"{proposal_mov.proposalCode}{proposal_mov.proposalNumber}-{bl_session_mov.visit_number}"
         except Exception:
             self.log.error(
                 "Uncaught exception {e!r} while querying ISPyB, "
@@ -146,14 +170,144 @@ class AlignImagesService(CommonService):
             return
 
         # Align images differently depending on which data types are being compared
-        match (experiment_type_ref.name, experiment_type_mov.name):
-            case ("Tomography", "FIB"):
-                self.log.info("Aligning FIB atlas to tomography one")
-            case _:
-                self.log.info(
-                    "No image alignment algorithm implemented for this case yet"
-                )
+        try:
+            match sorted((experiment_type_ref.name, experiment_type_mov.name)):
+                case (
+                    ["FIB", "Tomography"]
+                    | ["FIB", "Lamella Tomography"]
+                    | ["FIB", "Single Particle"]
+                ):
+                    self.log.info("Aligning FIB atlas to TEM one")
+                    result = self._handle_fib_tem_case(
+                        params,
+                        atlas_ref,
+                        visit_ref,
+                        atlas_mov,
+                        visit_mov,
+                    )
+                    if result["transform"] is not None:
+                        self.log.info("Successfully aligned FIB atlas to TEM atlas")
+                case _:
+                    self.log.info(
+                        "No image alignment algorithm implemented for this case yet"
+                    )
+        except Exception:
+            self.log.error(
+                "Error while attempting to perform image alignment", exc_info=True
+            )
+            self._reject_message(header, transport=rw.transport)
 
         # Ack message after completion
         rw.transport.ack(header)
         return
+
+    def _handle_fib_tem_case(
+        self,
+        params: AlignImagesParameters,
+        atlas_ref: ISPyBDB.Atlas,
+        visit_ref: str,
+        atlas_mov: ISPyBDB.Atlas,
+        visit_mov: str,
+    ):
+        # Ensure image path and pixel size are present as params or in the atlas tables
+        if not (
+            (
+                (atlas_ref.atlasImage and atlas_ref.pixelSize)
+                or (params.image_ref and params.pixel_size_ref)
+            )
+            and (
+                (atlas_mov.atlasImage and atlas_mov.pixelSize)
+                or (params.image_mov and params.pixel_size_mov)
+            )
+        ):
+            raise ValueError(
+                "Could not determine the file path or pixel size for "
+                "either the reference or moving image"
+            )
+        # Load image files and pixel sizes
+        # Load from params, then fall back to table (useful for testing)
+        file_ref = (
+            params.image_ref
+            if params.image_ref is not None
+            else Path(atlas_ref.atlasImage)
+        )
+        img_ref = cv2.imread(file_ref, flags=cv2.IMREAD_GRAYSCALE)
+        pixel_size_ref = (
+            params.pixel_size_ref
+            if params.pixel_size_ref is not None
+            else atlas_ref.pixelSize
+        )
+        file_mov = (
+            params.image_mov
+            if params.image_mov is not None
+            else Path(atlas_mov.atlasImage)
+        )
+        img_mov = cv2.imread(file_mov, flags=cv2.IMREAD_GRAYSCALE)
+        pixel_size_mov = (
+            params.pixel_size_mov
+            if params.pixel_size_mov is not None
+            else atlas_mov.pixelSize
+        )
+
+        # Get save directory from message
+        save_dir = params.save_dir
+        # Fall back to constructing a save directory using ISPyB-derived data
+        if save_dir is None:
+            visit_dir = file_ref.parents[-(file_ref.parts.index(visit_ref) + 1)]
+            save_dir = (
+                visit_dir / "processed" / "correlation" / visit_mov / file_mov.stem
+            )
+
+        # Store images under the visit name of the moving image
+        if not save_dir.exists():
+            save_dir.mkdir(parents=True)
+            self.log.info(f"Created save directory at {save_dir}")
+
+        # Rescale images to same pixel size and crop to the same dimensions
+        pixel_size_target = 4.0e-6
+        resized_ref = cv2.resize(
+            img_ref,
+            dsize=None,
+            dst=None,
+            fx=pixel_size_ref / pixel_size_target,
+            fy=pixel_size_ref / pixel_size_target,
+            interpolation=cv2.INTER_AREA,
+        )
+        resized_mov = cv2.resize(
+            img_mov,
+            dsize=None,
+            dst=None,
+            fx=pixel_size_mov / pixel_size_target,
+            fy=pixel_size_mov / pixel_size_target,
+            interpolation=cv2.INTER_AREA,
+        )
+        height = min(resized_ref.shape[0], resized_mov.shape[0])
+        width = min(resized_ref.shape[1], resized_mov.shape[1])
+        cropped_ref = crop_image(resized_ref, width=width, height=height)
+        cropped_mov = crop_image(resized_mov, width=width, height=height)
+
+        # Perform image alignment
+        # Parameters empirically determined to work for a pixel size of ~4.0e-6
+        return align_images_using_neighbors(
+            cropped_ref,
+            cropped_mov,
+            median_blur=None,
+            gaussian_blur=0.5,
+            sobel_kernel=3,
+            use_hanning=False,
+            min_component_area=20,
+            threshold_percentile=98.5,
+            morph_close_kernel=10,
+            morph_open_kernel=2,
+            min_feature_area=20,
+            max_feature_area=1000,
+            min_solidity=0.6,
+            min_ellipse_fit=0.4,
+            max_aspect_ratio=0.95,
+            max_neighbor_distance=200,
+            min_score=0.3,
+            ransac_threshold=5,
+            save_images=True,
+            save_tables=True,
+            save_dir=save_dir,
+        )

--- a/src/cryoemservices/util/image_processing/align_images_using_neighbors.py
+++ b/src/cryoemservices/util/image_processing/align_images_using_neighbors.py
@@ -823,7 +823,7 @@ def align_images_using_neighbors(
     # Similarity calculation and registration
     max_neighbor_distance: float | None = 400,
     min_score: float | None = 0.2,
-    ransac_threshold: float = 10,
+    ransac_threshold: float = 5,
     # Debug options
     save_images: bool = False,
     save_tables: bool = False,

--- a/src/cryoemservices/util/image_processing/shared.py
+++ b/src/cryoemservices/util/image_processing/shared.py
@@ -774,3 +774,20 @@ def threshold_image(
         type=cv2.THRESH_BINARY + (0 if percentile is not None else cv2.THRESH_OTSU),
     )
     return cast(np.ndarray, binary).astype(np.uint8)
+
+
+def crop_image(
+    array: np.ndarray,
+    width: int,
+    height: int,
+):
+    """
+    Crops a 2D image around its center to the desired shape and returns it.
+    """
+    h, w = array.shape[:2]
+    if height > h or width > w:
+        raise ValueError("Crop size exceeds image dimensions")
+    left = (w - width) // 2
+    top = (h - height) // 2
+    arr = array[top : top + height, left : left + width]
+    return arr

--- a/tests/services/test_correlative_align_images_service.py
+++ b/tests/services/test_correlative_align_images_service.py
@@ -158,12 +158,10 @@ def test_align_images_service(
     )
     # It goes into the correct case block
     match sorted((ref_type, mov_type)):
-        case (
-            ["FIB", "Tomography"]
-            | ["FIB", "Lamella Tomography"]
-            | ["FIB", "Single Particle"]
-        ):
-            service.log.info.assert_called_with("Aligning FIB atlas to TEM one")
+        case ["FIB", "Tomography"] | ["FIB", "Lamella Tomography"]:
+            service.log.info.assert_called_with(
+                "Aligning FIB atlas to tomography atlas"
+            )
         case _:
             service.log.info.assert_called_with(
                 "No image alignment algorithm implemented for this case yet"

--- a/tests/services/test_correlative_align_images_service.py
+++ b/tests/services/test_correlative_align_images_service.py
@@ -1,7 +1,9 @@
 from pathlib import Path
+from typing import cast
 from unittest import mock
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
 from pytest_mock import MockerFixture
 from workflows.transport.offline_transport import OfflineTransport
@@ -230,3 +232,65 @@ def test_align_images_service(
             service.log.info.assert_called_with(
                 "No image alignment algorithm implemented for this case yet"
             )
+
+
+def test_handle_fib_tomo_case(
+    mocker: MockerFixture,
+    tmp_path: Path,
+    mock_config_file: Path,
+    offline_transport: OfflineTransport,
+):
+    # Patch the 'cv2.imread' function
+    mocker.patch(
+        "cryoemservices.services.correlative_align_images.cv2.imread",
+        side_effect=[
+            np.random.randint(0, 256, (400, 600), dtype=np.uint8),
+            np.random.randint(0, 256, (600, 400), dtype=np.uint8),
+        ],
+    )
+
+    # Mock the image alignment function
+    mock_align = mocker.patch(
+        "cryoemservices.services.correlative_align_images.align_images_using_neighbors"
+    )
+    save_dir = tmp_path / "dummy"
+
+    # Set up the service and run the function
+    service = AlignImagesService(
+        environment={"config": str(mock_config_file), "queue": ""},
+        transport=offline_transport,
+    )
+    service._handle_fib_tomo_case(
+        tmp_path / "dummy.png", 1e-6, tmp_path / "dummy.png", 1e-6, save_dir
+    )
+
+    # Check that the expected calls were made
+    mock_align.assert_called_once_with(
+        mock.ANY,
+        mock.ANY,
+        median_blur=None,
+        gaussian_blur=0.5,
+        sobel_kernel=3,
+        use_hanning=False,
+        min_component_area=20,
+        threshold_percentile=98.5,
+        morph_close_kernel=10,
+        morph_open_kernel=2,
+        min_feature_area=20,
+        max_feature_area=1000,
+        min_solidity=0.6,
+        min_ellipse_fit=0.4,
+        max_aspect_ratio=0.95,
+        max_neighbor_distance=200,
+        min_score=0.3,
+        ransac_threshold=5,
+        save_images=True,
+        save_tables=True,
+        save_dir=save_dir,
+    )
+    # Unpack the mocks to check that the arrays have been resized and cropped correctly
+    # Calculate the expected output shape of the array
+    num_pixels = int(400 * (1e-6 / 4e-6))
+    image_ref, image_mov = mock_align.call_args.args[:2]
+    assert cast(np.ndarray, image_ref).shape == (num_pixels, num_pixels)
+    assert cast(np.ndarray, image_mov).shape == (num_pixels, num_pixels)

--- a/tests/services/test_correlative_align_images_service.py
+++ b/tests/services/test_correlative_align_images_service.py
@@ -9,7 +9,7 @@ from workflows.transport.offline_transport import OfflineTransport
 from cryoemservices.services.correlative_align_images import (
     AlignImagesParameters,
     AlignImagesService,
-    _get_atlas_dcg_experiment_type,
+    _get_atlas_proposal_session_experiment_type,
 )
 from cryoemservices.util.models import MockRW
 
@@ -17,12 +17,14 @@ from cryoemservices.util.models import MockRW
 def test_get_atlas_dcg_experiment_type(mocker: MockerFixture):
     # Create mock return results
     mock_atlas = MagicMock()
-    mock_dcg = MagicMock()
+    mock_proposal = MagicMock()
+    mock_bl_session = MagicMock()
     mock_experiment = MagicMock()
 
     mock_result = MagicMock()
     mock_result.Atlas = mock_atlas
-    mock_result.DataCollectionGroup = mock_dcg
+    mock_result.Proposal = mock_proposal
+    mock_result.BLSession = mock_bl_session
     mock_result.ExperimentType = mock_experiment
 
     # Create the mock SQLAlchemy session
@@ -30,9 +32,10 @@ def test_get_atlas_dcg_experiment_type(mocker: MockerFixture):
     mock_session.execute.return_value.one.return_value = mock_result
 
     # Run the function
-    assert _get_atlas_dcg_experiment_type(mock_session, 1) == (
+    assert _get_atlas_proposal_session_experiment_type(mock_session, 1) == (
         mock_atlas,
-        mock_dcg,
+        mock_proposal,
+        mock_bl_session,
         mock_experiment,
     )
 
@@ -103,20 +106,22 @@ def test_align_images_service(
 
     # Mock the query function and its returns
     mock_atlas_ref = MagicMock()
-    mock_dcg_ref = MagicMock()
+    mock_proposal_ref = MagicMock()
+    mock_session_ref = MagicMock()
     mock_experiment_ref = MagicMock()
     mock_experiment_ref.name = ref_type
 
     mock_atlas_mov = MagicMock()
-    mock_dcg_mov = MagicMock()
+    mock_proposal_mov = MagicMock()
+    mock_session_mov = MagicMock()
     mock_experiment_mov = MagicMock()
     mock_experiment_mov.name = mov_type
 
     mock_get = mocker.patch(
-        "cryoemservices.services.correlative_align_images._get_atlas_dcg_experiment_type",
+        "cryoemservices.services.correlative_align_images._get_atlas_proposal_session_experiment_type",
         side_effect=[
-            (mock_atlas_ref, mock_dcg_ref, mock_experiment_ref),
-            (mock_atlas_mov, mock_dcg_mov, mock_experiment_mov),
+            (mock_atlas_ref, mock_proposal_ref, mock_session_ref, mock_experiment_ref),
+            (mock_atlas_mov, mock_proposal_mov, mock_session_mov, mock_experiment_mov),
         ],
     )
 
@@ -152,9 +157,13 @@ def test_align_images_service(
         atlas_id=params.id_mov,
     )
     # It goes into the correct case block
-    match (ref_type, mov_type):
-        case ("Tomography", "FIB"):
-            service.log.info.assert_called_with("Aligning FIB atlas to tomography one")
+    match sorted((ref_type, mov_type)):
+        case (
+            ["FIB", "Tomography"]
+            | ["FIB", "Lamella Tomography"]
+            | ["FIB", "Single Particle"]
+        ):
+            service.log.info.assert_called_with("Aligning FIB atlas to TEM one")
         case _:
             service.log.info.assert_called_with(
                 "No image alignment algorithm implemented for this case yet"

--- a/tests/services/test_correlative_align_images_service.py
+++ b/tests/services/test_correlative_align_images_service.py
@@ -227,6 +227,7 @@ def test_align_images_service(
                 image_mov,
                 pixel_size_mov,
                 save_dir,
+                params,
             )
         case _:
             service.log.info.assert_called_with(
@@ -261,7 +262,12 @@ def test_handle_fib_tomo_case(
         transport=offline_transport,
     )
     service._handle_fib_tomo_case(
-        tmp_path / "dummy.png", 1e-6, tmp_path / "dummy.png", 1e-6, save_dir
+        tmp_path / "dummy.png",
+        1e-6,
+        tmp_path / "dummy.png",
+        1e-6,
+        save_dir,
+        AlignImagesParameters(),
     )
 
     # Check that the expected calls were made

--- a/tests/services/test_correlative_align_images_service.py
+++ b/tests/services/test_correlative_align_images_service.py
@@ -176,6 +176,11 @@ def test_align_images_service(
         ],
     )
 
+    # Mock the '_handle_fib_tomo_case' class function
+    mock_handle_fib_tomo = mocker.patch(
+        "cryoemservices.services.correlative_align_images.AlignImagesService._handle_fib_tomo_case"
+    )
+
     # Set up and run the service
     service = AlignImagesService(
         environment={"config": str(mock_config_file), "queue": ""},
@@ -214,8 +219,12 @@ def test_align_images_service(
     # It goes into the correct case block
     match sorted((ref_type, mov_type)):
         case ["FIB", "Tomography"] | ["FIB", "Lamella Tomography"]:
-            service.log.info.assert_called_with(
-                "Aligning FIB atlas to tomography atlas"
+            mock_handle_fib_tomo.assert_called_with(
+                image_ref,
+                pixel_size_ref,
+                image_mov,
+                pixel_size_mov,
+                save_dir,
             )
         case _:
             service.log.info.assert_called_with(

--- a/tests/services/test_correlative_align_images_service.py
+++ b/tests/services/test_correlative_align_images_service.py
@@ -66,15 +66,15 @@ def mock_config_file(tmp_path: Path):
 
 @pytest.mark.parametrize(
     "test_params",
-    (  # Use recwrap | Use ISPyB | Ref type | Mov type
-        (True, True, "Tomography", "FIB"),
-        (False, True, "Tomography", "FIB"),
-        (True, False, "Tomography", "Single Particle"),
-        (False, False, "Tomography", "Single Particle"),
-        (True, True, "Tomography", "CLEM"),
-        (False, True, "Tomography", "CLEM"),
-        (True, True, "Lamella Tomography", "FIB"),
-        (False, True, "Lamella Tomography", "FIB"),
+    (  # Use recwrap | Use ISPyB | Ref type | Mov type | Alignment successful
+        (True, True, "Tomography", "FIB", True),
+        (False, True, "Tomography", "FIB", False),
+        (True, False, "Tomography", "Single Particle", True),
+        (False, False, "Tomography", "Single Particle", False),
+        (True, True, "Tomography", "CLEM", True),
+        (False, True, "Tomography", "CLEM", False),
+        (True, True, "Lamella Tomography", "FIB", True),
+        (False, True, "Lamella Tomography", "FIB", False),
     ),
 )
 def test_align_images_service(
@@ -82,10 +82,10 @@ def test_align_images_service(
     tmp_path: Path,
     mock_config_file: Path,
     offline_transport: OfflineTransport,
-    test_params: tuple[bool, bool, str, str],
+    test_params: tuple[bool, bool, str, str, bool],
 ):
     # Set up the message parameters
-    use_recwrap, use_ispyb, ref_type, mov_type = test_params
+    use_recwrap, use_ispyb, ref_type, mov_type, alignment_successful = test_params
 
     # Set up reference image and moving image parameters
     id_ref = 1
@@ -178,10 +178,18 @@ def test_align_images_service(
         ],
     )
 
+    # Mock the '_reject_message' function
+    mock_reject = mocker.patch(
+        "cryoemservices.services.common_service.CommonService._reject_message"
+    )
+
     # Mock the '_handle_fib_tomo_case' class function
     mock_handle_fib_tomo = mocker.patch(
         "cryoemservices.services.correlative_align_images.AlignImagesService._handle_fib_tomo_case"
     )
+    mock_handle_fib_tomo.return_value = {
+        "transform": np.ones((3, 3), dtype=np.float32) if alignment_successful else None
+    }
 
     # Set up and run the service
     service = AlignImagesService(
@@ -229,10 +237,21 @@ def test_align_images_service(
                 save_dir,
                 params,
             )
+            if alignment_successful:
+                service.log.info.assert_called_with(
+                    "Successfully aligned FIB atlas to tomography atlas"
+                )
+                mock_reject.assert_not_called()
+            else:
+                service.log.error.assert_called_with(
+                    "Could not align FIB atlas to tomography atlas"
+                )
+                mock_reject.assert_called()
         case _:
             service.log.info.assert_called_with(
                 "No image alignment algorithm implemented for this case yet"
             )
+            mock_reject.assert_not_called()
 
 
 def test_handle_fib_tomo_case(

--- a/tests/services/test_correlative_align_images_service.py
+++ b/tests/services/test_correlative_align_images_service.py
@@ -64,13 +64,15 @@ def mock_config_file(tmp_path: Path):
 
 @pytest.mark.parametrize(
     "test_params",
-    (  # Use recwrap | Ref type | Mov type
-        (True, "Tomography", "FIB"),
-        (False, "Tomography", "FIB"),
-        (True, "Tomography", "Single Particle"),
-        (False, "Tomography", "Single Particle"),
-        (True, "Tomography", "CLEM"),
-        (False, "Tomography", "CLEM"),
+    (  # Use recwrap | Use ISPyB | Ref type | Mov type
+        (True, True, "Tomography", "FIB"),
+        (False, True, "Tomography", "FIB"),
+        (True, False, "Tomography", "Single Particle"),
+        (False, False, "Tomography", "Single Particle"),
+        (True, True, "Tomography", "CLEM"),
+        (False, True, "Tomography", "CLEM"),
+        (True, True, "Lamella Tomography", "FIB"),
+        (False, True, "Lamella Tomography", "FIB"),
     ),
 )
 def test_align_images_service(
@@ -78,21 +80,47 @@ def test_align_images_service(
     tmp_path: Path,
     mock_config_file: Path,
     offline_transport: OfflineTransport,
-    test_params: tuple[bool, str, str],
+    test_params: tuple[bool, bool, str, str],
 ):
     # Set up the message parameters
-    use_recwrap, ref_type, mov_type = test_params
+    use_recwrap, use_ispyb, ref_type, mov_type = test_params
+
+    # Set up reference image and moving image parameters
+    id_ref = 1
+    id_mov = 2
+
+    proposal_code = "cm"
+    proposal_number = "12345"
+
+    visit_ref = f"{proposal_code}{proposal_number}-{id_ref}"
+    image_ref = tmp_path / visit_ref / "processed" / "atlas" / "test.png"
+    pixel_size_ref = 1e-6
+
+    visit_mov = f"{proposal_code}{proposal_number}-{id_mov}"
+    image_mov = tmp_path / visit_mov / "processed" / "atlas" / "test.png"
+    pixel_size_mov = 1e-6
+
+    save_dir = (
+        tmp_path / visit_ref / "processed" / "correlation" / visit_mov / image_mov.stem
+    )
+
+    # Populate message based on whether to use ISPyB
     header = {
         "message-id": mock.sentinel,
         "subscription": mock.sentinel,
     }
     align_images_test_message = {
-        "id_ref": 1,
-        "image_ref": str(tmp_path / "ref.png"),
-        "pixel_size_ref": 1e-6,
-        "id_mov": 2,
-        "image_mov": str(tmp_path / "mov.png"),
-        "pixel_size_mov": 1e-6,
+        "id_ref": id_ref if use_ispyb else None,
+        "id_mov": id_mov if use_ispyb else None,
+        "visit_ref": None if use_ispyb else visit_ref,
+        "experiment_type_ref": None if use_ispyb else ref_type,
+        "image_ref": None if use_ispyb else str(image_ref),
+        "pixel_size_ref": None if use_ispyb else pixel_size_ref,
+        "visit_mov": None if use_ispyb else visit_mov,
+        "experiment_type_mov": None if use_ispyb else mov_type,
+        "image_mov": None if use_ispyb else str(image_mov),
+        "pixel_size_mov": None if use_ispyb else pixel_size_mov,
+        "save_dir": None if use_ispyb else save_dir,
     }
     params = AlignImagesParameters(**align_images_test_message)
 
@@ -107,21 +135,44 @@ def test_align_images_service(
     # Mock the query function and its returns
     mock_atlas_ref = MagicMock()
     mock_proposal_ref = MagicMock()
-    mock_session_ref = MagicMock()
+    mock_bl_session_ref = MagicMock()
     mock_experiment_ref = MagicMock()
-    mock_experiment_ref.name = ref_type
 
     mock_atlas_mov = MagicMock()
     mock_proposal_mov = MagicMock()
-    mock_session_mov = MagicMock()
+    mock_bl_session_mov = MagicMock()
     mock_experiment_mov = MagicMock()
-    mock_experiment_mov.name = mov_type
 
-    mock_get = mocker.patch(
+    if use_ispyb:
+        mock_atlas_ref.atlasImage = str(image_ref)
+        mock_atlas_ref.pixelSize = pixel_size_ref
+        mock_proposal_ref.proposalCode = proposal_code
+        mock_proposal_ref.proposalNumber = proposal_number
+        mock_bl_session_ref.visit_number = id_ref
+        mock_experiment_ref.name = ref_type
+
+        mock_atlas_mov.atlasImage = str(image_mov)
+        mock_atlas_mov.pixelSize = pixel_size_mov
+        mock_proposal_mov.proposalCode = proposal_code
+        mock_proposal_mov.proposalNumber = proposal_number
+        mock_bl_session_mov.visit_number = id_mov
+        mock_experiment_mov.name = mov_type
+
+    mock_get_ispyb = mocker.patch(
         "cryoemservices.services.correlative_align_images._get_atlas_proposal_session_experiment_type",
         side_effect=[
-            (mock_atlas_ref, mock_proposal_ref, mock_session_ref, mock_experiment_ref),
-            (mock_atlas_mov, mock_proposal_mov, mock_session_mov, mock_experiment_mov),
+            (
+                mock_atlas_ref,
+                mock_proposal_ref,
+                mock_bl_session_ref,
+                mock_experiment_ref,
+            ),
+            (
+                mock_atlas_mov,
+                mock_proposal_mov,
+                mock_bl_session_mov,
+                mock_experiment_mov,
+            ),
         ],
     )
 
@@ -148,14 +199,18 @@ def test_align_images_service(
         )
 
     # Queries for the Atlas, DCG, and ExperimentType were made
-    mock_get.assert_any_call(
-        session=mock_ispyb_session,
-        atlas_id=params.id_ref,
-    )
-    mock_get.assert_any_call(
-        session=mock_ispyb_session,
-        atlas_id=params.id_mov,
-    )
+    if use_ispyb:
+        mock_get_ispyb.assert_any_call(
+            session=mock_ispyb_session,
+            atlas_id=params.id_ref,
+        )
+        mock_get_ispyb.assert_any_call(
+            session=mock_ispyb_session,
+            atlas_id=params.id_mov,
+        )
+    else:
+        mock_get_ispyb.assert_not_called()
+
     # It goes into the correct case block
     match sorted((ref_type, mov_type)):
         case ["FIB", "Tomography"] | ["FIB", "Lamella Tomography"]:


### PR DESCRIPTION
Further updates to the image correlation service's functionality.
* Adds more optional keys to the Pydantic model so that the image paths, pixel sizes, visit names, experiment types, and save directory can be directly injected as part of a manually constructed message. For ISPyB usage, these same values will be generated and constructed from the ISPyB queries performed
* Modified the ISPyB database query so that the `Proposal` and `BLSession` are also returned, from which the visit names can then be constructed
* Adds a utility function to the shared image processing module that crops the image around the center
* Applies the image alignment algorithm for the FIB + tomo case using values empirically determined for a target pixel size of `4e-6`. Currently, it will save the image processing output to a folder named after the moving image's visit name and atlas file name. e.g. `".../cm12345-1/processed/correlation/cm12345-2/atlas/..."`