### PR TITLE
Added Dockerfile to build image that will run PySIMRecon

### DIFF
--- a/Dockerfiles/pysimrecon
+++ b/Dockerfiles/pysimrecon
@@ -1,0 +1,62 @@
+# This Dockerfile is used to run PySIMRecon with a GPU
+FROM rockylinux:8 AS conda-build
+
+# Install git and other tools
+RUN echo "Installing system and build dependencies..." && \
+    dnf -y update && \
+    dnf -y install \
+        git && \
+    dnf clean all
+
+# Install MiniForge (use local installer before attempting to download it from online)
+ENV PATH=/conda/bin:${PATH}
+RUN --mount=type=bind,source=installers,target=/mnt/installers,U \
+    echo "Installing MiniForge3..." && \
+    MINIFORGE_INSTALLER="Miniforge3-$(uname)-$(uname -m).sh" && \
+    if [ -f "/mnt/installers/${MINIFORGE_INSTALLER}" ]; then \
+        cp "/mnt/installers/${MINIFORGE_INSTALLER}" "/tmp/${MINIFORGE_INSTALLER}"; \
+    else \
+        curl -L \
+            -o "/tmp/${MINIFORGE_INSTALLER}" \
+            "https://github.com/conda-forge/miniforge/releases/latest/download/${MINIFORGE_INSTALLER}"; \
+    fi && \
+    bash "/tmp/${MINIFORGE_INSTALLER}" -b -p conda
+
+# Install PySIMRecon
+RUN echo "Installing PySIMRecon..." && \
+    git clone https://github.com/DiamondLightSource/PySIMRecon.git /tmp/pysimrecon && \
+    conda create \
+        -c conda-forge \
+        -p /install/pysimrecon \
+            python=3.12.* \
+            pip \
+        --file /tmp/pysimrecon/conda_requirements.txt \
+        --override-channels -y && \
+    /install/pysimrecon/bin/pip install /tmp/pysimrecon
+
+# Install cryoem-services
+RUN --mount=type=bind,source=.,target=/mnt/cryoemservices,U \
+    echo "Installing cryoemservices..." && \
+    cp -r /mnt/cryoemservices /tmp/cryoemservices && \
+    conda create \
+        -c conda-forge \
+        -p /install/cryoemservices \
+            python=3.12.* \
+            pip \
+        --override-channels -y && \
+    /install/cryoemservices/bin/pip install /tmp/cryoemservices
+
+# Copy the installed Python environments to the runner image
+FROM nvidia/cuda:12.9.2-runtime-rockylinux8
+
+# Create EM user
+ARG groupid
+ARG userid
+ARG groupname
+RUN groupadd -r -g "${groupid}" "${groupname}" && \
+    useradd -r -M "${groupname}" -u "${userid}" -g "${groupname}"
+
+# Copy the Python environments in
+COPY --from=conda-build --chown="${userid}":"${groupid}" /install /install
+ENV PATH=/install/pysimrecon/bin:/install/cryoemservices/bin:${PATH}
+ENV LD_LIBRARY_PATH=/install/pysimrecon/lib:/install/cryoemservices/lib:${LD_LIBRARY_PATH}

--- a/Dockerfiles/pysimrecon
+++ b/Dockerfiles/pysimrecon
@@ -1,29 +1,29 @@
-# This Dockerfile is used to run PySIMRecon with a GPU
+# This Dockerfile is used to build a CryoEM service that can be used to run PySIMRecon
 FROM rockylinux:8 AS conda-build
 
-# Install git and other tools
-RUN echo "Installing system and build dependencies..." && \
+# 1. Install git and other build tools
+# 2. Install MiniForge (use local installer before attempting to download it from online)
+# 3. Install PySIMRecon
+# 4. Install cryoemservices
+ARG MINIFORGE_INSTALLER=Miniforge3-Linux-x86_64.sh
+ENV PATH=/conda/bin:${PATH}
+RUN \
+    --mount=type=bind,source=.,target=/mnt/cryoemservices,U \
+    echo "Installing system and build dependencies..." && \
     dnf -y update && \
     dnf -y install \
         git && \
-    dnf clean all
-
-# Install MiniForge (use local installer before attempting to download it from online)
-ENV PATH=/conda/bin:${PATH}
-RUN --mount=type=bind,source=installers,target=/mnt/installers,U \
+    dnf clean all && \
     echo "Installing MiniForge3..." && \
-    MINIFORGE_INSTALLER="Miniforge3-$(uname)-$(uname -m).sh" && \
-    if [ -f "/mnt/installers/${MINIFORGE_INSTALLER}" ]; then \
-        cp "/mnt/installers/${MINIFORGE_INSTALLER}" "/tmp/${MINIFORGE_INSTALLER}"; \
+    if [ -f "/mnt/cryoemservices/installers/${MINIFORGE_INSTALLER}" ]; then \
+        cp "/mnt/cryoemservices/installers/${MINIFORGE_INSTALLER}" "/tmp/${MINIFORGE_INSTALLER}"; \
     else \
         curl -L \
             -o "/tmp/${MINIFORGE_INSTALLER}" \
             "https://github.com/conda-forge/miniforge/releases/latest/download/${MINIFORGE_INSTALLER}"; \
     fi && \
-    bash "/tmp/${MINIFORGE_INSTALLER}" -b -p conda
-
-# Install PySIMRecon
-RUN echo "Installing PySIMRecon..." && \
+    bash "/tmp/${MINIFORGE_INSTALLER}" -b -p conda && \
+    echo "Installing PySIMRecon..." && \
     git clone https://github.com/DiamondLightSource/PySIMRecon.git /tmp/pysimrecon && \
     conda create \
         -c conda-forge \
@@ -32,10 +32,7 @@ RUN echo "Installing PySIMRecon..." && \
             pip \
         --file /tmp/pysimrecon/conda_requirements.txt \
         --override-channels -y && \
-    /install/pysimrecon/bin/pip install /tmp/pysimrecon
-
-# Install cryoem-services
-RUN --mount=type=bind,source=.,target=/mnt/cryoemservices,U \
+    /install/pysimrecon/bin/pip install /tmp/pysimrecon && \
     echo "Installing cryoemservices..." && \
     cp -r /mnt/cryoemservices /tmp/cryoemservices && \
     conda create \
@@ -50,8 +47,8 @@ RUN --mount=type=bind,source=.,target=/mnt/cryoemservices,U \
 FROM nvidia/cuda:12.9.2-runtime-rockylinux8
 
 # Create EM user
-ARG groupid
 ARG userid
+ARG groupid
 ARG groupname
 RUN groupadd -r -g "${groupid}" "${groupname}" && \
     useradd -r -M "${groupname}" -u "${userid}" -g "${groupname}"


### PR DESCRIPTION
Adds a new Dockerfile to build a container that can run PySIMRecon as a cryoem-services service. The container, when run using `podman run ...`, has been confirmed to work on existing SIM data.

The next PR will involve configuring the PySIMRecon service to run PySIMRecon in a subprocess.