### PR TITLE
Safer conversion of xrm files to jpegs

### DIFF
--- a/src/cryoemservices/services/images_plugins.py
+++ b/src/cryoemservices/services/images_plugins.py
@@ -950,7 +950,7 @@ def xrm_to_jpeg(plugin_params: Callable):
     with OleFileIO(xrm_path) as xrm_ole:
         if xrm_ole.exists("ImageInfo/ImagesTaken"):
             image_count = np.frombuffer(
-                xrm_ole.openstream("ImageInfo/ImagesTaken").getvalue(), np.float32
+                xrm_ole.openstream("ImageInfo/ImagesTaken").getvalue(), np.int16
             ).tolist()
     if image_count and image_count[0] == 0:
         # Skip conversion if there are no images

--- a/src/cryoemservices/services/images_plugins.py
+++ b/src/cryoemservices/services/images_plugins.py
@@ -11,6 +11,7 @@ import pandas as pd
 import PIL.Image
 import starfile
 import tifffile
+from olefile import OleFileIO
 from PIL import ImageDraw, ImageEnhance, ImageFilter, ImageFont
 from txrm2tiff.main import convert_and_save
 
@@ -945,15 +946,40 @@ def xrm_to_jpeg(plugin_params: Callable):
         logger.error(f"File {xrm_path} not found")
         return False
 
-    convert_and_save(
-        xrm_path, str(tiff_path).replace("_Annotated", ""), annotate=annotate or False
-    )
-    data = tifffile.imread(tiff_path)
-    if len(data.shape) == 4:
-        # Take first frame if 3D RGB
+    image_count: list | None = None
+    with OleFileIO(xrm_path) as xrm_ole:
+        if xrm_ole.exists("ImageInfo/ImagesTaken"):
+            image_count = np.frombuffer(
+                xrm_ole.openstream("ImageInfo/ImagesTaken").getvalue(), np.float32
+            ).tolist()
+    if image_count and image_count[0] == 0:
+        # Skip conversion if there are no images
+        logger.warning(f"xrm file {xrm_path} has no images")
+        return xrm_path
+
+    try:
+        convert_and_save(
+            xrm_path,
+            str(tiff_path).replace("_Annotated", ""),
+            annotate=annotate or False,
+        )
+    except Exception as e:
+        logger.error(f"Failed xrm to tiff conversion due to {e}")
+        return False
+    if tiff_path.is_file():
+        data = tifffile.imread(tiff_path)
+    elif Path(str(tiff_path).replace("_Annotated", "")).is_file():
+        data = tifffile.imread(str(tiff_path).replace("_Annotated", ""))
+    else:
+        logger.error(f"File {tiff_path} not found")
+        return False
+    logger.info(data.shape)
+    if len(data.shape) == 4 or len(data.shape) == 3:
+        # Take first frame if 3D RGB or 3D greyscale
         data = data[0]
     with PIL.Image.fromarray(data) as thumb_im:
-        thumb_im.thumbnail((1024, 1024))
+        colour_im = thumb_im.convert(mode="RGB")
+        colour_im.thumbnail((1024, 1024))
         thumbnail_jpg = tiff_path.parent / (tiff_path.stem + "_thumbnail.jpg")
-        thumb_im.save(thumbnail_jpg)
+        colour_im.save(thumbnail_jpg)
     return tiff_path

--- a/tests/services/test_images_plugins.py
+++ b/tests/services/test_images_plugins.py
@@ -822,8 +822,12 @@ def test_tilt_image_alignment_works_2d(mock_imagedraw, tmp_path):
     assert ellipse_calls[1][1] == {"width": 20, "outline": "#f5a927"}
 
 
+@mock.patch("cryoemservices.services.images_plugins.OleFileIO")
 @mock.patch("cryoemservices.services.images_plugins.convert_and_save")
-def test_xrm_to_jpeg(mock_convert, tmp_path):
+def test_xrm_to_jpeg(mock_convert, mock_olefile, tmp_path):
+    mock_olefile().__enter__().openstream().getvalue.return_value = np.array(
+        [10], dtype=np.int16
+    ).tobytes()
     input_xrm = tmp_path / "example.xrm"
     input_xrm.touch()
     output_tiff = tmp_path / "example_Annotated.tiff"
@@ -833,6 +837,9 @@ def test_xrm_to_jpeg(mock_convert, tmp_path):
 
     assert xrm_to_jpeg(plugin_params_xrm(input_xrm, output_tiff, "xrm_to_tiff"))
 
+    mock_olefile.assert_any_call(input_xrm)
+    mock_olefile().__enter__().exists.assert_any_call("ImageInfo/ImagesTaken")
+    mock_olefile().__enter__().openstream.assert_any_call("ImageInfo/ImagesTaken")
     mock_convert.assert_called_once_with(
         input_xrm, f"{tmp_path}/example.tiff", annotate=True
     )


### PR DESCRIPTION
Instead of just running the conversion, check that there are images to convert first, and then try-except the conversion.
Then for 3D greyscale images, take the first frame and RGB convert it