### PR TITLE
PySIMRecon service message bug fixes

### DIFF
--- a/recipes/ispyb/sim-reconstruction.json
+++ b/recipes/ispyb/sim-reconstruction.json
@@ -1,11 +1,12 @@
 {
   "1": {
     "parameters": {
+      "file": "{file}",
+      "output_dir": "{output_dir}",
       "blue_params": "{blue_params}",
       "green_params": "{green_params}",
       "red_params": "{red_params}",
-      "far_red_params": "{far_red_params}",
-      "output_dir": "{output_dir}"
+      "far_red_params": "{far_red_params}"
     },
     "output": {
       "murfey_feedback": 2

--- a/src/cryoemservices/services/sim_recon.py
+++ b/src/cryoemservices/services/sim_recon.py
@@ -13,32 +13,32 @@ from cryoemservices.util.models import MockRW
 
 class SIMOTFParameters(BaseModel):
     """
-    These are the shared values used by PySIMRecon to run the 'sim-otf' function.
-    These are read in from a config file under the '[otf config] section.
+    These are the shared values used by PySIMRecon to run the 'sim-otf' function. These
+    are read in from a config file under the section '[otf config]'.
 
-    It is currently unsure if they are needed by the 'sim-recon' function, but
-    a warning does appear if they are omitted from the config file read in by
-    'sim-recon', so we are including it for now.
+    The values listed are the default values used by PySIMRecon. 'cudasirecon', which
+    PySIMRecon runs under the hood, has a different set of preset values, which are
+    overridden by these ones.
 
     Source:
     https://github.com/DiamondLightSource/PySIMRecon/commit/c039b09cbe3b510c032462c6817a517d2d7b2f99
     """
 
-    # Number of phases, by default 5.
+    # Number of phases
     nphases: int = 5
-    # The diameter of the bead in microns, by default 0.12.
+    # The diameter of the bead in microns
     beaddiam: float = 0.17
-    # The k0 vector angle with which the PSF is taken, by default 0.
+    # The k0 vector angle with which the PSF is taken
     angle: float = -0.264228
     # Do not perform bead size compensation, default False (do perform).
     nocompen: bool = False
-    # The starting and end pixel for interpolation along kr axis, by default (2, 9).
+    # The starting and end pixel for interpolation along kr axis
     fixorigin: tuple[int, int] = (2, 9)
-    # The (effective) NA of the objective, by default 1.4.
+    # The (effective) NA of the objective
     na: float = 0.9
-    # The index of refraction of the immersion liquid, by default 1.515 (1 for air/gaseous N2).
+    # The index of refraction of the immersion liquid.
     nimm: float = 1
-    # User-supplied number as the background to subtract. If `None`, background will be estimated from image, by default `None`.
+    # User-supplied number as the background to subtract. If `None`, background will be estimated from image.
     background: int = 500
 
 

--- a/src/cryoemservices/services/sim_recon.py
+++ b/src/cryoemservices/services/sim_recon.py
@@ -95,11 +95,12 @@ class WavelengthParameters(BaseModel):
 
 
 class PySIMReconParameters(BaseModel):
+    file: Path
+    output_dir: Path
     blue_params: WavelengthParameters = WavelengthParameters(wavelength=452)
     green_params: WavelengthParameters = WavelengthParameters(wavelength=525)
     red_params: WavelengthParameters = WavelengthParameters(wavelength=605)
     far_red_params: WavelengthParameters = WavelengthParameters(wavelength=655)
-    output_dir: Path
 
     @field_validator(
         "blue_params", "green_params", "red_params", "far_red_params", mode="before"
@@ -147,7 +148,7 @@ class PySIMReconService(CommonService):
         self,
         rw: RecipeWrapper | None,
         header: dict,
-        message: dict,
+        message: dict | None,
     ):
         """
         Pass incoming message to the relevant plugin function

--- a/src/cryoemservices/services/sim_recon.py
+++ b/src/cryoemservices/services/sim_recon.py
@@ -11,10 +11,14 @@ from cryoemservices.services.common_service import CommonService
 from cryoemservices.util.models import MockRW
 
 
-class SIMOTFConfig:
+class SIMOTFParameters(BaseModel):
     """
     These are the shared values used by PySIMRecon to run the 'sim-otf' function.
-    These are read in from a config file under the section '[otf config]'.
+    These are read in from a config file under the '[otf config] section.
+
+    It is currently unsure if they are needed by the 'sim-recon' function, but
+    a warning does appear if they are omitted from the config file read in by
+    'sim-recon', so we are including it for now.
 
     Source:
     https://github.com/DiamondLightSource/PySIMRecon/commit/c039b09cbe3b510c032462c6817a517d2d7b2f99
@@ -38,7 +42,7 @@ class SIMOTFConfig:
     background: int = 500
 
 
-class SIMReconConfig:
+class SIMReconParameters(BaseModel):
     """
     These are the shared values used by PySIMRecon to run the 'sim-recon' function.
     These are read in from a config file under the section '[recon config]'.
@@ -101,6 +105,8 @@ class PySIMReconParameters(BaseModel):
     green_params: WavelengthParameters = WavelengthParameters(wavelength=525)
     red_params: WavelengthParameters = WavelengthParameters(wavelength=605)
     far_red_params: WavelengthParameters = WavelengthParameters(wavelength=655)
+    sim_otf_params: SIMOTFParameters = SIMOTFParameters()
+    sim_recon_params: SIMReconParameters = SIMReconParameters()
 
     @field_validator(
         "blue_params", "green_params", "red_params", "far_red_params", mode="before"

--- a/tests/services/test_sim_recon_service.py
+++ b/tests/services/test_sim_recon_service.py
@@ -46,6 +46,8 @@ def test_align_images_service(
         "message-id": mock.sentinel,
         "subscription": mock.sentinel,
     }
+    test_file = tmp_path / "raw" / "some_dir" / "test_file"
+    output_dir = tmp_path / "processed" / "some_dir"
     blue_params = {
         "wavelength": 452,
         "ls": 0.330,
@@ -65,15 +67,18 @@ def test_align_images_service(
     }
 
     pysimrecon_test_message = {
+        "file": str(test_file),
+        "output_dir": str(output_dir),
         "blue_params": func(blue_params) if func else blue_params,
         "green_params": func(green_params) if func else green_params,
         "red_params": func(red_params) if func else red_params,
         "far_red_params": func(far_red_params) if func else far_red_params,
-        "output_dir": str(tmp_path / "dummy"),
     }
     params = PySIMReconParameters(**pysimrecon_test_message)
 
     # Check that the values were parsed correctly
+    assert params.file == test_file
+    assert params.output_dir == output_dir
     assert params.blue_params.model_dump(exclude_none=True) == blue_params
     assert params.green_params.model_dump(exclude_none=True) == green_params
     assert params.red_params.model_dump(exclude_none=True) == red_params

--- a/tests/services/test_sim_recon_service.py
+++ b/tests/services/test_sim_recon_service.py
@@ -11,6 +11,8 @@ from workflows.transport.offline_transport import OfflineTransport
 from cryoemservices.services.sim_recon import (
     PySIMReconParameters,
     PySIMReconService,
+    SIMOTFParameters,
+    SIMReconParameters,
 )
 from cryoemservices.util.models import MockRW
 
@@ -83,6 +85,8 @@ def test_align_images_service(
     assert params.green_params.model_dump(exclude_none=True) == green_params
     assert params.red_params.model_dump(exclude_none=True) == red_params
     assert params.far_red_params.model_dump(exclude_none=True) == far_red_params
+    assert params.sim_otf_params.model_dump() == SIMOTFParameters().model_dump()
+    assert params.sim_recon_params.model_dump() == SIMReconParameters().model_dump()
 
     # Set up and run the service
     service = PySIMReconService(environment={"queue": ""}, transport=offline_transport)


### PR DESCRIPTION
Further updates to the PySIMRecon service's Pydantic model:
* Include the `SIMOTFParameters` and `SIMReconParameters` as default fields in `PySIMReconParameters`. This will allow us to (eventually) pass in values from Murfey.
* Forgot to include the input file in the incoming message.