### PR TITLE
Imod alignment shift plots

### DIFF
--- a/src/cryoemservices/services/images_plugins.py
+++ b/src/cryoemservices/services/images_plugins.py
@@ -745,12 +745,12 @@ def tiff_to_apng(plugin_params: Callable):
 
 
 def tilt_series_alignment(plugin_params: Callable):
-    if not required_parameters(plugin_params, ["file", "direction"]):
+    if not required_parameters(plugin_params, ["file", "projection"]):
         return False
     filepath = Path(plugin_params("file"))
     aln_file = Path(plugin_params("aln_file")) if plugin_params("aln_file") else None
     xf_file = Path(plugin_params("xf_file")) if plugin_params("xf_file") else None
-    direction = plugin_params("direction")
+    projection = plugin_params("projection")
     if not filepath.is_file():
         logger.error(f"File {filepath} not found")
         return False
@@ -852,7 +852,7 @@ def tilt_series_alignment(plugin_params: Callable):
         shifted_cen_y = cen[1] + y_shifts[tid]
 
         # Find distance to edge of image, accounting for x or y tilt
-        if direction == "XZ":
+        if projection == "XZ":
             x_half_width = flat_size[1] / 2
             y_half_width = (flat_size[0] * np.cos(tlt * np.pi / 180)) / 2
         else:

--- a/src/cryoemservices/services/images_plugins.py
+++ b/src/cryoemservices/services/images_plugins.py
@@ -745,13 +745,14 @@ def tiff_to_apng(plugin_params: Callable):
 
 
 def tilt_series_alignment(plugin_params: Callable):
-    if not required_parameters(plugin_params, ["file", "aln_file", "pixel_size"]):
+    if not required_parameters(plugin_params, ["file", "direction"]):
         return False
     filepath = Path(plugin_params("file"))
-    aln_file = Path(plugin_params("aln_file"))
-    pixel_size = float(plugin_params("pixel_size"))
-    if not filepath.is_file() or not aln_file.is_file():
-        logger.error(f"File {filepath} or {aln_file} not found")
+    aln_file = Path(plugin_params("aln_file")) if plugin_params("aln_file") else None
+    xf_file = Path(plugin_params("xf_file")) if plugin_params("xf_file") else None
+    direction = plugin_params("direction")
+    if not filepath.is_file():
+        logger.error(f"File {filepath} not found")
         return False
     start = time.perf_counter()
     try:
@@ -781,16 +782,37 @@ def tilt_series_alignment(plugin_params: Callable):
     angles = []
     x_shifts = []
     y_shifts = []
-    with open(aln_file) as alns:
-        while True:
-            line = alns.readline()
-            if not line:
-                break
-            if not line.startswith("#"):
-                tilts.append(float(line.split()[-1]))
-                angles.append(float(line.split()[1]))
-                x_shifts.append(float(line.split()[3]))
-                y_shifts.append(float(line.split()[4]))
+    if aln_file and aln_file.is_file():
+        with open(aln_file) as alns:
+            while True:
+                line = alns.readline()
+                if not line:
+                    break
+                if not line.startswith("#"):
+                    tilts.append(float(line.split()[-1]))
+                    angles.append(float(line.split()[1]))
+                    x_shifts.append(float(line.split()[3]))
+                    y_shifts.append(float(line.split()[4]))
+    elif xf_file and xf_file.is_file():
+        with open(xf_file) as xf:
+            lines = xf.readlines()
+            angles = [np.asin(float(l.split()[1])) * 180 / np.pi for l in lines]
+            x_shifts = [float(l.split()[4]) for l in lines]
+            y_shifts = [float(l.split()[5]) for l in lines]
+        if xf_file.with_suffix(".rawtlt").is_file():
+            with open(xf_file.with_suffix(".rawtlt")) as rawtlt:
+                lines = rawtlt.readlines()
+                tilts = [float(l.strip()) for l in lines]
+        elif xf_file.with_suffix(".tlt").is_file():
+            with open(xf_file.with_suffix(".tlt")) as rawtlt:
+                lines = rawtlt.readlines()
+                tilts = [float(l.strip()) for l in lines]
+        else:
+            logger.error(f"Cannot find tlt or rawtlt file for {xf_file}")
+            return False
+    else:
+        logger.error(f"aln file {aln_file} or xf file {xf_file} not found")
+        return False
 
     # Pad the image to make the shifts more visible - x and y end up flipped here
     flat_size = central_slice_data.shape
