### PR TITLE
Remove textured noise from ORB image registration test

### DIFF
--- a/tests/util/image_processing/test_align_images_using_orb.py
+++ b/tests/util/image_processing/test_align_images_using_orb.py
@@ -30,7 +30,7 @@ def test_align_images_using_orb(test_params: tuple[int, int, int]):
         shape=(h, w),
         num_frames=num_frames,
         layer_intensity=96,
-        noise_sigma=4,
+        noise_sigma=0,
         hole_intensity=32,
         hole_list=[
             {
@@ -75,7 +75,7 @@ def test_align_images_using_orb(test_params: tuple[int, int, int]):
         shape=(512, 512),
         num_frames=num_frames,
         layer_intensity=96,
-        noise_sigma=4,
+        noise_sigma=0,
         hole_intensity=32,
         hole_list=[
             {


### PR DESCRIPTION
The image registration tests set up so far involve running the algorithm on programmatically generated test images to verify that the alignment works correctly. However, the test will occasionally fail, with the alignment not falling within the expected tolerance range.

It's been previously shown that removing the application of random noise does make the registration more consistent between iterations (see PR #268), so we have also removed the addition of noise to the test images generated for the ORB algorithm to alleviate this issue.