### PR TITLE
Add a recipe for running IMOD reconstruction with SIRT

### DIFF
--- a/recipes/ispyb/sxt-imod-beads-sirt.json
+++ b/recipes/ispyb/sxt-imod-beads-sirt.json
@@ -22,13 +22,13 @@
       "success": 7
     },
     "parameters": {
-      "bead_count": 8,
+      "bead_count": 4,
       "copy_output": true,
       "manual_tilt_offset": "{manual_tilt_offset}",
       "out_bin": 1,
       "patch": 0,
       "pixel_size": "{pixel_size}",
-      "sirt": 0,
+      "sirt": 1,
       "stack_file": "{stack_file}",
       "tilt_axis": 0,
       "txrm_file": "{txrm_file}",

--- a/src/cryoemservices/services/tomo_align_imod.py
+++ b/src/cryoemservices/services/tomo_align_imod.py
@@ -132,7 +132,7 @@ class ImodTomoAlign(CommonService):
             "w",
         ) as angles_file:
             for ang in angles.values():
-                angles_file.write(f"{ang}\n")
+                angles_file.write(f"{round(ang, 4):.4f}\n")
 
         # Find the input image dimensions
         self.log.info(f"Converted {tomo_params.txrm_file} to mrc format")
@@ -310,7 +310,7 @@ class ImodTomoAlign(CommonService):
 
 
 def write_batch_directive_file(tomo_params: ImodTomoParameters):
-    adoc_file = Path(tomo_params.stack_file).with_suffix(".adoc")
+    adoc_file = Path(tomo_params.stack_file).parent / "batchDirective.adoc"
     with open(adoc_file, "w") as adoc:
         # Commands for copytomocoms
         adoc.write(f"setupset.datasetDirectory={adoc_file.parent}\n")

--- a/tests/services/test_tomo_align_imod.py
+++ b/tests/services/test_tomo_align_imod.py
@@ -107,7 +107,7 @@ def test_tomo_align_imod(
         [
             "batchruntomo",
             "-directive",
-            f"{tmp_path}/recipe/Tomograms/test_stack.adoc",
+            f"{tmp_path}/recipe/Tomograms/batchDirective.adoc",
             "-cpus",
             "2",
             "-bypass",
@@ -250,7 +250,7 @@ def test_write_batch_directive_patch_wbp(tmp_path):
             }
         )
     )
-    assert returned_adoc == tmp_path / "stack.adoc"
+    assert returned_adoc == tmp_path / "batchDirective.adoc"
     with open(returned_adoc) as f:
         adoc_lines = f.readlines()
 
@@ -289,7 +289,7 @@ def test_write_batch_directive_beads_sirt(tmp_path):
             }
         )
     )
-    assert returned_adoc == tmp_path / "stack.adoc"
+    assert returned_adoc == tmp_path / "batchDirective.adoc"
     with open(returned_adoc) as f:
         adoc_lines = f.readlines()
 


### PR DESCRIPTION
This adds a recipe for reconstructing with SIRT after bead alignment.
The current b24 processing uses 4 beads in the SIRT recipe but 8 in the WBP recipe. I've replicated that behaviour for now but with imod v5 the behaviour of the bead finding (autofidseed) seems to be a bit different so this may need adjustment in future.