### PR TITLE
Membrain-seg should generate binned mrc itself

### DIFF
--- a/src/cryoemservices/services/easymode.py
+++ b/src/cryoemservices/services/easymode.py
@@ -12,6 +12,7 @@ from workflows.recipe import wrap_subscribe
 
 from cryoemservices.pipeliner_plugins.easymode_segmentation import segment_tomogram
 from cryoemservices.services.common_service import CommonService
+from cryoemservices.util.display_images import generate_binned_mrc
 from cryoemservices.util.models import MockRW
 from cryoemservices.util.relion_service_options import RelionServiceOptions
 
@@ -164,20 +165,6 @@ class Easymode(CommonService):
         )
 
         # Forward binned tomograms to ispyb
-        if easymode_params.membrain_segmentation:
-            mini_membrain_mrc = generate_binned_mrc(
-                Path(easymode_params.membrain_segmentation),
-                easymode_params.display_binning,
-            )
-            rw.send_to(
-                "ispyb_connector",
-                {
-                    "ispyb_command": "insert_processed_tomogram",
-                    "file_path": str(mini_membrain_mrc),
-                    "processing_type": "Feature",
-                    "feature": "membrane",
-                },
-            )
         for feature, tomogram in ispyb_tomograms.items():
             rw.send_to(
                 "ispyb_connector",
@@ -191,38 +178,3 @@ class Easymode(CommonService):
 
         self.log.info(f"Finished segmenting {easymode_params.tomogram}")
         rw.transport.ack(header)
-
-
-def generate_binned_mrc(input_path: Path, binning: int) -> Path:
-    """Produce binned mrc files for display purposes"""
-    with mrcfile.open(input_path) as mrc:
-        input_header = mrc.header
-        input_data = mrc.data
-
-    # Bin the data and set values to a range of 0-127
-    input_size = np.array(input_data.shape)
-    output_size = (input_size / binning).astype("int")
-    if not np.sum(input_size / output_size) == binning * 3:
-        reduction = abs(output_size * binning - input_size)
-        input_data = input_data[reduction[0] :, reduction[1] :, reduction[2] :]
-    reshaped_data = input_data.reshape(
-        output_size[0], binning, output_size[1], binning, output_size[2], binning
-    )
-    binned_data = reshaped_data.mean(5).mean(3).mean(1)
-    binned_data -= binned_data.min()
-    binned_data *= 127 / binned_data.max()
-
-    # Edge clip all directions as segmentations often have edge artifacts
-    binned_data[-5:] = 0
-    binned_data[:5] = 0
-    binned_data[:, :5] = 0
-    binned_data[:, -5:] = 0
-    binned_data[:, :, :5] = 0
-    binned_data[:, :, -5:] = 0
-
-    # Save output binned mrc
-    mini_mrc_name = str(input_path.with_suffix("")) + f"_bin{binning}.mrc"
-    with mrcfile.new(mini_mrc_name, overwrite=True) as mrc:
-        mrc.set_data(binned_data.astype("int8"))
-        mrc.header.cella = input_header.cella
-    return Path(mini_mrc_name)

--- a/src/cryoemservices/services/membrain_seg.py
+++ b/src/cryoemservices/services/membrain_seg.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field, ValidationError
 from workflows.recipe import wrap_subscribe
 
 from cryoemservices.services.common_service import CommonService
+from cryoemservices.util.display_images import generate_binned_mrc
 from cryoemservices.util.models import MockRW
 from cryoemservices.util.relion_service_options import RelionServiceOptions
 from cryoemservices.util.slurm_submission import slurm_submission_for_services
@@ -39,6 +40,7 @@ class MembrainSegParameters(BaseModel):
     cleanup_output: bool = True
     submit_to_slurm: bool = False
     copy_output: bool = False
+    display_binning: int = 4
     relion_options: RelionServiceOptions
 
 
@@ -255,6 +257,20 @@ class MembrainSeg(CommonService):
             "processing_type": "Segmented",
         }
         rw.send_to("ispyb_connector", ispyb_parameters)