@@ -826,12 +848,16 @@ def tilt_series_alignment(plugin_params: Callable):
     outliers = []
     for tid, tlt in enumerate(tilts):
         # Apply the shifts to the centre position
-        shifted_cen_x = cen[0] + x_shifts[tid] / pixel_size
-        shifted_cen_y = cen[1] + y_shifts[tid] / pixel_size
+        shifted_cen_x = cen[0] + x_shifts[tid]
+        shifted_cen_y = cen[1] + y_shifts[tid]
 
-        # Find distance to edge of image, accounting for y tilt
-        x_half_width = flat_size[1] / 2
-        y_half_width = (flat_size[0] * np.cos(tlt * np.pi / 180)) / 2
+        # Find distance to edge of image, accounting for x or y tilt
+        if direction == "XZ":
+            x_half_width = flat_size[1] / 2
+            y_half_width = (flat_size[0] * np.cos(tlt * np.pi / 180)) / 2
+        else:
+            x_half_width = (flat_size[1] * np.cos(tlt * np.pi / 180)) / 2
+            y_half_width = flat_size[0] / 2
 
         # Flip the angles if greater than 45 degrees
         if angles[tid] > 45:
@@ -889,7 +915,7 @@ def tilt_series_alignment(plugin_params: Callable):
                     shifted_cen_y + y_corners[3],
                 ),
             ],
-            width=int(20 - np.abs(len(tilts) / 2 - tid)),
+            width=max(int(20 - np.abs(len(tilts) / 2 - tid)), 1),
             outline=outline_colour,
         )
 
@@ -904,25 +930,25 @@ def tilt_series_alignment(plugin_params: Callable):
         )
     dim.text(
         (100 * text_scaling, 10),
-        "Shift over 100 nm",
+        "Shift over 100 pixels",
         fill="#f52407",
         font_size=150 * text_scaling,
     )
     dim.text(
         (100 * text_scaling, 10 + 150 * text_scaling),
-        "Shift 10 to 100 nm",
+        "Shift 10 to 100 pixels",
         fill="#f5a927",
         font_size=150 * text_scaling,
     )
     dim.text(
         (100 * text_scaling, 10 + 300 * text_scaling),
-        "Shift 1 to 10 nm",
+        "Shift 1 to 10 pixels",
         fill="#f5e90a",
         font_size=150 * text_scaling,
     )
     dim.text(
         (100 * text_scaling, 10 + 450 * text_scaling),
-        "Shift under 1 nm",
+        "Shift under 1 pixels",
         fill="#0af549",
         font_size=150 * text_scaling,
     )

--- a/src/cryoemservices/services/tomo_align_aretomo.py
+++ b/src/cryoemservices/services/tomo_align_aretomo.py
@@ -777,7 +777,7 @@ class AreTomoAlign(CommonService):
                 "file": tomo_params.stack_file,
                 "aln_file": str(aln_file),
                 "pixel_size": tomo_params.pixel_size,
