### PR TITLE
Safer exception handling in 'process_recipe' service

### DIFF
--- a/src/cryoemservices/services/process_recipe.py
+++ b/src/cryoemservices/services/process_recipe.py
@@ -100,7 +100,7 @@ class ProcessRecipe(CommonService):
                 )
             except Exception as e:
                 self.log.info(f"Rejected message due to filter {name} error: {e}")
-                self._reject_message(header, transport=rw.transport)
+                self._reject_message(header, requeue=False)
                 return
 
         self.log.info(f"Filtered processing request: {str(message)}")


### PR DESCRIPTION
We discovered a bug in the exception handling logic of the `process_recipe` service when it tries and fails to look for an existing recipe. It will try to reject the message with `transport=rw.transport`, which will error if the recipe wrapper variable is set to `None`.

This PR makes the exception handling logic safer by letting the service default to using the Transport class set by `self._transport` when rejecting the message.