+
+        # Forward binned tomogram to ispyb
+        mini_membrain_mrc = generate_binned_mrc(
+            segmented_path, membrain_seg_params.display_binning
+        )
+        rw.send_to(
+            "ispyb_connector",
+            {
+                "ispyb_command": "insert_processed_tomogram",
+                "file_path": str(mini_membrain_mrc),
+                "processing_type": "Feature",
+                "feature": "membrane",
+            },
+        )
 
         # Send on to easymode for further segmentation
         rw.send_to(

--- a/src/cryoemservices/util/display_images.py
+++ b/src/cryoemservices/util/display_images.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+import mrcfile
+import numpy as np
+
+
+def generate_binned_mrc(input_path: Path, binning: int) -> Path:
+    """Produce binned mrc files for display purposes"""
+    with mrcfile.open(input_path) as mrc:
+        input_header = mrc.header
+        input_data = mrc.data
+
+    # Bin the data and set values to a range of 0-127
+    input_size = np.array(input_data.shape)
+    output_size = (input_size / binning).astype("int")
+    if not np.sum(input_size / output_size) == binning * 3:
+        reduction = abs(output_size * binning - input_size)
+        input_data = input_data[reduction[0] :, reduction[1] :, reduction[2] :]
+    reshaped_data = input_data.reshape(
+        output_size[0], binning, output_size[1], binning, output_size[2], binning
+    )
+    binned_data = reshaped_data.mean(5).mean(3).mean(1)
+    binned_data -= binned_data.min()
+    binned_data *= 127 / binned_data.max()
+
+    # Edge clip all directions as segmentations often have edge artifacts
+    binned_data[-5:] = 0
+    binned_data[:5] = 0
+    binned_data[:, :5] = 0
+    binned_data[:, -5:] = 0
+    binned_data[:, :, :5] = 0
+    binned_data[:, :, -5:] = 0
+
+    # Save output binned mrc
+    mini_mrc_name = str(input_path.with_suffix("")) + f"_bin{binning}.mrc"
+    with mrcfile.new(mini_mrc_name, overwrite=True) as mrc:
+        mrc.set_data(binned_data.astype("int8"))
+        mrc.header.cella = input_header.cella
+    return Path(mini_mrc_name)

--- a/tests/services/test_easymode.py
+++ b/tests/services/test_easymode.py
@@ -132,7 +132,7 @@ def test_easymode_service_with_mask(
     ).is_file()
 
     # Check the images service request
-    assert offline_transport.send.call_count == 4
+    assert offline_transport.send.call_count == 3
     offline_transport.send.assert_any_call(
         "images",
         {
@@ -146,19 +146,6 @@ def test_easymode_service_with_mask(
             "mask": str(
                 f"{tmp_path}/Segmentation/job008/tomograms/test_stack_aretomo_easymode_void.mrc",
             ),
-        },
-    )
-    mini_seg_path = (
-        tmp_path / "Segmentation/job008/tomograms/test_stack_aretomo_segmented_bin8.mrc"
-    )
-    assert (mini_seg_path).is_file()
-    offline_transport.send.assert_any_call(
-        "ispyb_connector",
-        {
-            "ispyb_command": "insert_processed_tomogram",
-            "file_path": str(mini_seg_path),
-            "processing_type": "Feature",
-            "feature": "membrane",
         },
     )
     for feature in ["ribosome", "tric"]:

--- a/tests/services/test_membrain_seg.py
+++ b/tests/services/test_membrain_seg.py
@@ -1,8 +1,8 @@
-from __future__ import annotations
-
 import subprocess
 from unittest import mock
 
+import mrcfile
+import numpy as np
 import pytest
 from requests import Response
 from workflows.transport.offline_transport import OfflineTransport
@@ -20,7 +20,9 @@ def offline_transport(mocker):
 
 
 @mock.patch("cryoemservices.services.membrain_seg.segment")
+@mock.patch("cryoemservices.services.membrain_seg.generate_binned_mrc")
 def test_membrain_seg_service_local_memseg(
+    mock_bin_mrc,
     mock_segment,
     offline_transport,
     tmp_path,
@@ -29,6 +31,7 @@ def test_membrain_seg_service_local_memseg(
     Send a test message to membrain-seg for the version running without a subprocess
     This should call the mock subprocess then send messages to the images service.
     """
+    mock_bin_mrc.return_value = f"{tmp_path}/Segmentation/job008/tomograms/binned.mrc"
 
     header = {
         "message-id": mock.sentinel,
@@ -46,6 +49,7 @@ def test_membrain_seg_service_local_memseg(
         "window_size": 100,
         "connected_component_threshold": 2,
         "segmentation_threshold": 4,
+        "display_binning": 8,
         "relion_options": {},
     }
     output_relion_options = dict(RelionServiceOptions())
@@ -95,8 +99,14 @@ def test_membrain_seg_service_local_memseg(
         segmentation_threshold=4.0,
     )
 
+    mock_bin_mrc.assert_called_once_with(
+        tmp_path
+        / "Segmentation/job008/tomograms/test_stack_aretomo.denoised_segmented.mrc",
+        8,
+    )
+
     # Check the images service request
-    assert offline_transport.send.call_count == 5
+    assert offline_transport.send.call_count == 6
     offline_transport.send.assert_any_call(
         "node_creator",
         {
@@ -136,6 +146,15 @@ def test_membrain_seg_service_local_memseg(
         },
     )
     offline_transport.send.assert_any_call(
+        "ispyb_connector",
+        {
+            "ispyb_command": "insert_processed_tomogram",
+            "file_path": f"{tmp_path}/Segmentation/job008/tomograms/binned.mrc",
+            "processing_type": "Feature",
+            "feature": "membrane",
+        },
+    )
+    offline_transport.send.assert_any_call(
         "easymode",
         {
             "tomogram": f"{tmp_path}/Denoise/job007/tomograms/test_stack_aretomo.denoised.mrc",
@@ -162,10 +181,12 @@ def test_membrain_seg_service_local_subprocess(
     """
 
     def touch_membrain_output(*args, **kwargs):
-        (
+        segmentation_tomogram = (
             tmp_path
             / "Segmentation/job008/tomograms/test_stack_aretomo.denoised_segmented.mrc"
-        ).touch()
+        )
+        with mrcfile.new(segmentation_tomogram) as mrc:
+            mrc.set_data(np.random.random((20, 20, 15)).astype("int8"))
         return subprocess.CompletedProcess(
             "",
             returncode=0,
@@ -234,7 +255,7 @@ def test_membrain_seg_service_local_subprocess(
     ).is_file()
 
     # Check the images service request
-    assert offline_transport.send.call_count == 5
+    assert offline_transport.send.call_count == 6
     offline_transport.send.assert_any_call(
         "node_creator",
         {
@@ -285,9 +306,26 @@ def test_membrain_seg_service_local_subprocess(
         },
     )
 
+    mini_seg_path = (
+        tmp_path
+        / "Segmentation/job008/tomograms/test_stack_aretomo.denoised_segmented_bin4.mrc"
+    )
+    assert mini_seg_path.is_file()
+    offline_transport.send.assert_any_call(
+        "ispyb_connector",
+        {
+            "ispyb_command": "insert_processed_tomogram",
+            "file_path": str(mini_seg_path),
+            "processing_type": "Feature",
+            "feature": "membrane",
+        },
+    )
+
 
 @mock.patch("cryoemservices.util.slurm_submission.requests")
+@mock.patch("cryoemservices.services.membrain_seg.generate_binned_mrc")
 def test_membrain_seg_service_slurm(
+    mock_bin_mrc,
     mock_requests,
     offline_transport,
     tmp_path,
@@ -304,6 +342,7 @@ def test_membrain_seg_service_slurm(
     response_object.status_code = 200
     mock_requests.Session().post.return_value = response_object
     mock_requests.Session().get.return_value = response_object
+    mock_bin_mrc.return_value = "binned_mrc"
 
     header = {
         "message-id": mock.sentinel,
@@ -417,8 +456,14 @@ def test_membrain_seg_service_slurm(
         url="/url/of/slurm/restapi/slurm/v0.0.40/job/1"
     )
 
+    mock_bin_mrc.assert_called_once_with(
+        tmp_path
+        / "Segmentation/job008/tomograms/test_stack_aretomo.denoised_segmented.mrc",
+        4,
+    )
+
     # Check the images service request
-    assert offline_transport.send.call_count == 5
+    assert offline_transport.send.call_count == 6
     offline_transport.send.assert_any_call(
         "node_creator",
         {
@@ -455,6 +500,15 @@ def test_membrain_seg_service_slurm(
             "ispyb_command": "insert_processed_tomogram",
             "file_path": f"{tmp_path}/Segmentation/job008/tomograms/test_stack_aretomo.denoised_segmented.mrc",
             "processing_type": "Segmented",
+        },
+    )
+    offline_transport.send.assert_any_call(
+        "ispyb_connector",
+        {
+            "ispyb_command": "insert_processed_tomogram",
+            "file_path": "binned_mrc",
+            "processing_type": "Feature",
+            "feature": "membrane",
         },
     )
     offline_transport.send.assert_any_call(
@@ -503,11 +557,13 @@ def test_membrain_seg_service_local_memseg_rerun(
     output_relion_options = dict(RelionServiceOptions())
 
     # Pre-make the output so this is a rerun
-    (tmp_path / "Segmentation/job008/tomograms").mkdir(parents=True)
-    (
+    segmentation_tomogram = (
         tmp_path
         / "Segmentation/job008/tomograms/test_stack_aretomo.denoised_segmented.mrc"
-    ).touch()
+    )
+    segmentation_tomogram.parent.mkdir(parents=True)
+    with mrcfile.new(segmentation_tomogram) as mrc:
+        mrc.set_data(np.random.random((20, 20, 15)).astype("int8"))
 
     # Set up the mock service and send a message to it
     service = membrain_seg.MembrainSeg(
@@ -517,7 +573,7 @@ def test_membrain_seg_service_local_memseg_rerun(
     service.membrain_seg(None, header=header, message=segmentation_test_message)
 
     # Check the images service request
-    assert offline_transport.send.call_count == 4
+    assert offline_transport.send.call_count == 5
     offline_transport.send.assert_any_call(
         "images",
         {
@@ -551,5 +607,20 @@ def test_membrain_seg_service_local_memseg_rerun(
             "segmentation_apng": f"{tmp_path}/Segmentation/job008/tomograms/test_stack_aretomo.denoised_segmented_movie.png",
             "pixel_size": 1.0,
             "relion_options": output_relion_options,
+        },
+    )
+
+    mini_seg_path = (
+        tmp_path
+        / "Segmentation/job008/tomograms/test_stack_aretomo.denoised_segmented_bin4.mrc"
+    )
+    assert mini_seg_path.is_file()
+    offline_transport.send.assert_any_call(
+        "ispyb_connector",
+        {
+            "ispyb_command": "insert_processed_tomogram",
+            "file_path": str(mini_seg_path),
+            "processing_type": "Feature",
+            "feature": "membrane",
         },
     )


### PR DESCRIPTION
Rather than generating all the binned mrc files in the easymode service, we should do the membrain one in that service. This means we can display the 3D visualisation for SXT where easymode does not run.

Most of the diff here is just moving the `generate_binned_mrc` function into a new file (the function itself is unchanged).