### PR TITLE
Early refinement and alter batch sizes

### DIFF
--- a/src/cryoemservices/services/select_classes.py
+++ b/src/cryoemservices/services/select_classes.py
@@ -458,7 +458,7 @@ class SelectClasses(CommonService):
                 f"{self.total_count}, {autoselect_params.class3d_batch_size}, {np.log(new_batch_multiple) / np.log(2)}"
             )
             if new_batch_multiple > previous_batch_multiple and (
-                previous_batch_multiple == 0
+                not previous_batch_multiple
                 or (np.log(new_batch_multiple) / np.log(2)).is_integer()
                 or int((np.log(new_batch_multiple) / np.log(2)))
                 != int(np.log(previous_batch_multiple) / np.log(2))

--- a/src/cryoemservices/services/select_classes.py
+++ b/src/cryoemservices/services/select_classes.py
@@ -36,7 +36,7 @@ class SelectClassesParameters(BaseModel):
     autoselect_min_score: float = 0
     min_particles: int = 500
     class3d_batch_size: int = 50000
-    class3d_max_size: int = 200000
+    class3d_max_size: int | None = None
     class_uuids: str
     relion_options: RelionServiceOptions
     app_id: Optional[int] = None
@@ -440,7 +440,10 @@ class SelectClasses(CommonService):
             if self.total_count > autoselect_params.class3d_batch_size:
                 # Do 3D classification if there are more particles than the batch size
                 send_to_3d_classification = True
-        elif self.previous_total_count >= autoselect_params.class3d_max_size:
+        elif (
+            autoselect_params.class3d_max_size is not None
+            and self.previous_total_count >= autoselect_params.class3d_max_size
+        ):
             # Iterations beyond those where 3D classification is run
             next_batch_size = autoselect_params.class3d_max_size
         else:
@@ -468,7 +471,10 @@ class SelectClasses(CommonService):
                 next_batch_size = (
                     new_batch_multiple * autoselect_params.class3d_batch_size
                 )
-                if next_batch_size > autoselect_params.class3d_max_size:
+                if (
+                    autoselect_params.class3d_max_size is not None
+                    and next_batch_size > autoselect_params.class3d_max_size
+                ):
                     next_batch_size = autoselect_params.class3d_max_size
             else:
                 # Otherwise just get the next threshold

--- a/src/cryoemservices/services/select_classes.py
+++ b/src/cryoemservices/services/select_classes.py
@@ -451,8 +451,18 @@ class SelectClasses(CommonService):
             new_batch_multiple = (
                 self.total_count // autoselect_params.class3d_batch_size
             )
-            if new_batch_multiple > previous_batch_multiple:
+            self.log.info(
+                f"{self.total_count}, {autoselect_params.class3d_batch_size}, {np.log(new_batch_multiple) / np.log(2)}"
+            )
+            if new_batch_multiple > previous_batch_multiple and (
+                previous_batch_multiple == 0
+                or (np.log(new_batch_multiple) / np.log(2)).is_integer()
+                or int((np.log(new_batch_multiple) / np.log(2)))
+                != int(np.log(previous_batch_multiple) / np.log(2))
+            ):
                 # Do 3D classification if a batch threshold has been crossed
+                # Batch thresholds are done as multiples of 2 from the batch size
+                # With the defaults this leads to 50000, 100000, 200000
                 send_to_3d_classification = True
                 # Set the batch size from the total count, but do not exceed the maximum
                 next_batch_size = (

--- a/src/cryoemservices/wrappers/class3d_wrapper.py
+++ b/src/cryoemservices/wrappers/class3d_wrapper.py
@@ -625,10 +625,8 @@ def run_class3d(class3d_params: Class3DParameters, send_to_rabbitmq: Callable) -
         class_sorting_array, order=("resolutions", "efficiencies", "particles")
     )
     for cid in class_sorting:
-        if (
-            class3d_params.batch_size == 200000
-            and class_resolutions[cid] < 11
-            and (class_efficiencies[cid] > 0.65 or class3d_params.symmetry != "C1")
+        if class_resolutions[cid] < 11 and (
+            class_efficiencies[cid] > 0.65 or class3d_params.symmetry != "C1"
         ):
             murfey_params["do_refinement"] = True
             murfey_params["best_class"] = class_ids[cid]

--- a/tests/services/test_select_classes_service.py
+++ b/tests/services/test_select_classes_service.py
@@ -106,7 +106,7 @@ def select_classes_common_setup(
         "min_score": 0,
         "min_particles": 500,
         "class3d_batch_size": 50000,
-        "class3d_max_size": 200000,
+        "class3d_max_size": None,
         "class_uuids": "{'1': '1', '2': '2'}",
         "relion_options": {},
     }
@@ -499,6 +499,7 @@ def test_select_classes_service_last_threshold(
     select_test_message, relion_options = select_classes_common_setup(
         tmp_path, initial_particle_count=190000, particles_to_add=70000
     )
+    select_test_message["class3d_max_size"] = 200000
 
     # Set up the mock service and send the message to it
     service = select_classes.SelectClasses(
@@ -587,7 +588,49 @@ def test_select_classes_service_past_maximum(
         "subscription": mock.sentinel,
     }
     select_test_message, relion_options = select_classes_common_setup(
-        tmp_path, initial_particle_count=290000, particles_to_add=20000
+        tmp_path, initial_particle_count=390000, particles_to_add=20000
+    )
+    select_test_message["class3d_max_size"] = 200000
+
+    # Set up the mock service and send the message to it
+    service = select_classes.SelectClasses(
+        environment={"queue": ""}, transport=offline_transport
+    )
+    service.initializing()
+    service.select_classes(None, header=header, message=select_test_message)
+
+    # Check the correct particle counts were found and split files made
+    assert service.previous_total_count == 390000
+    assert service.total_count == 410000
+    assert (tmp_path / "Select/job013/particles_split1.star").is_file()
+    assert (tmp_path / "Select/job013/particles_split2.star").is_file()
+    assert len(list(tmp_path.glob("Select/job013/particles_batch_*"))) == 0
+
+    # Don't bother to check the auto-selection calls here, they are checked above
+    # Do check the Murfey 3D calls
+    assert len(offline_transport.send.call_args_list) == 7
+
+
+@mock.patch("cryoemservices.services.select_classes.subprocess.run")
+def test_select_classes_service_no_maximum(
+    mock_subprocess, offline_transport, tmp_path
+):
+    """
+    Test the service for the case where the existing particle count exceeds 200000
+    with no maximum set. (Same as previous test but no maximum)
+    In this case particles_all.star already exists so should be appended to,
+    and 3D classification should be requested at 400000.
+    """
+    mock_subprocess().returncode = 0
+    mock_subprocess().stdout = "stdout".encode("ascii")
+    mock_subprocess().stderr = "stderr".encode("ascii")
+
+    header = {
+        "message-id": mock.sentinel,
+        "subscription": mock.sentinel,
+    }
+    select_test_message, relion_options = select_classes_common_setup(
+        tmp_path, initial_particle_count=390000, particles_to_add=20000
     )
 
     # Set up the mock service and send the message to it
@@ -598,15 +641,25 @@ def test_select_classes_service_past_maximum(
     service.select_classes(None, header=header, message=select_test_message)
 
     # Check the correct particle counts were found and split files made
-    assert service.previous_total_count == 290000
-    assert service.total_count == 310000
+    assert service.previous_total_count == 390000
+    assert service.total_count == 410000
     assert (tmp_path / "Select/job013/particles_split1.star").is_file()
     assert (tmp_path / "Select/job013/particles_split2.star").is_file()
-    assert len(list(tmp_path.glob("Select/job013/particles_batch_*"))) == 0
+    assert (tmp_path / "Select/job013/particles_batch_400000.star").is_file()
 
     # Don't bother to check the auto-selection calls here, they are checked above
     # Do check the Murfey 3D calls
-    assert len(offline_transport.send.call_args_list) == 7
+    offline_transport.send.assert_any_call(
+        "murfey_feedback",
+        {
+            "register": "run_class3d",
+            "class3d_message": {
+                "particles_file": f"{tmp_path}/Select/job013/particles_batch_400000.star",
+                "class3d_dir": f"{tmp_path}/Class3D/job",
+                "batch_size": 400000,
+            },
+        },
+    )
 
 
 @mock.patch("cryoemservices.services.select_classes.subprocess.run")

--- a/tests/wrappers/test_class3d_wrapper.py
+++ b/tests/wrappers/test_class3d_wrapper.py
@@ -139,7 +139,7 @@ def test_class3d_wrapper_do_initial_model(
             "_rlnReferenceImage\n_Fraction\n_Rotation\n_Translation\n"
             "_Resolution\n_Completeness\n_OffsetX\n_OffsetY\n"
             "1@Class3D/job015/run_it020_classes.mrcs 0.4 30.3 33.3 12.2 1.0 0.6 0.01\n"
-            "2@Class3D/job015/run_it020_classes.mrcs 0.6 20.2 22.2 10.0 0.9 -0.5 -0.02"
+            "2@Class3D/job015/run_it020_classes.mrcs 0.6 20.2 22.2 11.1 0.9 -0.5 -0.02"
         )
 
     # Create a recipe wrapper with the test message
@@ -365,7 +365,7 @@ def test_class3d_wrapper_do_initial_model(
                         f"{tmp_path}/Class3D/job015/run_it025_class002.mrc"
                     ),
                     "class_number": 2,
-                    "estimated_resolution": 10.0,
+                    "estimated_resolution": 11.1,
                     "ispyb_command": "buffer",
                     "overall_fourier_completeness": 0.9,
                     "particles_per_class": 30000.0,
@@ -722,8 +722,8 @@ def test_class3d_wrapper_initial_model_star_file(
             "register": "done_3d_batch",
             "refine_dir": f"{tmp_path}/Refine3D/job",
             "class3d_dir": f"{tmp_path}/Class3D/job015",
-            "best_class": 0,
-            "do_refinement": False,
+            "best_class": 2,
+            "do_refinement": True,
         },
     )
 


### PR DESCRIPTION
This adjusts the decisions about when we run 3D classification and refinement:
- 3D classification is now run at 50000, 100000, 200000, ... with no upper limit, just increasing by factor 2 each time
- Refinement is run for any 3D batch which meets the resolution and efficiency thresholds