-                "direction": side_projection,
+                "projection": side_projection,
             },
         )
         rw.send_to(

--- a/src/cryoemservices/services/tomo_align_aretomo.py
+++ b/src/cryoemservices/services/tomo_align_aretomo.py
@@ -777,6 +777,7 @@ class AreTomoAlign(CommonService):
                 "file": tomo_params.stack_file,
                 "aln_file": str(aln_file),
                 "pixel_size": tomo_params.pixel_size,
+                "direction": side_projection,
             },
         )
         rw.send_to(

--- a/src/cryoemservices/services/tomo_align_imod.py
+++ b/src/cryoemservices/services/tomo_align_imod.py
@@ -1,3 +1,4 @@
+import json
 import shutil
 import subprocess
 from pathlib import Path
@@ -5,6 +6,7 @@ from typing import Optional
 
 import mrcfile
 import numpy as np
+import plotly.express as px
 from olefile import OleFileIO
 from pydantic import BaseModel, Field, ValidationError
 from txrm2tiff.main import convert_and_save
@@ -72,10 +74,10 @@ class ImodTomoAlign(CommonService):
 
         with open(xf_file) as xf:
             lines = xf.readlines()
-        self.x_shift = [l.split()[4] for l in lines]
-        self.y_shift = [l.split()[5] for l in lines]
-        if self.x_shift and self.y_shift:
-            fig = px.scatter(x=self.x_shift, y=self.y_shift)
+        x_shift = [l.split()[4] for l in lines]
+        y_shift = [l.split()[5] for l in lines]
+        if x_shift and y_shift:
+            fig = px.scatter(x=x_shift, y=y_shift)
             fig_as_json = {
                 "data": [json.loads(fig["data"][0].to_json())],
                 "layout": json.loads(fig["layout"].to_json()),
@@ -83,7 +85,6 @@ class ImodTomoAlign(CommonService):
             with open(plot_path, "w") as plot_json:
                 json.dump(fig_as_json, plot_json)
         return xf_file
-
 
     def tomo_align(self, rw, header: dict, message: dict):
         """Main function which interprets and processes received messages"""
@@ -116,10 +117,6 @@ class ImodTomoAlign(CommonService):
             )
             self._reject_message(header, rw.transport, requeue=False)
             return
-
-        # TODO
-        # aln_file = "dummy"
-        shift_plot_suffix = "_xy_shift_plot.json"
 
         # Do txrm conversion
         self.log.info(f"Input file {tomo_params.txrm_file}")
@@ -164,10 +161,7 @@ class ImodTomoAlign(CommonService):
 
         # Run batchruntomo
         adoc_file = write_batch_directive_file(tomo_params)
-        imod_output_path = (
-            output_dir
-            / f"{Path(tomo_params.stack_file).stem}_rec.mrc"
-        )
+        imod_output_path = output_dir / f"{Path(tomo_params.stack_file).stem}_rec.mrc"
         imod_result = subprocess.run(
             [
                 "batchruntomo",
@@ -198,8 +192,14 @@ class ImodTomoAlign(CommonService):
             self._reject_message(header, rw.transport, requeue=False)
             return
 
-        plot_path = output_dir / (Path(tomo_params.stack_file).stem + shift_plot_suffix)
-        self.extract_from_xf(tomo_params.stack_file, plot_path)
+        # Generate shift plot for ispyb
+        plot_file = imod_output_path.stem + "_xy_shift_plot.json"
+        plot_path = output_dir / plot_file
+        xf_file = self.extract_from_xf(tomo_params.stack_file, plot_path)
+        if not xf_file:
+            self.log.error("Failed to read alignment file")
+            self._reject_message(header, transport=rw.transport)
+            return
 
         # Insert tomogram into ispyb
         ispyb_command_list: list[dict] = [
@@ -215,7 +215,7 @@ class ImodTomoAlign(CommonService):
                 "file_directory": str(imod_output_path.parent),
                 "central_slice_image": imod_output_path.stem + "_thumbnail.jpeg",
                 "tomogram_movie": imod_output_path.stem + "_movie.png",
-                "xy_shift_plot": imod_output_path.stem + shift_plot_suffix,
+                "xy_shift_plot": plot_file,
                 "proj_xy": imod_output_path.stem + "_projXY.jpeg",
                 "proj_xz": imod_output_path.stem + "_projYZ.jpeg",
                 "thickness": tomo_params.vol_z * tomo_params.pixel_size / 10,
@@ -234,18 +234,15 @@ class ImodTomoAlign(CommonService):
 
         # Forward results to images service
         self.log.info(f"Sending to images service {tomo_params.stack_file}")
-        # TODO
-        """
         rw.send_to(
             "images",
             {
                 "image_command": "tilt_series_alignment",
                 "file": tomo_params.stack_file,
-                "aln_file": str(aln_file),
+                "xf_file": str(xf_file),
                 "pixel_size": tomo_params.pixel_size,
             },
         )
-        """
         rw.send_to(
             "images",
             {

--- a/src/cryoemservices/services/tomo_align_imod.py
+++ b/src/cryoemservices/services/tomo_align_imod.py
@@ -246,7 +246,7 @@ class ImodTomoAlign(CommonService):
                 "file": tomo_params.stack_file,
                 "xf_file": str(xf_file),
                 "pixel_size": tomo_params.pixel_size,
-                "direction": side_projection,
+                "projection": side_projection,
             },
         )
         rw.send_to(

--- a/src/cryoemservices/services/tomo_align_imod.py
+++ b/src/cryoemservices/services/tomo_align_imod.py
@@ -74,8 +74,8 @@ class ImodTomoAlign(CommonService):
 
         with open(xf_file) as xf:
             lines = xf.readlines()
-        x_shift = [l.split()[4] for l in lines]
-        y_shift = [l.split()[5] for l in lines]
+        x_shift = [float(l.split()[4]) for l in lines]
+        y_shift = [float(l.split()[5]) for l in lines]
         if x_shift and y_shift:
             fig = px.scatter(x=x_shift, y=y_shift)
             fig_as_json = {
@@ -202,6 +202,11 @@ class ImodTomoAlign(CommonService):
             return
 
         # Insert tomogram into ispyb
+        side_projection = (
+            "YZ"
+            if tomo_params.tilt_axis is not None and -45 < tomo_params.tilt_axis < 45
+            else "XZ"
+        )
         ispyb_command_list: list[dict] = [
             {
                 "ispyb_command": "insert_tomogram",
@@ -217,7 +222,7 @@ class ImodTomoAlign(CommonService):
                 "tomogram_movie": imod_output_path.stem + "_movie.png",
                 "xy_shift_plot": plot_file,
                 "proj_xy": imod_output_path.stem + "_projXY.jpeg",
-                "proj_xz": imod_output_path.stem + "_projYZ.jpeg",
+                "proj_xz": imod_output_path.stem + f"_proj{side_projection}.jpeg",
                 "thickness": tomo_params.vol_z * tomo_params.pixel_size / 10,
             },
             {
@@ -241,6 +246,7 @@ class ImodTomoAlign(CommonService):
                 "file": tomo_params.stack_file,
                 "xf_file": str(xf_file),
                 "pixel_size": tomo_params.pixel_size,
+                "direction": side_projection,
             },
         )
         rw.send_to(
@@ -274,11 +280,6 @@ class ImodTomoAlign(CommonService):
         )
 
         self.log.info("Sending to images service for XY and XZ projections")
-        side_projection = (
-            "YZ"
-            if tomo_params.tilt_axis is not None and -45 < tomo_params.tilt_axis < 45
-            else "XZ"
-        )
         for projection_type in ["XY", side_projection]:
             images_call_params: dict[str, str | float] = {
                 "image_command": "mrc_projection",

--- a/src/cryoemservices/services/tomo_align_imod.py
+++ b/src/cryoemservices/services/tomo_align_imod.py
@@ -62,6 +62,27 @@ class ImodTomoAlign(CommonService):
             allow_non_recipe_messages=True,
         )
 
+    def extract_from_xf(self, stack_file: str, plot_path: Path) -> Path | None:
+        xf_file = Path(stack_file).with_suffix(".xf")
+
+        if not xf_file.exists():
+            return None
+
+        with open(xf_file) as xf:
+            lines = xf.readlines()
+        self.x_shift = [l.split()[4] for l in lines]
+        self.y_shift = [l.split()[5] for l in lines]
+        if self.x_shift and self.y_shift:
+            fig = px.scatter(x=self.x_shift, y=self.y_shift)
+            fig_as_json = {
+                "data": [json.loads(fig["data"][0].to_json())],
+                "layout": json.loads(fig["layout"].to_json()),
+            }
+            with open(plot_path, "w") as plot_json:
+                json.dump(fig_as_json, plot_json)
+        return xf_file
+
+
     def tomo_align(self, rw, header: dict, message: dict):
         """Main function which interprets and processes received messages"""
         if not rw:
@@ -137,10 +158,12 @@ class ImodTomoAlign(CommonService):
         with mrcfile.open(tomo_params.stack_file) as mrc:
             mrc_header = mrc.header
 
+        output_dir = Path(tomo_params.stack_file).parent
+
         # Run batchruntomo
         adoc_file = write_batch_directive_file(tomo_params)
         imod_output_path = (
-            Path(tomo_params.stack_file).parent
+            output_dir
             / f"{Path(tomo_params.stack_file).stem}_rec.mrc"
         )
         imod_result = subprocess.run(
@@ -171,6 +194,9 @@ class ImodTomoAlign(CommonService):
             rw.send_to("failure", {})
             self._reject_message(header, rw.transport, requeue=False)
             return
+
+        plot_path = output_dir / (Path(tomo_params.stack_file).stem + shift_plot_suffix)
+        self.extract_from_xf(tomo_params.stack_file, plot_path)
 
         # Insert tomogram into ispyb
         ispyb_command_list: list[dict] = [

--- a/tests/services/test_images_plugins.py
+++ b/tests/services/test_images_plugins.py
@@ -38,6 +38,7 @@ def plugin_params(
             "parameters": {"images_command": "mrc_to_jpeg"},
             "file": jpeg_path.with_suffix(".mrc"),
             "aln_file": jpeg_path.with_suffix(".aln"),
+            "xf_file": jpeg_path.with_suffix(".xf"),
             "all_frames": all_frames,
             "pixel_spacing": pixel_size,
             "pixel_size": pixel_size,
@@ -732,7 +733,7 @@ def test_tiff_to_apng(
 
 
 @mock.patch("cryoemservices.services.images_plugins.ImageDraw")
-def test_tilt_image_alignment_works_3d(mock_imagedraw, tmp_path):
+def test_tilt_image_alignment_works_3d_aln(mock_imagedraw, tmp_path):
     tmp_mrc_path = tmp_path / "tmp.mrc"
     aln_file = tmp_path / "tmp.aln"
 
@@ -754,20 +755,20 @@ def test_tilt_image_alignment_works_3d(mock_imagedraw, tmp_path):
         )
 
     # Send to image creation
-    assert tilt_series_alignment(plugin_params(tmp_mrc_path, True, 2)) == str(
-        tmp_path / "tmp_alignment.jpeg"
-    )
+    assert tilt_series_alignment(
+        plugin_params(tmp_mrc_path, True, 2, projection="XZ")
+    ) == str(tmp_path / "tmp_alignment.jpeg")
 
-    # Check that the expected picking ellipses were drawn
+    # Check that the expected picking tilt boxes were drawn
     mock_imagedraw.Draw.assert_called()
     assert mock_imagedraw.Draw().polygon.call_count == 2
     ellipse_calls = mock_imagedraw.Draw().polygon.call_args_list
     assert ellipse_calls[0][1] == {"width": 19, "outline": "#0af549"}
     assert ellipse_calls[1][1] == {"width": 20, "outline": "#f52407"}
 
-    # Check the box corners are right for the first ellipse
-    x_cen_a = 2.5 - 1.5 / 2
-    y_cen_a = 1 + 2.5 / 2
+    # Check the box corners are right for the first tilt boxes
+    x_cen_a = 2.5 - 1.5
+    y_cen_a = 1 + 2.5
     x_shift_1 = 2.5 * rotation_matrix[0][0]
     y_shift_a1 = rotation_matrix[0][1] * np.cos(-3 * np.pi / 180)
     x_shift_2 = 2.5 * rotation_matrix[1][0]
@@ -781,9 +782,9 @@ def test_tilt_image_alignment_works_3d(mock_imagedraw, tmp_path):
     assert np.isclose(ellipse_calls[0][0][0][3][0], x_cen_a + x_shift_1 - y_shift_a1)
     assert np.isclose(ellipse_calls[0][0][0][3][1], y_cen_a + x_shift_2 - y_shift_a2)
 
-    # Check the box corners are right for the second ellipse
-    x_cen_b = 2.5 + 1022.2 / 2
-    y_cen_b = 1 + 21.2 / 2
+    # Check the box corners are right for the second tilt boxes
+    x_cen_b = 2.5 + 1022.2
+    y_cen_b = 1 + 21.2
     y_shift_b1 = rotation_matrix[0][1] * np.cos(6 * np.pi / 180)
     y_shift_b2 = rotation_matrix[1][1] * np.cos(6 * np.pi / 180)
     assert np.isclose(ellipse_calls[1][0][0][0][0], x_cen_b + x_shift_1 + y_shift_b1)
@@ -794,6 +795,59 @@ def test_tilt_image_alignment_works_3d(mock_imagedraw, tmp_path):
     assert np.isclose(ellipse_calls[1][0][0][2][1], y_cen_b - x_shift_2 - y_shift_b2)
     assert np.isclose(ellipse_calls[1][0][0][3][0], x_cen_b + x_shift_1 - y_shift_b1)
     assert np.isclose(ellipse_calls[1][0][0][3][1], y_cen_b + x_shift_2 - y_shift_b2)
+
+
+@mock.patch("cryoemservices.services.images_plugins.ImageDraw")
+def test_tilt_image_alignment_works_3d_xf(mock_imagedraw, tmp_path):
+    tmp_mrc_path = tmp_path / "tmp.mrc"
+    xf_file = tmp_path / "tmp.xf"
+
+    # Rotation of tomogram relative to tilts
+    angle = 42.7
+    rotation_matrix = [
+        [np.cos(angle * np.pi / 180), -np.sin(angle * np.pi / 180)],
+        [np.sin(angle * np.pi / 180), np.cos(angle * np.pi / 180)],
+    ]
+
+    # Construct mrc and xf file
+    data_3d = np.linspace(-1000, 1000, 20, dtype=np.int16).reshape((2, 2, 5))
+    with mrcfile.new(tmp_mrc_path, overwrite=True) as mrc:
+        mrc.set_data(data_3d)
+    with open(xf_file, "w") as xf:
+        xf.write(
+            f"1 {np.sin(angle * np.pi / 180)} 0 1 -1.5 2.5\n"
+            f"1 {np.sin(angle * np.pi / 180)} 0 1 1022.2 21.2\n"
+        )
+    with open(xf_file.with_suffix(".rawtlt"), "w") as tlt:
+        tlt.write("-3.0\n6.0")
+
+    # Send to image creation
+    assert tilt_series_alignment(
+        plugin_params(tmp_mrc_path, True, 2, projection="YZ")
+    ) == str(tmp_path / "tmp_alignment.jpeg")
+
+    # Check that the expected tilt boxes were drawn
+    mock_imagedraw.Draw.assert_called()
+    assert mock_imagedraw.Draw().polygon.call_count == 2
+    ellipse_calls = mock_imagedraw.Draw().polygon.call_args_list
+    assert ellipse_calls[0][1] == {"width": 19, "outline": "#0af549"}
+    assert ellipse_calls[1][1] == {"width": 20, "outline": "#f52407"}
+
+    # Check the box corners are right for the first tilt boxes
+    x_cen_a = 2.5 - 1.5
+    y_cen_a = 1 + 2.5
+    x_shift_a1 = 2.5 * rotation_matrix[0][0] * np.cos(-3 * np.pi / 180)
+    y_shift_1 = rotation_matrix[0][1]
+    x_shift_a2 = 2.5 * rotation_matrix[1][0] * np.cos(-3 * np.pi / 180)
+    y_shift_2 = rotation_matrix[1][1]
+    assert np.isclose(ellipse_calls[0][0][0][0][0], x_cen_a + x_shift_a1 + y_shift_1)
+    assert np.isclose(ellipse_calls[0][0][0][0][1], y_cen_a + x_shift_a2 + y_shift_2)
+    assert np.isclose(ellipse_calls[0][0][0][1][0], x_cen_a - x_shift_a1 + y_shift_1)
+    assert np.isclose(ellipse_calls[0][0][0][1][1], y_cen_a - x_shift_a2 + y_shift_2)
+    assert np.isclose(ellipse_calls[0][0][0][2][0], x_cen_a - x_shift_a1 - y_shift_1)
+    assert np.isclose(ellipse_calls[0][0][0][2][1], y_cen_a - x_shift_a2 - y_shift_2)
+    assert np.isclose(ellipse_calls[0][0][0][3][0], x_cen_a + x_shift_a1 - y_shift_1)
+    assert np.isclose(ellipse_calls[0][0][0][3][1], y_cen_a + x_shift_a2 - y_shift_2)
 
 
 @mock.patch("cryoemservices.services.images_plugins.ImageDraw")
@@ -812,9 +866,9 @@ def test_tilt_image_alignment_works_2d(mock_imagedraw, tmp_path):
         )
 
     # Send to image creation
-    assert tilt_series_alignment(plugin_params(tmp_mrc_path, True, 2)) == str(
-        tmp_path / "tmp_alignment.jpeg"
-    )
+    assert tilt_series_alignment(
+        plugin_params(tmp_mrc_path, True, 2, projection="XZ")
+    ) == str(tmp_path / "tmp_alignment.jpeg")
 
     # Check that the expected picking ellipses were drawn - skip checking all the rest
     mock_imagedraw.Draw.assert_called()

--- a/tests/services/test_images_plugins.py
+++ b/tests/services/test_images_plugins.py
@@ -163,10 +163,12 @@ def test_mrc_to_jpeg_3d_ack_not_all_frames(tmp_path):
     assert (tmp_path / "convert_test.jpeg").is_file()
 
 
-def test_picked_particles_processes_when_basefile_exists(tmp_path):
+@mock.patch("cryoemservices.services.images_plugins.grid_bar_histogram")
+def test_picked_particles_processes_when_basefile_exists(mock_flatten, tmp_path):
     base_mrc_path = tmp_path / "base.mrc"
     out_jpeg_path = tmp_path / "processed.jpeg"
     test_data = np.arange(16, dtype=np.int8).reshape(4, 4)
+    mock_flatten.return_value = test_data
     with mrcfile.new(base_mrc_path) as mrc:
         mrc.set_data(test_data)
     assert (

--- a/tests/services/test_tomo_align_aretomo.py
+++ b/tests/services/test_tomo_align_aretomo.py
@@ -313,7 +313,7 @@ def test_tomo_align_service_file_list_aretomo3(
             "file": tomo_align_test_message["stack_file"],
             "aln_file": f"{tmp_path}/Tomograms/job006/tomograms/test_stack.aln",
             "pixel_size": tomo_align_test_message["pixel_size"],
-            "direction": "XZ",
+            "projection": "XZ",
         },
     )
     offline_transport.send.assert_any_call(
@@ -638,7 +638,7 @@ def test_tomo_align_service_file_list_aretomo2(
             "file": tomo_align_test_message["stack_file"],
             "aln_file": f"{tmp_path}/Tomograms/job006/tomograms/test_stack.aln",
             "pixel_size": tomo_align_test_message["pixel_size"],
-            "direction": "XZ",
+            "projection": "XZ",
         },
     )
     offline_transport.send.assert_any_call(
@@ -1290,7 +1290,7 @@ def test_tomo_align_service_file_list_rerun(
             "file": tomo_align_test_message["stack_file"],
             "aln_file": f"{tmp_path}/Tomograms/job006/tomograms/test_stack.aln",
             "pixel_size": tomo_align_test_message["pixel_size"],
-            "direction": "XZ",
+            "projection": "XZ",
         },
     )
     offline_transport.send.assert_any_call(
@@ -2306,7 +2306,7 @@ def test_tomo_align_service_txrm(
             "file": tomo_align_test_message["stack_file"],
             "aln_file": f"{tmp_path}/recipe/Tomograms/stack.aln",
             "pixel_size": tomo_align_test_message["pixel_size"],
-            "direction": "YZ",
+            "projection": "YZ",
         },
     )
     offline_transport.send.assert_any_call(

--- a/tests/services/test_tomo_align_aretomo.py
+++ b/tests/services/test_tomo_align_aretomo.py
@@ -313,6 +313,7 @@ def test_tomo_align_service_file_list_aretomo3(
             "file": tomo_align_test_message["stack_file"],
             "aln_file": f"{tmp_path}/Tomograms/job006/tomograms/test_stack.aln",
             "pixel_size": tomo_align_test_message["pixel_size"],
+            "direction": "XZ",
         },
     )
     offline_transport.send.assert_any_call(
@@ -637,6 +638,7 @@ def test_tomo_align_service_file_list_aretomo2(
             "file": tomo_align_test_message["stack_file"],
             "aln_file": f"{tmp_path}/Tomograms/job006/tomograms/test_stack.aln",
             "pixel_size": tomo_align_test_message["pixel_size"],
+            "direction": "XZ",
         },
     )
     offline_transport.send.assert_any_call(
@@ -1288,6 +1290,7 @@ def test_tomo_align_service_file_list_rerun(
             "file": tomo_align_test_message["stack_file"],
             "aln_file": f"{tmp_path}/Tomograms/job006/tomograms/test_stack.aln",
             "pixel_size": tomo_align_test_message["pixel_size"],
+            "direction": "XZ",
         },
     )
     offline_transport.send.assert_any_call(
@@ -2303,6 +2306,7 @@ def test_tomo_align_service_txrm(
             "file": tomo_align_test_message["stack_file"],
             "aln_file": f"{tmp_path}/recipe/Tomograms/stack.aln",
             "pixel_size": tomo_align_test_message["pixel_size"],
+            "direction": "YZ",
         },
     )
     offline_transport.send.assert_any_call(

--- a/tests/services/test_tomo_align_imod.py
+++ b/tests/services/test_tomo_align_imod.py
@@ -139,7 +139,7 @@ def test_tomo_align_imod(
             "file": tomo_align_test_message["stack_file"],
             "xf_file": f"{tmp_path}/recipe/Tomograms/test_stack.xf",
             "pixel_size": tomo_align_test_message["pixel_size"],
-            "direction": "YZ",
+            "projection": "YZ",
         },
     )
     offline_transport.send.assert_any_call(

--- a/tests/services/test_tomo_align_imod.py
+++ b/tests/services/test_tomo_align_imod.py
@@ -1,3 +1,4 @@
+import json
 from subprocess import CompletedProcess
 from unittest import mock
 
@@ -44,12 +45,6 @@ def test_tomo_align_imod(
     mock_ole_file().__enter__().openstream().getvalue.return_value = np.array(
         [0.01, 0.3, 0.5], dtype=np.float32
     ).tobytes()
-    mock_subprocess.return_value = CompletedProcess(
-        "",
-        returncode=0,
-        stdout="stdout".encode("ascii"),
-        stderr="stderr".encode("ascii"),
-    )
 
     header = {
         "message-id": mock.sentinel,
@@ -69,14 +64,23 @@ def test_tomo_align_imod(
     # Touch the expected input/output and stack files
     (tmp_path / "test.txrm").touch()
     (tmp_path / "recipe/Tomograms").mkdir(parents=True)
-    (tmp_path / "recipe/Tomograms/test_stack.mrc").touch()
-    (tmp_path / "recipe/Tomograms/test_stack_rec.mrc").touch()
 
     # Set up the mock service
     service = tomo_align_imod.ImodTomoAlign(
         environment={"queue": ""}, transport=offline_transport
     )
     service.initializing()
+
+    def write_imod_outputs(command, capture_output: bool = False):
+        if command[0] != "batchruntomo":
+            (tmp_path / "recipe/Tomograms/test_stack.mrc").touch(exist_ok=True)
+            return CompletedProcess("", returncode=0)
+        (tmp_path / "recipe/Tomograms/test_stack_rec.mrc").touch()
+        with open(tmp_path / "recipe/Tomograms/test_stack.xf", "w") as aln_file:
+            aln_file.write("1 0 0 1 1.2 2.3")
+        return CompletedProcess("", returncode=0)
+
+    mock_subprocess.side_effect = write_imod_outputs
 
     # Send a message to the service
     service.tomo_align(None, header=header, message=tomo_align_test_message)
@@ -118,27 +122,26 @@ def test_tomo_align_imod(
     # Check output copy
     assert (tmp_path / "recipe_volume.mrc").is_file()
 
-    """# Check the shift plot
+    # Check the shift plot
     with open(
-        tmp_path / "recipe/Tomograms/test_stack_rec.mrc/test_stack_xy_shift_plot.json"
+        tmp_path / "recipe/Tomograms/test_stack_rec_xy_shift_plot.json"
     ) as shift_plot:
         shift_data = json.load(shift_plot)
     assert shift_data["data"][0]["x"] == [1.2]
     assert shift_data["data"][0]["y"] == [2.3]
-    """
+
     # Check that the correct messages were sent
-    assert offline_transport.send.call_count == 9  # 10
-    """
+    assert offline_transport.send.call_count == 10
     offline_transport.send.assert_any_call(
         "images",
         {
             "image_command": "tilt_series_alignment",
             "file": tomo_align_test_message["stack_file"],
-            "aln_file": "dummy",  # f"{tmp_path}/Tomograms/job006/tomograms/test_stack.aln",
+            "xf_file": f"{tmp_path}/recipe/Tomograms/test_stack.xf",
             "pixel_size": tomo_align_test_message["pixel_size"],
+            "direction": "YZ",
         },
     )
-    """
     offline_transport.send.assert_any_call(
         "images",
         {


### PR DESCRIPTION
This generates the shift plot json and tilt alignment jpg for imod xf files.

The imod tomo service reads the xf file to generate a shift plot

The function to generate the tilt alignment image has been updated to support xf files as well as aln files. Shifts are now in pixels, although I'm not certain I've got the units right.
This image can now also display the tilts on either axis as the Talos and b24 tilt the other way to the Krios microscopes.

